### PR TITLE
test(web): restore test credibility — rewrite stale mocks (Candidate 7)

### DIFF
--- a/apps/web/__tests__/components/auth/protected-route.test.tsx
+++ b/apps/web/__tests__/components/auth/protected-route.test.tsx
@@ -1,13 +1,14 @@
 /**
  * Tests for ProtectedRoute component
- * Tests authentication checking, redirection, loading states, and HOC
+ *
+ * Tests authentication checking, redirection, and content rendering
+ * with the cookie-based auth system (validateSession, not loadUserFromStorage).
  */
 
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '../../utils/test-utils';
-import { ProtectedRoute, withAuth } from '../../../src/components/auth/protected-route';
-import { useAuthStore } from '../../../src/store/auth.store';
+import { ProtectedRoute } from '../../../src/components/auth/protected-route';
 
 // Mock next/navigation
 const mockPush = vi.fn();
@@ -19,45 +20,42 @@ vi.mock('next/navigation', () => ({
   }),
 }));
 
-// Mock auth store
+// Mock auth store - matches current interface: { isAuthenticated, user, validateSession }
 vi.mock('../../../src/store/auth.store', () => ({
   useAuthStore: vi.fn(),
 }));
 
+// Import the mocked store for per-test configuration
+import { useAuthStore } from '../../../src/store/auth.store';
 const mockUseAuthStore = useAuthStore as unknown as ReturnType<typeof vi.fn>;
 
-// TODO(tier0): mock structure does not match current ProtectedRoute component
-describe.skip('ProtectedRoute Component', () => {
+// Standard mock user
+const mockUser = {
+  id: '550e8400-e29b-41d4-a716-446655440000',
+  email: 'test@example.com',
+  firstName: 'John',
+  lastName: 'Doe',
+  role: 'USER',
+  status: 'ACTIVE',
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+  fullName: 'John Doe',
+  isEmailVerified: true,
+  isActive: true,
+};
+
+describe('ProtectedRoute Component', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockPush.mockClear();
   });
 
-  describe('Loading State', () => {
-    it('shows loading spinner during initialization', () => {
+  describe('Checking State', () => {
+    it('returns null during session validation (no spinner)', () => {
       mockUseAuthStore.mockReturnValue({
         isAuthenticated: false,
-        isLoading: true,
-        loadUserFromStorage: vi.fn(),
-      });
-
-      render(
-        <ProtectedRoute>
-          <div>Protected Content</div>
-        </ProtectedRoute>
-      );
-
-      // Should show spinner (animate-spin class)
-      const spinner = document.querySelector('.animate-spin');
-      expect(spinner).toBeInTheDocument();
-      expect(screen.queryByText('Protected Content')).not.toBeInTheDocument();
-    });
-
-    it('shows loading spinner while auth is loading', () => {
-      mockUseAuthStore.mockReturnValue({
-        isAuthenticated: false,
-        isLoading: true,
-        loadUserFromStorage: vi.fn(),
+        user: null,
+        validateSession: vi.fn().mockReturnValue(new Promise(() => {})), // never resolves
       });
 
       const { container } = render(
@@ -66,8 +64,25 @@ describe.skip('ProtectedRoute Component', () => {
         </ProtectedRoute>
       );
 
-      const loadingContainer = container.querySelector('.min-h-screen.flex.items-center.justify-center');
-      expect(loadingContainer).toBeInTheDocument();
+      // ProtectedRoute returns null during checking - no spinner, no content
+      expect(container.innerHTML).toBe('');
+      expect(screen.queryByText('Protected Content')).not.toBeInTheDocument();
+    });
+
+    it('does not render children while checking authentication', () => {
+      mockUseAuthStore.mockReturnValue({
+        isAuthenticated: false,
+        user: null,
+        validateSession: vi.fn().mockReturnValue(new Promise(() => {})),
+      });
+
+      render(
+        <ProtectedRoute>
+          <div>Protected Content</div>
+        </ProtectedRoute>
+      );
+
+      expect(screen.queryByText('Protected Content')).not.toBeInTheDocument();
     });
   });
 
@@ -75,8 +90,8 @@ describe.skip('ProtectedRoute Component', () => {
     it('renders children when user is authenticated', async () => {
       mockUseAuthStore.mockReturnValue({
         isAuthenticated: true,
-        isLoading: false,
-        loadUserFromStorage: vi.fn(),
+        user: mockUser,
+        validateSession: vi.fn(),
       });
 
       render(
@@ -93,8 +108,8 @@ describe.skip('ProtectedRoute Component', () => {
     it('does not redirect when user is authenticated', async () => {
       mockUseAuthStore.mockReturnValue({
         isAuthenticated: true,
-        isLoading: false,
-        loadUserFromStorage: vi.fn(),
+        user: mockUser,
+        validateSession: vi.fn(),
       });
 
       render(
@@ -104,17 +119,19 @@ describe.skip('ProtectedRoute Component', () => {
       );
 
       await waitFor(() => {
-        expect(mockPush).not.toHaveBeenCalled();
+        expect(screen.getByText('Protected Content')).toBeInTheDocument();
       });
+
+      expect(mockPush).not.toHaveBeenCalled();
     });
 
-    it('calls loadUserFromStorage on mount', () => {
-      const loadUserFromStorage = vi.fn();
+    it('does not call validateSession when already authenticated with user', async () => {
+      const validateSession = vi.fn();
 
       mockUseAuthStore.mockReturnValue({
         isAuthenticated: true,
-        isLoading: false,
-        loadUserFromStorage,
+        user: mockUser,
+        validateSession,
       });
 
       render(
@@ -123,16 +140,41 @@ describe.skip('ProtectedRoute Component', () => {
         </ProtectedRoute>
       );
 
-      expect(loadUserFromStorage).toHaveBeenCalledTimes(1);
+      await waitFor(() => {
+        expect(screen.getByText('Protected Content')).toBeInTheDocument();
+      });
+
+      // When already authenticated with user, validateSession should not be called
+      expect(validateSession).not.toHaveBeenCalled();
     });
   });
 
   describe('Unauthenticated Access', () => {
-    it('redirects to login when not authenticated', async () => {
+    it('calls validateSession when not authenticated', async () => {
+      const validateSession = vi.fn().mockResolvedValue(false);
+
       mockUseAuthStore.mockReturnValue({
         isAuthenticated: false,
-        isLoading: false,
-        loadUserFromStorage: vi.fn(),
+        user: null,
+        validateSession,
+      });
+
+      render(
+        <ProtectedRoute>
+          <div>Protected Content</div>
+        </ProtectedRoute>
+      );
+
+      await waitFor(() => {
+        expect(validateSession).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('redirects to login when validateSession returns false', async () => {
+      mockUseAuthStore.mockReturnValue({
+        isAuthenticated: false,
+        user: null,
+        validateSession: vi.fn().mockResolvedValue(false),
       });
 
       render(
@@ -146,30 +188,11 @@ describe.skip('ProtectedRoute Component', () => {
       });
     });
 
-    it('shows access denied message when not authenticated', async () => {
-      mockUseAuthStore.mockReturnValue({
-        isAuthenticated: false,
-        isLoading: false,
-        loadUserFromStorage: vi.fn(),
-      });
-
-      render(
-        <ProtectedRoute>
-          <div>Protected Content</div>
-        </ProtectedRoute>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Access Denied')).toBeInTheDocument();
-        expect(screen.getByText(/You need to be logged in/)).toBeInTheDocument();
-      });
-    });
-
     it('does not render protected content when not authenticated', async () => {
       mockUseAuthStore.mockReturnValue({
         isAuthenticated: false,
-        isLoading: false,
-        loadUserFromStorage: vi.fn(),
+        user: null,
+        validateSession: vi.fn().mockResolvedValue(false),
       });
 
       render(
@@ -179,64 +202,64 @@ describe.skip('ProtectedRoute Component', () => {
       );
 
       await waitFor(() => {
-        expect(screen.queryByText('Protected Content')).not.toBeInTheDocument();
+        expect(mockPush).toHaveBeenCalledWith('/auth/login');
       });
+
+      expect(screen.queryByText('Protected Content')).not.toBeInTheDocument();
     });
   });
 
-  describe('Custom Fallback', () => {
-    it('renders custom fallback when provided and not authenticated', async () => {
+  describe('Session Validation Success', () => {
+    it('renders children after successful session validation', async () => {
+      // Start unauthenticated, but validateSession succeeds
+      // After validateSession succeeds, the store will update to authenticated
+      const validateSession = vi.fn().mockResolvedValue(true);
+
       mockUseAuthStore.mockReturnValue({
         isAuthenticated: false,
-        isLoading: false,
-        loadUserFromStorage: vi.fn(),
+        user: null,
+        validateSession,
       });
 
-      const CustomFallback = () => <div>Custom Access Denied</div>;
-
-      render(
-        <ProtectedRoute fallback={<CustomFallback />}>
+      const { rerender } = render(
+        <ProtectedRoute>
           <div>Protected Content</div>
         </ProtectedRoute>
       );
 
+      // Wait for validateSession to be called
       await waitFor(() => {
-        expect(screen.getByText('Custom Access Denied')).toBeInTheDocument();
-        expect(screen.queryByText('Access Denied')).not.toBeInTheDocument();
+        expect(validateSession).toHaveBeenCalled();
       });
-    });
 
-    it('does not render custom fallback when authenticated', async () => {
+      // Simulate store update after successful validation
       mockUseAuthStore.mockReturnValue({
         isAuthenticated: true,
-        isLoading: false,
-        loadUserFromStorage: vi.fn(),
+        user: mockUser,
+        validateSession,
       });
 
-      const CustomFallback = () => <div>Custom Access Denied</div>;
-
-      render(
-        <ProtectedRoute fallback={<CustomFallback />}>
+      rerender(
+        <ProtectedRoute>
           <div>Protected Content</div>
         </ProtectedRoute>
       );
 
       await waitFor(() => {
-        expect(screen.queryByText('Custom Access Denied')).not.toBeInTheDocument();
         expect(screen.getByText('Protected Content')).toBeInTheDocument();
       });
     });
   });
 
   describe('Authentication State Transitions', () => {
-    it('handles transition from loading to authenticated', async () => {
-      const loadUserFromStorage = vi.fn();
+    it('handles transition from checking to authenticated', async () => {
+      const validateSession = vi.fn().mockResolvedValue(true);
 
-      // Start with loading state
+      // Start not authenticated
       mockUseAuthStore.mockReturnValue({
         isAuthenticated: false,
-        isLoading: true,
-        loadUserFromStorage,
+        user: null,
+        validateSession,
       });
 
       const { rerender } = render(
@@ -245,14 +268,14 @@ describe.skip('ProtectedRoute Component', () => {
         </ProtectedRoute>
       );
 
-      // Should show loading
-      expect(document.querySelector('.animate-spin')).toBeInTheDocument();
+      // Should render null (checking)
+      expect(screen.queryByText('Protected Content')).not.toBeInTheDocument();
 
       // Transition to authenticated
       mockUseAuthStore.mockReturnValue({
         isAuthenticated: true,
-        isLoading: false,
-        loadUserFromStorage,
+        user: mockUser,
+        validateSession,
       });
 
       rerender(
@@ -266,30 +289,16 @@ describe.skip('ProtectedRoute Component', () => {
       });
     });
 
-    it('handles transition from loading to unauthenticated', async () => {
-      const loadUserFromStorage = vi.fn();
+    it('handles transition from checking to unauthenticated', async () => {
+      const validateSession = vi.fn().mockResolvedValue(false);
 
-      // Start with loading state
       mockUseAuthStore.mockReturnValue({
         isAuthenticated: false,
-        isLoading: true,
-        loadUserFromStorage,
+        user: null,
+        validateSession,
       });
 
-      const { rerender } = render(
-        <ProtectedRoute>
-          <div>Protected Content</div>
-        </ProtectedRoute>
-      );
-
-      // Transition to unauthenticated
-      mockUseAuthStore.mockReturnValue({
-        isAuthenticated: false,
-        isLoading: false,
-        loadUserFromStorage,
-      });
-
-      rerender(
+      render(
         <ProtectedRoute>
           <div>Protected Content</div>
         </ProtectedRoute>
@@ -305,8 +314,8 @@ describe.skip('ProtectedRoute Component', () => {
     it('renders all children when authenticated', async () => {
       mockUseAuthStore.mockReturnValue({
         isAuthenticated: true,
-        isLoading: false,
-        loadUserFromStorage: vi.fn(),
+        user: mockUser,
+        validateSession: vi.fn(),
       });
 
       render(
@@ -321,124 +330,6 @@ describe.skip('ProtectedRoute Component', () => {
         expect(screen.getByText('Child 1')).toBeInTheDocument();
         expect(screen.getByText('Child 2')).toBeInTheDocument();
         expect(screen.getByText('Child 3')).toBeInTheDocument();
-      });
-    });
-  });
-});
-
-// TODO(tier0): mock structure does not match current ProtectedRoute component
-describe.skip('withAuth Higher-Order Component', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockPush.mockClear();
-  });
-
-  describe('Component Wrapping', () => {
-    it('wraps component with ProtectedRoute', async () => {
-      mockUseAuthStore.mockReturnValue({
-        isAuthenticated: true,
-        isLoading: false,
-        loadUserFromStorage: vi.fn(),
-      });
-
-      const TestComponent = ({ title }: { title: string }) => <div>{title}</div>;
-      const ProtectedComponent = withAuth(TestComponent);
-
-      render(<ProtectedComponent title="Test Title" />);
-
-      await waitFor(() => {
-        expect(screen.getByText('Test Title')).toBeInTheDocument();
-      });
-    });
-
-    it('forwards props to wrapped component', async () => {
-      mockUseAuthStore.mockReturnValue({
-        isAuthenticated: true,
-        isLoading: false,
-        loadUserFromStorage: vi.fn(),
-      });
-
-      const TestComponent = ({ name, age }: { name: string; age: number }) => (
-        <div>
-          {name} - {age}
-        </div>
-      );
-
-      const ProtectedComponent = withAuth(TestComponent);
-
-      render(<ProtectedComponent name="John" age={30} />);
-
-      await waitFor(() => {
-        expect(screen.getByText('John - 30')).toBeInTheDocument();
-      });
-    });
-
-    it('protects wrapped component from unauthenticated access', async () => {
-      mockUseAuthStore.mockReturnValue({
-        isAuthenticated: false,
-        isLoading: false,
-        loadUserFromStorage: vi.fn(),
-      });
-
-      const TestComponent = () => <div>Sensitive Data</div>;
-      const ProtectedComponent = withAuth(TestComponent);
-
-      render(<ProtectedComponent />);
-
-      await waitFor(() => {
-        expect(screen.queryByText('Sensitive Data')).not.toBeInTheDocument();
-        expect(screen.getByText('Access Denied')).toBeInTheDocument();
-      });
-    });
-
-    it('redirects to login when wrapped component accessed without auth', async () => {
-      mockUseAuthStore.mockReturnValue({
-        isAuthenticated: false,
-        isLoading: false,
-        loadUserFromStorage: vi.fn(),
-      });
-
-      const TestComponent = () => <div>Protected Page</div>;
-      const ProtectedComponent = withAuth(TestComponent);
-
-      render(<ProtectedComponent />);
-
-      await waitFor(() => {
-        expect(mockPush).toHaveBeenCalledWith('/auth/login');
-      });
-    });
-  });
-
-  describe('HOC with Complex Components', () => {
-    it('works with components that have state', async () => {
-      mockUseAuthStore.mockReturnValue({
-        isAuthenticated: true,
-        isLoading: false,
-        loadUserFromStorage: vi.fn(),
-      });
-
-      const StatefulComponent = () => {
-        const [count, setCount] = React.useState(0);
-        return (
-          <div>
-            <p>Count: {count}</p>
-            <button onClick={() => setCount(count + 1)}>Increment</button>
-          </div>
-        );
-      };
-
-      const ProtectedComponent = withAuth(StatefulComponent);
-      const { user } = render(<ProtectedComponent />);
-
-      await waitFor(() => {
-        expect(screen.getByText('Count: 0')).toBeInTheDocument();
-      });
-
-      const button = screen.getByRole('button', { name: /increment/i });
-      await user.click(button);
-
-      await waitFor(() => {
-        expect(screen.getByText('Count: 1')).toBeInTheDocument();
       });
     });
   });

--- a/apps/web/__tests__/components/layout/dashboard-layout.test.tsx
+++ b/apps/web/__tests__/components/layout/dashboard-layout.test.tsx
@@ -257,7 +257,7 @@ describe('DashboardLayout Component', () => {
     });
 
     it('redirects to login even if logout API fails', async () => {
-      const mockLogout = vi.fn().mockResolvedValue(undefined);
+      const mockLogout = vi.fn().mockRejectedValue(new Error('Logout failed'));
 
       mockUseAuthStore.mockReturnValue({
         user: mockUser,
@@ -328,8 +328,10 @@ describe('DashboardLayout Component', () => {
         </DashboardLayout>
       );
 
-      // Open sidebar
-      const menuButton = container.querySelector('button.lg\\:hidden');
+      // Open sidebar — menu button is inside <header>, not the sidebar close button
+      const header = container.querySelector('header');
+      const menuButton = header?.querySelector('button');
+      expect(menuButton).toBeInTheDocument();
       await user.click(menuButton!);
 
       // Backdrop should appear
@@ -344,8 +346,9 @@ describe('DashboardLayout Component', () => {
         </DashboardLayout>
       );
 
-      // Open sidebar
-      const menuButton = container.querySelector('button.lg\\:hidden');
+      // Open sidebar via header menu button
+      const header = container.querySelector('header');
+      const menuButton = header?.querySelector('button');
       await user.click(menuButton!);
 
       // Click backdrop to close

--- a/apps/web/__tests__/components/layout/dashboard-layout.test.tsx
+++ b/apps/web/__tests__/components/layout/dashboard-layout.test.tsx
@@ -1,13 +1,15 @@
 /**
  * Tests for DashboardLayout component
- * Tests sidebar navigation, user menu, mobile responsiveness, and logout functionality
+ *
+ * Tests sidebar navigation, user menu, mobile responsiveness, and logout functionality.
+ * Updated to match current source: CSS transform-based sidebar, "Logout" button text,
+ * bg-blue-600 avatar, and accurate CSS class assertions.
  */
 
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, within } from '../../utils/test-utils';
 import { DashboardLayout } from '../../../src/components/layout/dashboard-layout';
-import { useAuthStore } from '../../../src/store/auth.store';
 
 // Mock next/navigation
 const mockPush = vi.fn();
@@ -29,6 +31,12 @@ vi.mock('../../../src/store/auth.store', () => ({
   useAuthStore: vi.fn(),
 }));
 
+// Mock NotificationBell to avoid complex dependency chain
+vi.mock('../../../src/components/notifications', () => ({
+  NotificationBell: () => <div data-testid="notification-bell">Notifications</div>,
+}));
+
+import { useAuthStore } from '../../../src/store/auth.store';
 const mockUseAuthStore = useAuthStore as unknown as ReturnType<typeof vi.fn>;
 
 // Mock user data
@@ -40,8 +48,7 @@ const mockUser = {
   fullName: 'John Doe',
 };
 
-// TODO(tier0): mock structure does not match current DashboardLayout component
-describe.skip('DashboardLayout Component', () => {
+describe('DashboardLayout Component', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockPush.mockClear();
@@ -84,7 +91,7 @@ describe.skip('DashboardLayout Component', () => {
 
       const main = container.querySelector('main');
       expect(main).toBeInTheDocument();
-      expect(main).toHaveClass('py-8');
+      expect(main).toHaveClass('flex-1', 'overflow-auto');
     });
   });
 
@@ -171,14 +178,15 @@ describe.skip('DashboardLayout Component', () => {
   });
 
   describe('User Information Display', () => {
-    it('displays user full name', () => {
+    it('displays user first and last name', () => {
       render(
         <DashboardLayout>
           <div>Content</div>
         </DashboardLayout>
       );
 
-      expect(screen.getAllByText('John Doe').length).toBeGreaterThan(0);
+      // The component renders "{user.firstName} {user.lastName}" in the sidebar
+      expect(screen.getByText('John Doe')).toBeInTheDocument();
     });
 
     it('displays user email', () => {
@@ -188,64 +196,46 @@ describe.skip('DashboardLayout Component', () => {
         </DashboardLayout>
       );
 
-      expect(screen.getAllByText('john.doe@example.com').length).toBeGreaterThan(0);
+      expect(screen.getByText('john.doe@example.com')).toBeInTheDocument();
     });
 
-    it('displays welcome message with first name', () => {
+    it('renders user menu area', () => {
       render(
         <DashboardLayout>
           <div>Content</div>
         </DashboardLayout>
       );
 
-      expect(screen.getByText(/Welcome back, John!/)).toBeInTheDocument();
+      const userMenu = screen.getByTestId('user-menu');
+      expect(userMenu).toBeInTheDocument();
     });
 
-    it('handles user without fullName gracefully', () => {
-      mockUseAuthStore.mockReturnValue({
-        user: {
-          ...mockUser,
-          fullName: undefined,
-        },
-        logout: vi.fn(),
-      });
-
-      render(
-        <DashboardLayout>
-          <div>Content</div>
-        </DashboardLayout>
-      );
-
-      // Should display firstName + lastName
-      expect(screen.getAllByText('John Doe').length).toBeGreaterThan(0);
-    });
-
-    it('renders user avatar placeholder', () => {
+    it('renders user avatar placeholder with blue background', () => {
       const { container } = render(
         <DashboardLayout>
           <div>Content</div>
         </DashboardLayout>
       );
 
-      // User icon should be present
-      const avatars = container.querySelectorAll('.rounded-full.bg-primary');
+      // Avatar uses rounded-full bg-blue-600
+      const avatars = container.querySelectorAll('.rounded-full.bg-blue-600');
       expect(avatars.length).toBeGreaterThan(0);
     });
   });
 
   describe('Logout Functionality', () => {
-    it('renders sign out button', () => {
+    it('renders logout button', () => {
       render(
         <DashboardLayout>
           <div>Content</div>
         </DashboardLayout>
       );
 
-      const signOutButtons = screen.getAllByTestId('logout-button');
-      expect(signOutButtons.length).toBeGreaterThan(0);
+      const logoutButton = screen.getByTestId('logout-button');
+      expect(logoutButton).toBeInTheDocument();
     });
 
-    it('calls logout and redirects on sign out click', async () => {
+    it('calls logout and redirects on logout click', async () => {
       const mockLogout = vi.fn().mockResolvedValue(undefined);
 
       mockUseAuthStore.mockReturnValue({
@@ -259,15 +249,15 @@ describe.skip('DashboardLayout Component', () => {
         </DashboardLayout>
       );
 
-      const signOutButtons = screen.getAllByTestId('logout-button');
-      await user.click(signOutButtons[0]);
+      const logoutButton = screen.getByTestId('logout-button');
+      await user.click(logoutButton);
 
       expect(mockLogout).toHaveBeenCalledTimes(1);
       expect(mockRouter.replace).toHaveBeenCalledWith('/auth/login');
     });
 
-    it('redirects to login even if logout fails', async () => {
-      const mockLogout = vi.fn().mockRejectedValue(new Error('Logout failed'));
+    it('redirects to login even if logout API fails', async () => {
+      const mockLogout = vi.fn().mockResolvedValue(undefined);
 
       mockUseAuthStore.mockReturnValue({
         user: mockUser,
@@ -280,26 +270,26 @@ describe.skip('DashboardLayout Component', () => {
         </DashboardLayout>
       );
 
-      const signOutButtons = screen.getAllByTestId('logout-button');
-      await user.click(signOutButtons[0]);
+      const logoutButton = screen.getByTestId('logout-button');
+      await user.click(logoutButton);
 
       expect(mockLogout).toHaveBeenCalledTimes(1);
-      // Should still redirect even on error
       expect(mockRouter.replace).toHaveBeenCalledWith('/auth/login');
     });
   });
 
   describe('Mobile Sidebar', () => {
-    it('mobile sidebar is hidden by default', () => {
+    it('sidebar starts off-screen on mobile via CSS transform', () => {
       const { container } = render(
         <DashboardLayout>
           <div>Content</div>
         </DashboardLayout>
       );
 
-      // Mobile sidebar should have 'hidden' class initially
-      const mobileSidebar = container.querySelector('.lg\\:hidden.hidden');
-      expect(mobileSidebar).toBeInTheDocument();
+      // The aside element uses -translate-x-full when closed (mobile)
+      const sidebar = container.querySelector('aside');
+      expect(sidebar).toBeInTheDocument();
+      expect(sidebar?.className).toContain('-translate-x-full');
     });
 
     it('renders menu button for mobile', () => {
@@ -309,48 +299,42 @@ describe.skip('DashboardLayout Component', () => {
         </DashboardLayout>
       );
 
-      // Menu button should be present for mobile
+      // Menu button is lg:hidden in the header
       const menuButton = container.querySelector('button.lg\\:hidden');
       expect(menuButton).toBeInTheDocument();
     });
 
-    it('closes mobile sidebar on close button click', async () => {
+    it('opens sidebar on menu button click', async () => {
       const { user, container } = render(
         <DashboardLayout>
           <div>Content</div>
         </DashboardLayout>
       );
 
-      // Open sidebar first
-      const menuButton = container.querySelector('button[type="button"]');
+      // Click mobile menu button to open sidebar
+      const menuButton = container.querySelector('button.lg\\:hidden');
+      expect(menuButton).toBeInTheDocument();
       await user.click(menuButton!);
 
-      // Find and click close button (X icon)
-      const closeButtons = container.querySelectorAll('button[type="button"]');
-      const closeButton = Array.from(closeButtons).find(
-        (button) => button.querySelector('.h-6.w-6')
-      );
-
-      if (closeButton) {
-        await user.click(closeButton);
-      }
-
-      // Sidebar should be hidden again
-      const mobileSidebar = container.querySelector('.lg\\:hidden.hidden');
-      expect(mobileSidebar).toBeInTheDocument();
+      // After opening, sidebar should have translate-x-0 class
+      const sidebar = container.querySelector('aside');
+      expect(sidebar?.className).toContain('translate-x-0');
     });
 
-    it('mobile sidebar has navigation links', () => {
-      render(
+    it('shows backdrop when mobile sidebar is open', async () => {
+      const { user, container } = render(
         <DashboardLayout>
           <div>Content</div>
         </DashboardLayout>
       );
 
-      // Navigation links should be present in both mobile and desktop sidebars
-      const dashboardLinks = screen.getAllByRole('link', { name: /dashboard/i });
-      // Should have at least 2 (mobile + desktop)
-      expect(dashboardLinks.length).toBeGreaterThanOrEqual(1);
+      // Open sidebar
+      const menuButton = container.querySelector('button.lg\\:hidden');
+      await user.click(menuButton!);
+
+      // Backdrop should appear
+      const backdrop = container.querySelector('.bg-gray-600.bg-opacity-75');
+      expect(backdrop).toBeInTheDocument();
     });
 
     it('closes mobile sidebar on backdrop click', async () => {
@@ -361,59 +345,72 @@ describe.skip('DashboardLayout Component', () => {
       );
 
       // Open sidebar
-      const menuButton = container.querySelector('button[type="button"]');
+      const menuButton = container.querySelector('button.lg\\:hidden');
       await user.click(menuButton!);
 
-      // Find and click backdrop
+      // Click backdrop to close
       const backdrop = container.querySelector('.bg-gray-600.bg-opacity-75');
-      if (backdrop) {
-        await user.click(backdrop as HTMLElement);
-      }
+      expect(backdrop).toBeInTheDocument();
+      await user.click(backdrop as HTMLElement);
 
-      // Sidebar should close
-      const mobileSidebar = container.querySelector('.lg\\:hidden.hidden');
-      expect(mobileSidebar).toBeInTheDocument();
+      // Sidebar should be closed again
+      const sidebar = container.querySelector('aside');
+      expect(sidebar?.className).toContain('-translate-x-full');
+    });
+
+    it('mobile sidebar has navigation links', () => {
+      render(
+        <DashboardLayout>
+          <div>Content</div>
+        </DashboardLayout>
+      );
+
+      // Navigation links are in the sidebar
+      const dashboardLinks = screen.getAllByRole('link', { name: /dashboard/i });
+      expect(dashboardLinks.length).toBeGreaterThanOrEqual(1);
     });
   });
 
   describe('Desktop Layout', () => {
-    it('renders desktop sidebar with correct classes', () => {
+    it('sidebar uses lg:static for desktop positioning', () => {
       const { container } = render(
         <DashboardLayout>
           <div>Content</div>
         </DashboardLayout>
       );
 
-      const desktopSidebar = container.querySelector('.hidden.lg\\:fixed.lg\\:inset-y-0');
-      expect(desktopSidebar).toBeInTheDocument();
-    });
-
-    it('applies proper spacing for main content with sidebar', () => {
-      const { container } = render(
-        <DashboardLayout>
-          <div>Content</div>
-        </DashboardLayout>
-      );
-
-      const mainContent = container.querySelector('.lg\\:pl-64');
-      expect(mainContent).toBeInTheDocument();
+      const sidebar = container.querySelector('aside');
+      expect(sidebar).toBeInTheDocument();
+      expect(sidebar?.className).toContain('lg:static');
+      expect(sidebar?.className).toContain('lg:translate-x-0');
     });
   });
 
   describe('Top Bar', () => {
-    it('renders sticky top bar', () => {
+    it('renders sticky header', () => {
       const { container } = render(
         <DashboardLayout>
           <div>Content</div>
         </DashboardLayout>
       );
 
-      const topBar = container.querySelector('.sticky.top-0');
-      expect(topBar).toBeInTheDocument();
-      expect(topBar).toHaveClass('h-16', 'bg-white', 'border-b');
+      const header = container.querySelector('header');
+      expect(header).toBeInTheDocument();
+      expect(header).toHaveClass('sticky', 'top-0');
     });
 
-    it('displays menu button on mobile', () => {
+    it('renders search input on desktop', () => {
+      render(
+        <DashboardLayout>
+          <div>Content</div>
+        </DashboardLayout>
+      );
+
+      const searchInput = screen.getByTestId('search-input');
+      expect(searchInput).toBeInTheDocument();
+    });
+
+    it('displays mobile menu button in header', () => {
       const { container } = render(
         <DashboardLayout>
           <div>Content</div>
@@ -453,6 +450,7 @@ describe.skip('DashboardLayout Component', () => {
 
       expect(container.querySelector('nav')).toBeInTheDocument();
       expect(container.querySelector('main')).toBeInTheDocument();
+      expect(container.querySelector('header')).toBeInTheDocument();
     });
 
     it('navigation links are accessible', () => {
@@ -464,17 +462,6 @@ describe.skip('DashboardLayout Component', () => {
 
       const dashboardLinks = screen.getAllByRole('link', { name: /dashboard/i });
       expect(dashboardLinks.length).toBeGreaterThan(0);
-    });
-
-    it('buttons have proper types', () => {
-      const { container } = render(
-        <DashboardLayout>
-          <div>Content</div>
-        </DashboardLayout>
-      );
-
-      const buttons = container.querySelectorAll('button[type="button"]');
-      expect(buttons.length).toBeGreaterThan(0);
     });
   });
 

--- a/apps/web/__tests__/components/pages/accounts.test.tsx
+++ b/apps/web/__tests__/components/pages/accounts.test.tsx
@@ -252,7 +252,7 @@ describe('AccountsPage', () => {
         () => {
           expect(mockAccountsClient.checkDeletionEligibility).toHaveBeenCalledWith('acc-to-delete');
         },
-        { timeout: 3000 }
+        { timeout: 5000 }
       );
     });
 
@@ -644,7 +644,7 @@ describe('AccountsPage', () => {
         () => {
           expect(screen.getByTestId('account-name-input')).toBeInTheDocument();
         },
-        { timeout: 3000 }
+        { timeout: 5000 }
       );
 
       // Click on piggybank icon if selector exists
@@ -696,7 +696,7 @@ describe('AccountsPage', () => {
         () => {
           expect(screen.getByTestId('account-name-input')).toBeInTheDocument();
         },
-        { timeout: 3000 }
+        { timeout: 5000 }
       );
 
       // Update name and balance
@@ -785,7 +785,7 @@ describe('AccountsPage', () => {
           const iconSelector = screen.queryByTestId('icon-bank') || screen.queryByTestId('icon-wallet');
           expect(iconSelector).toBeInTheDocument();
         },
-        { timeout: 3000 }
+        { timeout: 5000 }
       );
 
       // Select an icon and color
@@ -920,7 +920,7 @@ describe('AccountsPage', () => {
         () => {
           expect(mockAccountsClient.checkDeletionEligibility).toHaveBeenCalledWith('acc-orphaned');
         },
-        { timeout: 3000 }
+        { timeout: 5000 }
       );
 
       // Delete confirmation dialog should appear

--- a/apps/web/__tests__/lib/auth.test.ts
+++ b/apps/web/__tests__/lib/auth.test.ts
@@ -55,6 +55,8 @@ const mockUser: User = {
   isActive: true,
 };
 
+const originalFetch = global.fetch;
+
 describe('Auth Service', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -63,6 +65,7 @@ describe('Auth Service', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    global.fetch = originalFetch;
   });
 
   describe('authService.login', () => {
@@ -278,7 +281,7 @@ describe('Auth Service', () => {
       expect(result.emailVerifiedAt).toBe('2024-01-01T10:00:00.000Z');
     });
 
-    it('should include CSRF token header via apiRequest for GET', async () => {
+    it('should not include CSRF token header for GET requests', async () => {
       vi.mocked(global.fetch).mockResolvedValue(mockResponse(mockUser));
 
       await authService.getProfile();

--- a/apps/web/__tests__/lib/auth.test.ts
+++ b/apps/web/__tests__/lib/auth.test.ts
@@ -1,256 +1,156 @@
 /**
  * Auth Service Tests
  *
- * Tests the authentication service with API interceptors and token management
+ * Tests the cookie-based authentication service with fetch API and CSRF protection.
+ * Validates login, register, getProfile, logout, and error handling.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import axios from 'axios';
 
-// Create mock functions that will be reused
-const mockGet = vi.fn();
-const mockPost = vi.fn();
-const mockRequestInterceptor = vi.fn((config) => config);
-const mockResponseInterceptor = vi.fn((response) => response);
-const mockErrorInterceptor = vi.fn();
+// Mock CSRF utilities before importing authService
+vi.mock('../../src/utils/csrf', () => ({
+  getCsrfToken: vi.fn(() => 'mock-csrf-token'),
+  setCsrfToken: vi.fn(),
+  clearCsrfToken: vi.fn(),
+  requiresCsrf: vi.fn((method?: string) => {
+    if (!method) return false;
+    return ['POST', 'PUT', 'PATCH', 'DELETE'].includes(method.toUpperCase());
+  }),
+  isCsrfError: vi.fn(() => false),
+  refreshCsrfToken: vi.fn(),
+}));
 
-// Mock axios
-vi.mock('axios', () => {
-  const mockCreate = vi.fn(() => ({
-    interceptors: {
-      request: {
-        use: vi.fn((successHandler, errorHandler) => {
-          mockRequestInterceptor.mockImplementation(successHandler);
-          return 0;
-        })
-      },
-      response: {
-        use: vi.fn((successHandler, errorHandler) => {
-          mockResponseInterceptor.mockImplementation(successHandler);
-          mockErrorInterceptor.mockImplementation(errorHandler);
-          return 0;
-        })
-      },
-    },
-    get: mockGet,
-    post: mockPost,
-  }));
-
-  return {
-    default: {
-      create: mockCreate,
-      post: vi.fn(),
-    },
-    create: mockCreate,
-    post: vi.fn(),
-  };
-});
+// Mock sanitize utilities - sanitizeUser returns the user as-is in tests
+vi.mock('../../src/utils/sanitize', () => ({
+  sanitizeUser: vi.fn((user: unknown) => user),
+}));
 
 // Import after mocks are set up
-const { authApi, authService } = await import('../../lib/auth');
+import { authService } from '../../lib/auth';
 import type { User, AuthResponse } from '../../lib/auth';
+import { getCsrfToken, setCsrfToken, clearCsrfToken } from '../../src/utils/csrf';
 
-// Mock localStorage
-const localStorageMock = {
-  getItem: vi.fn(),
-  setItem: vi.fn(),
-  removeItem: vi.fn(),
-  clear: vi.fn(),
+// Helper to create a mock Response
+function mockResponse(data: unknown, options: { ok?: boolean; status?: number } = {}) {
+  const { ok = true, status = 200 } = options;
+  return {
+    ok,
+    status,
+    json: vi.fn().mockResolvedValue(data),
+    headers: new Headers(),
+  } as unknown as Response;
+}
+
+// Standard mock user for tests
+const mockUser: User = {
+  id: '550e8400-e29b-41d4-a716-446655440000',
+  email: 'test@example.com',
+  firstName: 'John',
+  lastName: 'Doe',
+  role: 'USER',
+  status: 'ACTIVE',
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+  fullName: 'John Doe',
+  isEmailVerified: true,
+  isActive: true,
 };
-Object.defineProperty(window, 'localStorage', { value: localStorageMock });
-
-// Mock window.location
-delete (window as any).location;
-window.location = { href: '' } as any;
 
 describe('Auth Service', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGet.mockClear();
-    mockPost.mockClear();
-    mockRequestInterceptor.mockClear();
-    mockResponseInterceptor.mockClear();
-    mockErrorInterceptor.mockClear();
-    localStorageMock.getItem.mockReturnValue(null);
-    window.location.href = '';
+    global.fetch = vi.fn();
   });
 
   afterEach(() => {
-    vi.clearAllMocks();
-  });
-
-  describe('authApi configuration', () => {
-    // TODO(tier0): auth service mock mismatch
-    it.skip('should create axios instance with correct base URL', () => {
-      // authApi was created during module import with our mock
-      expect(authApi).toBeDefined();
-      expect(authApi.get).toBe(mockGet);
-      expect(authApi.post).toBe(mockPost);
-    });
-
-    it('should set up request and response interceptors', () => {
-      // Interceptors are set up during module import
-      expect(mockRequestInterceptor).toBeDefined();
-      expect(mockResponseInterceptor).toBeDefined();
-      expect(mockErrorInterceptor).toBeDefined();
-    });
-  });
-
-  describe('Request interceptor', () => {
-    // TODO(tier0): auth service mock mismatch
-    it.skip('should add Authorization header when token exists', () => {
-      const mockConfig = { headers: {} as any };
-      localStorageMock.getItem.mockReturnValue('test-token');
-
-      const result = mockRequestInterceptor(mockConfig);
-
-      expect(localStorageMock.getItem).toHaveBeenCalledWith('accessToken');
-      expect(result.headers.Authorization).toBe('Bearer test-token');
-    });
-
-    // TODO(tier0): auth service mock mismatch
-    it.skip('should not add Authorization header when token does not exist', () => {
-      const mockConfig = { headers: {} as any };
-      localStorageMock.getItem.mockReturnValue(null);
-
-      const result = mockRequestInterceptor(mockConfig);
-
-      expect(localStorageMock.getItem).toHaveBeenCalledWith('accessToken');
-      expect(result.headers.Authorization).toBeUndefined();
-    });
-
-    // TODO(tier0): auth service mock mismatch
-    it.skip('should preserve existing headers', () => {
-      const mockConfig = {
-        headers: {
-          'X-Custom-Header': 'value',
-        } as any,
-      };
-      localStorageMock.getItem.mockReturnValue('test-token');
-
-      const result = mockRequestInterceptor(mockConfig);
-
-      expect(result.headers['X-Custom-Header']).toBe('value');
-      expect(result.headers.Authorization).toBe('Bearer test-token');
-    });
-  });
-
-  describe('Response interceptor', () => {
-    it('should pass through successful responses', () => {
-      const mockResponse = { data: 'success' };
-      const result = mockResponseInterceptor(mockResponse);
-      expect(result).toBe(mockResponse);
-    });
-
-    // TODO(tier0): needs richer mock — interceptor logic not exercised
-    it.skip('should handle 401 error and attempt token refresh', async () => {
-      // This test needs a proper mock of the axios interceptor chain
-      // The interceptor logic should be verified through actual 401 → refresh flow
-    });
-
-    // TODO(tier0): auth service mock mismatch
-    it.skip('should not retry if request already retried', async () => {
-      const error = {
-        response: { status: 401 },
-        config: { _retry: true },
-      };
-
-      await expect(mockErrorInterceptor(error)).rejects.toEqual(error);
-    });
-
-    // TODO(tier0): auth service mock mismatch
-    it.skip('should redirect to login on refresh failure', async () => {
-      localStorageMock.getItem.mockReturnValue('refresh-token');
-      vi.spyOn(axios, 'post').mockRejectedValue(new Error('Refresh failed'));
-
-      const error = {
-        response: { status: 401 },
-        config: {},
-      };
-
-      // The error interceptor should handle the error but still reject
-      try {
-        await mockErrorInterceptor(error);
-      } catch (e) {
-        // Expected to throw
-      }
-
-      expect(localStorageMock.removeItem).toHaveBeenCalledWith('accessToken');
-      expect(localStorageMock.removeItem).toHaveBeenCalledWith('refreshToken');
-      expect(window.location.href).toBe('/auth/login');
-    });
-
-    // TODO(tier0): auth service mock mismatch
-    it.skip('should redirect to login if no refresh token', async () => {
-      localStorageMock.getItem.mockReturnValue(null);
-
-      const error = {
-        response: { status: 401 },
-        config: {},
-      };
-
-      await expect(mockErrorInterceptor(error)).rejects.toEqual(error);
-      expect(window.location.href).not.toBe('/auth/login');
-    });
-
-    // TODO(tier0): auth service mock mismatch
-    it.skip('should pass through non-401 errors', async () => {
-      const error = {
-        response: { status: 500 },
-        config: {},
-      };
-
-      await expect(mockErrorInterceptor(error)).rejects.toEqual(error);
-    });
-
-    // TODO(tier0): auth service mock mismatch
-    it.skip('should handle errors without response', async () => {
-      const error = new Error('Network error');
-
-      await expect(mockErrorInterceptor(error)).rejects.toEqual(error);
-    });
+    vi.restoreAllMocks();
   });
 
   describe('authService.login', () => {
-    // TODO(tier0): auth service mock mismatch
-    it.skip('should make POST request to login endpoint', async () => {
-      const mockResponse: AuthResponse = {
-        accessToken: 'access-token',
-        refreshToken: 'refresh-token',
-        user: { id: '1', email: 'test@example.com' } as User,
-        expiresIn: 3600,
+    it('should make POST request to login endpoint with credentials', async () => {
+      const mockAuthResponse: AuthResponse = {
+        user: mockUser,
+        csrfToken: 'csrf-token-123',
       };
 
-      mockPost.mockResolvedValue({ data: mockResponse });
+      vi.mocked(global.fetch).mockResolvedValue(mockResponse(mockAuthResponse));
 
       const credentials = { email: 'test@example.com', password: 'password' };
       const result = await authService.login(credentials);
 
-      expect(mockPost).toHaveBeenCalledWith('/auth/login', credentials);
-      expect(result).toEqual(mockResponse);
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/auth/login',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify(credentials),
+        })
+      );
+      expect(result.user).toEqual(mockUser);
+      expect(result.csrfToken).toBe('csrf-token-123');
     });
 
-    // TODO(tier0): auth service mock mismatch
-    it.skip('should handle login errors', async () => {
-      const error = new Error('Invalid credentials');
-      mockPost.mockRejectedValue(error);
+    it('should store CSRF token on successful login', async () => {
+      const mockAuthResponse: AuthResponse = {
+        user: mockUser,
+        csrfToken: 'new-csrf-token',
+      };
 
-      const credentials = { email: 'test@example.com', password: 'wrong' };
+      vi.mocked(global.fetch).mockResolvedValue(mockResponse(mockAuthResponse));
 
-      await expect(authService.login(credentials)).rejects.toThrow('Invalid credentials');
+      await authService.login({ email: 'test@example.com', password: 'password' });
+
+      expect(setCsrfToken).toHaveBeenCalledWith('new-csrf-token');
+    });
+
+    it('should throw on login failure with error message', async () => {
+      vi.mocked(global.fetch).mockResolvedValue(
+        mockResponse(
+          { statusCode: 401, message: 'Invalid credentials' },
+          { ok: false, status: 401 }
+        )
+      );
+
+      await expect(
+        authService.login({ email: 'test@example.com', password: 'wrong' })
+      ).rejects.toThrow('Invalid credentials');
+    });
+
+    it('should join array error messages', async () => {
+      vi.mocked(global.fetch).mockResolvedValue(
+        mockResponse(
+          { statusCode: 400, message: ['Email is required', 'Password is required'] },
+          { ok: false, status: 400 }
+        )
+      );
+
+      await expect(
+        authService.login({ email: '', password: '' })
+      ).rejects.toThrow('Email is required, Password is required');
+    });
+
+    it('should use default error message when none provided', async () => {
+      vi.mocked(global.fetch).mockResolvedValue(
+        mockResponse(
+          { statusCode: 500 },
+          { ok: false, status: 500 }
+        )
+      );
+
+      await expect(
+        authService.login({ email: 'test@example.com', password: 'password' })
+      ).rejects.toThrow('Login failed');
     });
   });
 
   describe('authService.register', () => {
-    // TODO(tier0): auth service mock mismatch
-    it.skip('should make POST request to register endpoint', async () => {
-      const mockResponse: AuthResponse = {
-        accessToken: 'access-token',
-        refreshToken: 'refresh-token',
-        user: { id: '1', email: 'new@example.com' } as User,
-        expiresIn: 3600,
+    it('should make POST request to register endpoint', async () => {
+      const mockAuthResponse: AuthResponse = {
+        user: mockUser,
+        csrfToken: 'csrf-token-reg',
       };
 
-      mockPost.mockResolvedValue({ data: mockResponse });
+      vi.mocked(global.fetch).mockResolvedValue(mockResponse(mockAuthResponse));
 
       const credentials = {
         email: 'new@example.com',
@@ -260,113 +160,113 @@ describe('Auth Service', () => {
       };
       const result = await authService.register(credentials);
 
-      expect(mockPost).toHaveBeenCalledWith('/auth/register', credentials);
-      expect(result).toEqual(mockResponse);
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/auth/register',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify(credentials),
+        })
+      );
+      expect(result.user).toEqual(mockUser);
+      expect(result.csrfToken).toBe('csrf-token-reg');
     });
 
-    // TODO(tier0): auth service mock mismatch
-    it.skip('should handle registration errors', async () => {
-      const error = new Error('Email already exists');
-      mockPost.mockRejectedValue(error);
+    it('should store CSRF token on successful registration', async () => {
+      const mockAuthResponse: AuthResponse = {
+        user: mockUser,
+        csrfToken: 'reg-csrf-token',
+      };
 
-      const credentials = {
-        email: 'existing@example.com',
+      vi.mocked(global.fetch).mockResolvedValue(mockResponse(mockAuthResponse));
+
+      await authService.register({
+        email: 'new@example.com',
         password: 'password',
         firstName: 'John',
         lastName: 'Doe',
-      };
-
-      await expect(authService.register(credentials)).rejects.toThrow('Email already exists');
-    });
-  });
-
-  describe('authService.refreshToken', () => {
-    // TODO(tier0): auth service mock mismatch
-    it.skip('should make POST request to refresh endpoint', async () => {
-      const mockResponse: AuthResponse = {
-        accessToken: 'new-access-token',
-        refreshToken: 'new-refresh-token',
-        user: { id: '1', email: 'test@example.com' } as User,
-        expiresIn: 3600,
-      };
-
-      mockPost.mockResolvedValue({ data: mockResponse });
-
-      const result = await authService.refreshToken('old-refresh-token');
-
-      expect(mockPost).toHaveBeenCalledWith('/auth/refresh', {
-        refreshToken: 'old-refresh-token',
       });
-      expect(result).toEqual(mockResponse);
+
+      expect(setCsrfToken).toHaveBeenCalledWith('reg-csrf-token');
     });
 
-    // TODO(tier0): auth service mock mismatch
-    it.skip('should handle refresh errors', async () => {
-      const error = new Error('Invalid refresh token');
-      mockPost.mockRejectedValue(error);
-
-      await expect(authService.refreshToken('invalid-token')).rejects.toThrow(
-        'Invalid refresh token'
+    it('should throw on registration failure', async () => {
+      vi.mocked(global.fetch).mockResolvedValue(
+        mockResponse(
+          { statusCode: 409, message: 'Email already exists' },
+          { ok: false, status: 409 }
+        )
       );
+
+      await expect(
+        authService.register({
+          email: 'existing@example.com',
+          password: 'password',
+          firstName: 'John',
+          lastName: 'Doe',
+        })
+      ).rejects.toThrow('Email already exists');
+    });
+
+    it('should handle array validation errors on registration', async () => {
+      vi.mocked(global.fetch).mockResolvedValue(
+        mockResponse(
+          { statusCode: 400, message: ['Password too short', 'Invalid email'] },
+          { ok: false, status: 400 }
+        )
+      );
+
+      await expect(
+        authService.register({
+          email: 'bad',
+          password: 'x',
+          firstName: 'John',
+          lastName: 'Doe',
+        })
+      ).rejects.toThrow('Password too short, Invalid email');
     });
   });
 
   describe('authService.getProfile', () => {
-    // TODO(tier0): auth service mock mismatch
-    it.skip('should make GET request to profile endpoint', async () => {
-      const mockUser: User = {
-        id: '1',
-        email: 'test@example.com',
-        firstName: 'John',
-        lastName: 'Doe',
-        role: 'user',
-        status: 'active',
-        createdAt: '2024-01-01',
-        updatedAt: '2024-01-01',
-        fullName: 'John Doe',
-        isEmailVerified: true,
-        isActive: true,
-      };
-
-      mockGet.mockResolvedValue({ data: mockUser });
+    it('should make GET request to profile endpoint with credentials', async () => {
+      vi.mocked(global.fetch).mockResolvedValue(mockResponse(mockUser));
 
       const result = await authService.getProfile();
 
-      expect(mockGet).toHaveBeenCalledWith('/auth/profile');
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/auth/profile',
+        expect.objectContaining({
+          method: 'GET',
+          credentials: 'include',
+        })
+      );
       expect(result).toEqual(mockUser);
     });
 
-    // TODO(tier0): auth service mock mismatch
-    it.skip('should handle profile fetch errors', async () => {
-      const error = new Error('Unauthorized');
-      mockGet.mockRejectedValue(error);
+    it('should throw on profile fetch failure', async () => {
+      vi.mocked(global.fetch).mockResolvedValue(
+        mockResponse(
+          { statusCode: 401, message: 'Unauthorized' },
+          { ok: false, status: 401 }
+        )
+      );
 
-      await expect(authService.getProfile()).rejects.toThrow('Unauthorized');
+      await expect(authService.getProfile()).rejects.toThrow('Failed to fetch profile');
     });
 
-    // TODO(tier0): auth service mock mismatch
-    it.skip('should include all optional User fields', async () => {
-      const mockUser: User = {
-        id: '1',
-        email: 'test@example.com',
-        firstName: 'John',
-        lastName: 'Doe',
-        role: 'admin',
-        status: 'active',
+    it('should include all optional User fields', async () => {
+      const fullUser: User = {
+        ...mockUser,
         avatar: 'https://example.com/avatar.jpg',
         timezone: 'America/New_York',
         currency: 'USD',
         preferences: { theme: 'dark', notifications: true },
-        lastLoginAt: '2024-01-01T12:00:00Z',
-        emailVerifiedAt: '2024-01-01T10:00:00Z',
-        createdAt: '2024-01-01',
-        updatedAt: '2024-01-01',
-        fullName: 'John Doe',
-        isEmailVerified: true,
-        isActive: true,
+        lastLoginAt: '2024-01-01T12:00:00.000Z',
+        emailVerifiedAt: '2024-01-01T10:00:00.000Z',
       };
 
-      mockGet.mockResolvedValue({ data: mockUser });
+      vi.mocked(global.fetch).mockResolvedValue(mockResponse(fullUser));
 
       const result = await authService.getProfile();
 
@@ -374,114 +274,122 @@ describe('Auth Service', () => {
       expect(result.timezone).toBe('America/New_York');
       expect(result.currency).toBe('USD');
       expect(result.preferences).toEqual({ theme: 'dark', notifications: true });
-      expect(result.lastLoginAt).toBe('2024-01-01T12:00:00Z');
-      expect(result.emailVerifiedAt).toBe('2024-01-01T10:00:00Z');
+      expect(result.lastLoginAt).toBe('2024-01-01T12:00:00.000Z');
+      expect(result.emailVerifiedAt).toBe('2024-01-01T10:00:00.000Z');
+    });
+
+    it('should include CSRF token header via apiRequest for GET', async () => {
+      vi.mocked(global.fetch).mockResolvedValue(mockResponse(mockUser));
+
+      await authService.getProfile();
+
+      // apiRequest adds Content-Type but not CSRF for GET (requiresCsrf returns false for GET)
+      const callArgs = vi.mocked(global.fetch).mock.calls[0];
+      expect(callArgs[1]).toEqual(
+        expect.objectContaining({
+          credentials: 'include',
+        })
+      );
     });
   });
 
   describe('authService.logout', () => {
-    // TODO(tier0): auth service mock mismatch
-    it.skip('should make POST request to logout endpoint', async () => {
-      mockPost.mockResolvedValue({ data: {} });
+    it('should make POST request to logout endpoint', async () => {
+      vi.mocked(global.fetch).mockResolvedValue(mockResponse({}));
 
       await authService.logout();
 
-      expect(mockPost).toHaveBeenCalledWith('/auth/logout');
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/auth/logout',
+        expect.objectContaining({
+          method: 'POST',
+          credentials: 'include',
+        })
+      );
     });
 
-    // TODO(tier0): auth service mock mismatch
-    it.skip('should handle logout errors', async () => {
-      const error = new Error('Logout failed');
-      mockPost.mockRejectedValue(error);
+    it('should clear CSRF token on successful logout', async () => {
+      vi.mocked(global.fetch).mockResolvedValue(mockResponse({}));
 
-      await expect(authService.logout()).rejects.toThrow('Logout failed');
+      await authService.logout();
+
+      expect(clearCsrfToken).toHaveBeenCalled();
     });
 
-    // TODO(tier0): auth service mock mismatch
-    it.skip('should not return any value', async () => {
-      mockPost.mockResolvedValue({ data: { message: 'Logged out' } });
+    it('should clear CSRF token even when logout API call fails', async () => {
+      vi.mocked(global.fetch).mockRejectedValue(new Error('Network error'));
 
-      const result = await authService.logout();
+      // logout uses try/finally (no catch), so errors propagate
+      // but clearCsrfToken is still called in the finally block
+      await expect(authService.logout()).rejects.toThrow('Network error');
 
-      expect(result).toBeUndefined();
+      expect(clearCsrfToken).toHaveBeenCalled();
     });
   });
 
   describe('Error handling', () => {
-    // TODO(tier0): auth service mock mismatch
-    it.skip('should handle network errors', async () => {
-      const networkError = new Error('Network Error');
-      (networkError as any).code = 'ERR_NETWORK';
-
-      mockPost.mockRejectedValue(networkError);
+    it('should handle network errors on login', async () => {
+      vi.mocked(global.fetch).mockRejectedValue(new Error('Network Error'));
 
       await expect(
         authService.login({ email: 'test@example.com', password: 'password' })
       ).rejects.toThrow('Network Error');
     });
 
-    // TODO(tier0): auth service mock mismatch
-    it.skip('should handle timeout errors', async () => {
-      const timeoutError = new Error('Timeout');
-      (timeoutError as any).code = 'ECONNABORTED';
-
-      mockGet.mockRejectedValue(timeoutError);
-
-      await expect(authService.getProfile()).rejects.toThrow('Timeout');
-    });
-
-    // TODO(tier0): auth service mock mismatch
-    it.skip('should handle server errors with response data', async () => {
-      const serverError = {
-        response: {
-          status: 500,
-          data: { message: 'Internal Server Error' },
-        },
-      };
-
-      mockPost.mockRejectedValue(serverError);
-
-      await expect(
-        authService.login({ email: 'test@example.com', password: 'password' })
-      ).rejects.toEqual(serverError);
-    });
-
-    // TODO(tier0): auth service mock mismatch
-    it.skip('should handle validation errors', async () => {
-      const validationError = {
-        response: {
-          status: 400,
-          data: {
-            errors: [
-              { field: 'email', message: 'Invalid email format' },
-              { field: 'password', message: 'Password too short' },
-            ],
-          },
-        },
-      };
-
-      mockPost.mockRejectedValue(validationError);
+    it('should handle network errors on register', async () => {
+      vi.mocked(global.fetch).mockRejectedValue(new Error('fetch failed'));
 
       await expect(
         authService.register({
-          email: 'invalid',
-          password: 'short',
+          email: 'new@example.com',
+          password: 'password',
           firstName: 'John',
           lastName: 'Doe',
         })
-      ).rejects.toEqual(validationError);
+      ).rejects.toThrow('fetch failed');
+    });
+
+    it('should handle network errors on getProfile', async () => {
+      vi.mocked(global.fetch).mockRejectedValue(new Error('Connection refused'));
+
+      await expect(authService.getProfile()).rejects.toThrow('Connection refused');
     });
   });
 
-  describe('Token management', () => {
-    // TODO(tier0): needs richer mock — token refresh flow not exercised
-    it.skip('should handle expired access token with valid refresh token', async () => {
-      // This test needs a proper mock of the token refresh mechanism
+  describe('CSRF token management', () => {
+    it('should include CSRF token in POST requests via apiRequest', async () => {
+      vi.mocked(getCsrfToken).mockReturnValue('test-csrf-token');
+      vi.mocked(global.fetch).mockResolvedValue(mockResponse({}));
+
+      await authService.logout();
+
+      // apiRequest adds CSRF header for POST methods
+      const callArgs = vi.mocked(global.fetch).mock.calls[0];
+      const headers = callArgs[1]?.headers as Record<string, string>;
+      expect(headers['X-CSRF-Token']).toBe('test-csrf-token');
     });
 
-    // TODO(tier0): needs richer mock — concurrent 401 handling not exercised
-    it.skip('should handle concurrent 401 errors', async () => {
-      // This test needs a proper mock of concurrent request handling
+    it('should not include CSRF token when getCsrfToken returns null', async () => {
+      vi.mocked(getCsrfToken).mockReturnValue(null);
+      vi.mocked(global.fetch).mockResolvedValue(mockResponse({}));
+
+      await authService.logout();
+
+      const callArgs = vi.mocked(global.fetch).mock.calls[0];
+      const headers = callArgs[1]?.headers as Record<string, string>;
+      expect(headers['X-CSRF-Token']).toBeUndefined();
+    });
+  });
+
+  describe('authService.refreshCsrfToken', () => {
+    it('should delegate to refreshCsrfToken utility', async () => {
+      const { refreshCsrfToken } = await import('../../src/utils/csrf');
+      vi.mocked(refreshCsrfToken).mockResolvedValue('new-csrf-token');
+
+      const result = await authService.refreshCsrfToken();
+
+      expect(refreshCsrfToken).toHaveBeenCalledWith('/api');
+      expect(result).toBe('new-csrf-token');
     });
   });
 });

--- a/apps/web/__tests__/lib/auth.test.ts
+++ b/apps/web/__tests__/lib/auth.test.ts
@@ -27,7 +27,7 @@ vi.mock('../../src/utils/sanitize', () => ({
 // Import after mocks are set up
 import { authService } from '../../lib/auth';
 import type { User, AuthResponse } from '../../lib/auth';
-import { getCsrfToken, setCsrfToken, clearCsrfToken } from '../../src/utils/csrf';
+import { getCsrfToken, setCsrfToken, clearCsrfToken, refreshCsrfToken } from '../../src/utils/csrf';
 
 // Helper to create a mock Response
 function mockResponse(data: unknown, options: { ok?: boolean; status?: number } = {}) {
@@ -293,6 +293,9 @@ describe('Auth Service', () => {
           credentials: 'include',
         })
       );
+      // CSRF header must NOT be present on GET requests
+      const headers = callArgs[1]?.headers as Record<string, string> | undefined;
+      expect(headers?.['X-CSRF-Token']).toBeUndefined();
     });
   });
 
@@ -386,7 +389,6 @@ describe('Auth Service', () => {
 
   describe('authService.refreshCsrfToken', () => {
     it('should delegate to refreshCsrfToken utility', async () => {
-      const { refreshCsrfToken } = await import('../../src/utils/csrf');
       vi.mocked(refreshCsrfToken).mockResolvedValue('new-csrf-token');
 
       const result = await authService.refreshCsrfToken();

--- a/apps/web/__tests__/pages/dashboard/settings.test.tsx
+++ b/apps/web/__tests__/pages/dashboard/settings.test.tsx
@@ -1,14 +1,74 @@
 /**
  * Tests for SettingsPage component
- * Tests empty state placeholder with CTA
+ *
+ * Tests the full settings form including profile fields, theme selection,
+ * notification preferences, and save functionality.
  */
 
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '../../utils/test-utils';
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '../../utils/test-utils';
 import SettingsPage from '../../../app/dashboard/settings/page';
 
-// TODO(tier0): mock structure does not match current settings page
-describe.skip('SettingsPage', () => {
+// Mock auth store
+vi.mock('../../../src/store/auth.store', () => ({
+  useAuthStore: vi.fn(),
+}));
+
+// Mock useTheme hook
+vi.mock('../../../src/hooks/useTheme', () => ({
+  useTheme: vi.fn(() => ({
+    theme: 'light',
+    resolvedTheme: 'light',
+    isDark: false,
+    setTheme: vi.fn(),
+  })),
+}));
+
+// Mock CSRF utility
+vi.mock('../../../src/utils/csrf', () => ({
+  getCsrfToken: vi.fn(() => 'mock-csrf-token'),
+}));
+
+import { useAuthStore } from '../../../src/store/auth.store';
+const mockUseAuthStore = useAuthStore as unknown as ReturnType<typeof vi.fn>;
+
+// Mock user matching the User interface
+const mockUser = {
+  id: '550e8400-e29b-41d4-a716-446655440000',
+  email: 'john@example.com',
+  firstName: 'John',
+  lastName: 'Doe',
+  role: 'USER',
+  status: 'ACTIVE',
+  timezone: 'America/New_York',
+  currency: 'USD',
+  preferences: {
+    theme: 'light',
+    language: 'en',
+    notifications: {
+      email: true,
+      push: true,
+      categories: true,
+      budgets: true,
+    },
+  },
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+  fullName: 'John Doe',
+  isEmailVerified: true,
+  isActive: true,
+};
+
+describe('SettingsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseAuthStore.mockReturnValue({
+      user: mockUser,
+      setUser: vi.fn(),
+    });
+  });
+
   describe('Header', () => {
     it('renders the page heading', () => {
       render(<SettingsPage />);
@@ -30,54 +90,154 @@ describe.skip('SettingsPage', () => {
     });
   });
 
-  describe('Empty State', () => {
-    it('renders empty state title', () => {
+  describe('Profile Information Form', () => {
+    it('renders Profile Information section heading', () => {
       render(<SettingsPage />);
 
-      // Settings page has "Settings" as the empty state title
-      const headings = screen.getAllByRole('heading', { level: 2 });
-      expect(headings.some(h => h.textContent === 'Settings')).toBe(true);
+      expect(screen.getByText('Profile Information')).toBeInTheDocument();
     });
 
-    it('renders empty state description', () => {
+    it('renders first name input with user value', () => {
       render(<SettingsPage />);
 
-      expect(screen.getByText(/Profile settings, notifications, security/)).toBeInTheDocument();
+      const firstNameInput = screen.getByLabelText('First Name');
+      expect(firstNameInput).toBeInTheDocument();
+      expect(firstNameInput).toHaveValue('John');
     });
 
-    it('renders large icon in empty state', () => {
-      const { container } = render(<SettingsPage />);
+    it('renders last name input with user value', () => {
+      render(<SettingsPage />);
 
-      const emptyStateIcon = container.querySelector('.h-12.w-12.text-gray-300');
-      expect(emptyStateIcon).toBeInTheDocument();
+      const lastNameInput = screen.getByLabelText('Last Name');
+      expect(lastNameInput).toBeInTheDocument();
+      expect(lastNameInput).toHaveValue('Doe');
+    });
+
+    it('renders email input with user value', () => {
+      render(<SettingsPage />);
+
+      const emailInput = screen.getByLabelText(/Email Address/i);
+      expect(emailInput).toBeInTheDocument();
+      expect(emailInput).toHaveValue('john@example.com');
     });
   });
 
-  describe('CTA Button', () => {
-    it('renders Edit Profile button', () => {
+  describe('Regional Settings', () => {
+    it('renders Regional Settings section heading', () => {
       render(<SettingsPage />);
 
-      expect(screen.getByRole('button', { name: /Edit Profile/i })).toBeInTheDocument();
+      expect(screen.getByText('Regional Settings')).toBeInTheDocument();
     });
 
-    it('button is disabled', () => {
+    it('renders timezone select', () => {
       render(<SettingsPage />);
 
-      const button = screen.getByRole('button', { name: /Edit Profile/i });
-      expect(button).toBeDisabled();
+      const timezoneSelect = screen.getByLabelText('Timezone');
+      expect(timezoneSelect).toBeInTheDocument();
     });
 
-    it('button has Coming soon title attribute', () => {
+    it('renders currency select', () => {
       render(<SettingsPage />);
 
-      const button = screen.getByRole('button', { name: /Edit Profile/i });
-      expect(button).toHaveAttribute('title', 'Coming soon');
+      const currencySelect = screen.getByLabelText(/Preferred Currency/i);
+      expect(currencySelect).toBeInTheDocument();
+    });
+  });
+
+  describe('Appearance', () => {
+    it('renders Appearance section heading', () => {
+      render(<SettingsPage />);
+
+      expect(screen.getByText('Appearance')).toBeInTheDocument();
     });
 
-    it('renders Coming soon text below button', () => {
+    it('renders theme options: Light, Dark, System', () => {
       render(<SettingsPage />);
 
-      expect(screen.getByText('Coming soon')).toBeInTheDocument();
+      expect(screen.getByText('Light')).toBeInTheDocument();
+      expect(screen.getByText('Dark')).toBeInTheDocument();
+      expect(screen.getByText('System')).toBeInTheDocument();
+    });
+  });
+
+  describe('Notifications', () => {
+    it('renders Notifications section heading', () => {
+      render(<SettingsPage />);
+
+      expect(screen.getByText('Notifications')).toBeInTheDocument();
+    });
+
+    it('renders notification toggle options', () => {
+      render(<SettingsPage />);
+
+      expect(screen.getByText('Email Notifications')).toBeInTheDocument();
+      expect(screen.getByText('Push Notifications')).toBeInTheDocument();
+      expect(screen.getByText('Budget Alerts')).toBeInTheDocument();
+      expect(screen.getByText('Category Insights')).toBeInTheDocument();
+    });
+  });
+
+  describe('Account Information', () => {
+    it('renders Account Information section', () => {
+      render(<SettingsPage />);
+
+      expect(screen.getByText('Account Information')).toBeInTheDocument();
+    });
+
+    it('displays user account status', () => {
+      render(<SettingsPage />);
+
+      expect(screen.getByText('Account Status')).toBeInTheDocument();
+      expect(screen.getByText('ACTIVE')).toBeInTheDocument();
+    });
+  });
+
+  describe('Save Button', () => {
+    it('renders Save Changes button', () => {
+      render(<SettingsPage />);
+
+      const saveButton = screen.getByRole('button', { name: /Save Changes/i });
+      expect(saveButton).toBeInTheDocument();
+    });
+
+    it('Save Changes button is enabled by default', () => {
+      render(<SettingsPage />);
+
+      const saveButton = screen.getByRole('button', { name: /Save Changes/i });
+      expect(saveButton).not.toBeDisabled();
+    });
+
+    it('Save Changes button is a submit button', () => {
+      render(<SettingsPage />);
+
+      const saveButton = screen.getByRole('button', { name: /Save Changes/i });
+      expect(saveButton).toHaveAttribute('type', 'submit');
+    });
+  });
+
+  describe('Loading State', () => {
+    it('renders loading spinner when user is null', () => {
+      mockUseAuthStore.mockReturnValue({
+        user: null,
+        setUser: vi.fn(),
+      });
+
+      const { container } = render(<SettingsPage />);
+
+      // When user is null, a Loader2 spinner is shown
+      const spinner = container.querySelector('.animate-spin');
+      expect(spinner).toBeInTheDocument();
+    });
+
+    it('does not render form when user is null', () => {
+      mockUseAuthStore.mockReturnValue({
+        user: null,
+        setUser: vi.fn(),
+      });
+
+      render(<SettingsPage />);
+
+      expect(screen.queryByRole('button', { name: /Save Changes/i })).not.toBeInTheDocument();
     });
   });
 });

--- a/apps/web/__tests__/pages/dashboard/settings.test.tsx
+++ b/apps/web/__tests__/pages/dashboard/settings.test.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '../../utils/test-utils';
+import { render, screen } from '../../utils/test-utils';
 import SettingsPage from '../../../app/dashboard/settings/page';
 
 // Mock auth store

--- a/apps/web/__tests__/pages/dashboard/transactions.test.tsx
+++ b/apps/web/__tests__/pages/dashboard/transactions.test.tsx
@@ -174,7 +174,7 @@ describe('TransactionsPage', () => {
           createdAt: '2024-01-16T00:00:00Z',
           updatedAt: '2024-01-16T00:00:00Z',
         },
-      ] as any);
+      ]);
 
       render(<TransactionsPage />);
 
@@ -226,7 +226,7 @@ describe('TransactionsPage', () => {
           createdAt: '2024-01-01T00:00:00Z',
           updatedAt: '2024-01-01T00:00:00Z',
         },
-      ] as any);
+      ]);
 
       render(<TransactionsPage />);
 

--- a/apps/web/__tests__/pages/dashboard/transactions.test.tsx
+++ b/apps/web/__tests__/pages/dashboard/transactions.test.tsx
@@ -1,15 +1,90 @@
 /**
  * Tests for TransactionsPage component
- * Tests empty state placeholder with CTA
+ *
+ * Tests the full transactions page with header, "Add Transaction" button,
+ * transaction list rendering, and account filter.
  */
 
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '../../utils/test-utils';
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '../../utils/test-utils';
 import TransactionsPage from '../../../app/dashboard/transactions/page';
 
+// Mock service clients
+vi.mock('../../../src/services/transactions.client', () => ({
+  transactionsClient: {
+    getTransactions: vi.fn().mockResolvedValue([]),
+    getTransaction: vi.fn(),
+    createTransaction: vi.fn(),
+    updateTransaction: vi.fn(),
+    deleteTransaction: vi.fn(),
+  },
+}));
+
+vi.mock('../../../src/services/accounts.client', () => ({
+  accountsClient: {
+    getAccounts: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+vi.mock('../../../src/services/categories.client', () => ({
+  categoriesClient: {
+    getOptions: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+// Mock banking components that have complex sub-dependencies
+vi.mock('../../../src/components/banking', () => ({
+  ErrorAlert: ({ title, message, onDismiss }: { title: string; message: string; onDismiss: () => void }) => (
+    <div data-testid="error-alert">
+      <span>{title}</span>
+      <span>{message}</span>
+      <button onClick={onDismiss}>Dismiss</button>
+    </div>
+  ),
+  ErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+// Mock transaction components
+vi.mock('../../../src/components/transactions', () => ({
+  QuickAddTransaction: ({ trigger, onSuccess }: {
+    trigger: (props: { onClick: () => void }) => React.ReactNode;
+    onSuccess: () => void;
+  }) => <>{trigger({ onClick: vi.fn() })}</>,
+  EnhancedTransactionList: ({
+    transactions,
+    isLoading,
+  }: {
+    transactions: unknown[];
+    isLoading: boolean;
+    categoryMap: Map<string, string>;
+    accountMap: Map<string, string>;
+    onRefresh: () => void;
+  }) => (
+    <div data-testid="transaction-list">
+      {isLoading ? 'Loading...' : `${transactions.length} transactions`}
+    </div>
+  ),
+}));
+
+import { transactionsClient } from '../../../src/services/transactions.client';
+import { accountsClient } from '../../../src/services/accounts.client';
+import { categoriesClient } from '../../../src/services/categories.client';
+
+const mockTransactionsClient = vi.mocked(transactionsClient);
+const mockAccountsClient = vi.mocked(accountsClient);
+const mockCategoriesClient = vi.mocked(categoriesClient);
+
 describe('TransactionsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTransactionsClient.getTransactions.mockResolvedValue([]);
+    mockAccountsClient.getAccounts.mockResolvedValue([]);
+    mockCategoriesClient.getOptions.mockResolvedValue([]);
+  });
+
   describe('Header', () => {
-    it('renders the page heading', () => {
+    it('renders the page heading', async () => {
       render(<TransactionsPage />);
 
       expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Transactions');
@@ -29,58 +104,166 @@ describe('TransactionsPage', () => {
     });
   });
 
-  describe('Empty State', () => {
-    // TODO(tier0): component mock mismatch
-    it.skip('renders empty state title', () => {
-      render(<TransactionsPage />);
-
-      expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('No transactions yet');
-    });
-
-    // TODO(tier0): component mock mismatch
-    it.skip('renders empty state description', () => {
-      render(<TransactionsPage />);
-
-      expect(screen.getByText(/Once you connect your accounts, your transactions will appear/)).toBeInTheDocument();
-    });
-
-    // TODO(tier0): component mock mismatch
-    it.skip('renders large icon in empty state', () => {
-      const { container } = render(<TransactionsPage />);
-
-      const emptyStateIcon = container.querySelector('.h-12.w-12.text-gray-300');
-      expect(emptyStateIcon).toBeInTheDocument();
-    });
-  });
-
-  describe('CTA Button', () => {
+  describe('Add Transaction Button', () => {
     it('renders Add Transaction button', () => {
       render(<TransactionsPage />);
 
-      expect(screen.getByRole('button', { name: /Add Transaction/i })).toBeInTheDocument();
+      const addButton = screen.getByRole('button', { name: /Add Transaction/i });
+      expect(addButton).toBeInTheDocument();
     });
 
-    // TODO(tier0): component mock mismatch
-    it.skip('button is disabled', () => {
+    it('Add Transaction button is enabled', () => {
       render(<TransactionsPage />);
 
-      const button = screen.getByRole('button', { name: /Add Transaction/i });
-      expect(button).toBeDisabled();
+      const addButton = screen.getByRole('button', { name: /Add Transaction/i });
+      expect(addButton).not.toBeDisabled();
+    });
+  });
+
+  describe('Transaction List', () => {
+    it('renders the transaction list component', async () => {
+      render(<TransactionsPage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('transaction-list')).toBeInTheDocument();
+      });
     });
 
-    // TODO(tier0): component mock mismatch
-    it.skip('button has Coming soon title attribute', () => {
+    it('fetches transactions on mount', async () => {
       render(<TransactionsPage />);
 
-      const button = screen.getByRole('button', { name: /Add Transaction/i });
-      expect(button).toHaveAttribute('title', 'Coming soon');
+      await waitFor(() => {
+        expect(mockTransactionsClient.getTransactions).toHaveBeenCalled();
+      });
     });
 
-    // TODO(tier0): component mock mismatch
-    it.skip('renders Coming soon text below button', () => {
+    it('fetches accounts and categories on mount', async () => {
       render(<TransactionsPage />);
 
-      expect(screen.getByText('Coming soon')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(mockAccountsClient.getAccounts).toHaveBeenCalled();
+        expect(mockCategoriesClient.getOptions).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('Transaction Statistics', () => {
+    it('shows statistics when transactions exist', async () => {
+      mockTransactionsClient.getTransactions.mockResolvedValue([
+        {
+          id: 'tx-1',
+          accountId: 'acc-1',
+          amount: 100,
+          type: 'CREDIT',
+          description: 'Salary',
+          date: '2024-01-15',
+          status: 'POSTED',
+          source: 'MANUAL',
+          createdAt: '2024-01-15T00:00:00Z',
+          updatedAt: '2024-01-15T00:00:00Z',
+        },
+        {
+          id: 'tx-2',
+          accountId: 'acc-1',
+          amount: 50,
+          type: 'DEBIT',
+          description: 'Groceries',
+          date: '2024-01-16',
+          status: 'POSTED',
+          source: 'MANUAL',
+          createdAt: '2024-01-16T00:00:00Z',
+          updatedAt: '2024-01-16T00:00:00Z',
+        },
+      ] as any);
+
+      render(<TransactionsPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Total Transactions')).toBeInTheDocument();
+        expect(screen.getByText('Total Income')).toBeInTheDocument();
+        expect(screen.getByText('Total Expenses')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Empty State', () => {
+    it('shows connect bank prompt when no accounts and no transactions', async () => {
+      render(<TransactionsPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Connect Your Bank')).toBeInTheDocument();
+      });
+    });
+
+    it('has link to accounts page in empty state', async () => {
+      render(<TransactionsPage />);
+
+      await waitFor(() => {
+        const connectLink = screen.getByRole('link', { name: /Connect Accounts/i });
+        expect(connectLink).toHaveAttribute('href', '/dashboard/accounts');
+      });
+    });
+  });
+
+  describe('Account Filter', () => {
+    it('shows account filter when accounts exist', async () => {
+      mockAccountsClient.getAccounts.mockResolvedValue([
+        {
+          id: 'acc-1',
+          name: 'Checking',
+          displayName: 'My Checking',
+          type: 'CHECKING',
+          status: 'ACTIVE',
+          source: 'MANUAL',
+          currentBalance: 1000,
+          currency: 'USD',
+          isActive: true,
+          isManualAccount: true,
+          isPlaidAccount: false,
+          isSyncable: false,
+          needsSync: false,
+          syncEnabled: false,
+          createdAt: '2024-01-01T00:00:00Z',
+          updatedAt: '2024-01-01T00:00:00Z',
+        },
+      ] as any);
+
+      render(<TransactionsPage />);
+
+      await waitFor(() => {
+        const filterSelect = screen.getByLabelText('Filter by account');
+        expect(filterSelect).toBeInTheDocument();
+      });
+    });
+
+    it('does not show account filter when no accounts', async () => {
+      render(<TransactionsPage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('transaction-list')).toBeInTheDocument();
+      });
+
+      expect(screen.queryByLabelText('Filter by account')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('displays error when transaction fetch fails', async () => {
+      mockTransactionsClient.getTransactions.mockRejectedValue(new Error('Network error'));
+
+      render(<TransactionsPage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('error-alert')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Container', () => {
+    it('renders within transactions container', () => {
+      render(<TransactionsPage />);
+
+      expect(screen.getByTestId('transactions-container')).toBeInTheDocument();
     });
   });
 });

--- a/apps/web/vitest.config.mts
+++ b/apps/web/vitest.config.mts
@@ -43,6 +43,7 @@ export default defineConfig({
         // Infrastructure files (better tested via E2E/integration)
         'instrumentation*.ts',
         'app/global-error.tsx',
+        'public/mockServiceWorker.js',
         // API routes (tested via integration tests, not unit tests)
         'app/api/**/*.ts'
       ],

--- a/apps/web/vitest.config.mts
+++ b/apps/web/vitest.config.mts
@@ -43,7 +43,6 @@ export default defineConfig({
         // Infrastructure files (better tested via E2E/integration)
         'instrumentation*.ts',
         'app/global-error.tsx',
-        'public/mockServiceWorker.js',
         // API routes (tested via integration tests, not unit tests)
         'app/api/**/*.ts'
       ],


### PR DESCRIPTION
## Summary

Rewrite web test mocks from JWT/axios to cookie/fetch pattern. The auth system migrated but tests still mocked the old API, causing 99 skipped tests.

## Changes

- **auth.test.ts**: 28 skips removed — mock `global.fetch` instead of axios, `AuthResponse { user, csrfToken }` instead of `{ accessToken, refreshToken, user, expiresIn }`
- **protected-route.test.tsx**: fix mock to `{ isAuthenticated, user, validateSession }`, remove `withAuth` HOC tests (doesn't exist)
- **dashboard-layout.test.tsx**: remove `describe.skip`, fix `router.replace` assertion (not `push`)
- **settings.test.tsx**: rewrite for current form-based page (was placeholder)
- **transactions.test.tsx**: rewrite for current transaction list page (was placeholder)
- **accounts.test.tsx**: increase `waitFor` timeouts 3s→5s (flaky fix)
- **vitest.config.mts**: remove phantom test exclusions

## Test plan

- [ ] CI passes — web test skip count reduced from 99 to ~2
- [ ] No new test failures introduced
- [ ] Backend tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)