### PR TITLE
chore: bump version to 0.7.0 — Candidate 7+10 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,70 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_Next: Candidate 6 (Auth Hardening), cleanup pass, develop→main sync._
+
+---
+
+## [0.7.0] - 2026-04-13
+
+### Clinical Audit Response — Candidate 7 + 10
+
+This release completes the two prerequisite workstreams identified by the
+[2026-04-12 Clinical Health Audit](docs/audits/2026-04-12-health-audit.md)
+as non-negotiable before any feature work.
+
+### Added
+
+- **R1 — Test skip counter** (`scripts/testing/count-test-skips.sh`)
+  - CI step reports skip inventory on every pipeline run
+  - `pnpm test:report-skips` for local use
+- **R2 — Marker convention lint** (`scripts/lint-markers.sh` enhanced)
+  - Detects stale TODO/FIXME markers older than 90 days
+  - CI step in development pipeline
+- **R3 — Architecture ownership table** (`docs/ARCHITECTURE_OWNERSHIP.md`)
+  - Maps 9 cross-cutting concerns to canonical owner paths
+- **Dependabot grouping** — consolidated from 9 per-directory entries to 1 root
+  workspace entry with 15 semantic groups (nestjs, testing, linting, prisma, etc.)
+
+### Changed
+
+- **Web test credibility 28 → 60+** (Candidate 7)
+  - Rewrote 7 test files from JWT/axios mocks to cookie/fetch pattern
+  - Removed 97 stale `describe.skip` / `it.skip` markers
+  - Fixed `accounts.test.tsx` flaky timeouts (3s → 5s)
+  - All code review feedback (Claude + Copilot) addressed
+- **GitHub Actions v5** — checkout, setup-node, codecov upgraded across 5 workflows
+- **pnpm/action-setup v4** — reads `packageManager` from package.json (no explicit version)
+- **Playwright E2E cache** — split install into cache-miss (full) vs cache-hit (deps only)
+- **Docker BuildKit** — pre-build E2E images with GHA cache
+- **Pre-commit hook** — skip web tests on Node 24+ (jsdom incompatible)
+- **Telemetry opt-out** — `NEXT_TELEMETRY_DISABLED` in CI env
+
+### Fixed
+
+- **T8 tautology** (`auth.spec.ts`) — replaced `expect(a || b).toBe(true)` with
+  proper `toHaveURL(/\/auth\/login/)` assertion
+- **Auth guard E2E** — 2 `test.fixme` enabled with Playwright `toHaveURL`
+- **Bundle size job** — pnpm must install before setup-node (ordering fix)
+- **Dependabot CI failures** — 30 stale PRs closed, config fixed for pnpm monorepo
+- **Dashboard layout tests** — `router.replace` not `push`, correct button selectors
+
+### Security
+
+- **Dependabot overrides**: axios ≥1.15.0 (CRITICAL), vite ≥6.4.2, defu ≥6.1.5,
+  @xmldom/xmldom ≥0.8.12, picomatch ≥4.0.4 (all HIGH)
+- Critical Dependabot alerts: 2 → 0
+
+### Removed
+
+- Deploy preview placeholder job (commented out — was no-op with fake URL)
+- Phantom `mockServiceWorker.js` coverage exclusion
+- Unused `PNPM_VERSION` env vars from CI workflows
+
+---
+
+## [0.6.2] - 2025-12-05
+
 ### Added
 
 - **Phase 1: Categories Enhanced Module** - Complete category management system
@@ -287,7 +351,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Navigation link validation
   - Empty state and loading state tests
 
-## [Unreleased]
+## [0.5.2] - 2025-12-03 (pre-release, infrastructure)
 
 ### Added
 
@@ -677,35 +741,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## Version History Summary
-
-| Version | Date | Type | Description |
-|---------|------|------|-------------|
-| 0.1.0 | 2025-01-26 | Initial | Complete project infrastructure & MVP foundation |
-
-## Upcoming Releases
-
-### [0.2.0] - Planned (Q1 2025)
-
-- User authentication system
-- Core transaction management
-- Basic budgeting functionality
-- Database schema implementation
-
-### [0.3.0] - Planned (Q1 2025)
-
-- Account management system
-- Transaction categorization
-- Financial goal tracking
-- Enhanced UI components
-
-### [1.0.0] - Planned (Q2 2025)
-
-- Banking integration (Plaid)
-- Advanced financial analytics
-- Mobile application release
-- Production deployment pipeline
-
 ## Semantic Versioning Guidelines
 
 This project follows [Semantic Versioning](https://semver.org/) (SemVer):
@@ -757,4 +792,4 @@ This project follows [Semantic Versioning](https://semver.org/) (SemVer):
 
 **Changelog Automation**: This file is maintained through the documentation-specialist agent pattern, ensuring consistency and accuracy across all releases.
 
-**Last Updated**: 2025-01-26
+**Last Updated**: 2026-04-13

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Personal finance management application with cross-platform support
 
 [![CI/CD Pipeline](https://github.com/kdantuono/money-wise/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/kdantuono/money-wise/actions/workflows/ci-cd.yml)
-[![Version](https://img.shields.io/badge/version-0.6.2-blue.svg)](https://github.com/kdantuono/money-wise)
+[![Version](https://img.shields.io/badge/version-0.7.0-blue.svg)](https://github.com/kdantuono/money-wise)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node Version](https://img.shields.io/badge/node-%3E%3D22.0.0-brightgreen.svg)](https://nodejs.org/)
 [![Package Manager](https://img.shields.io/badge/package%20manager-pnpm%20%3E%3D10.0.0-orange.svg)](https://pnpm.io/)
@@ -12,10 +12,11 @@ Personal finance management application with cross-platform support
 
 MoneyWise is a comprehensive personal finance management application built with modern technologies and cross-platform compatibility. The application helps users track expenses, manage budgets, and gain insights into their financial health.
 
-### **Current Status: MVP Development (v0.6.2)**
+### **Current Status: MVP Development (v0.7.0)**
 - ✅ Project infrastructure and monorepo setup complete
-- ✅ Documentation and planning organization complete
-- 🚧 Core financial features in development
+- ✅ Clinical health audit completed ([report](./docs/audits/2026-04-12-health-audit.md))
+- ✅ Test credibility restored (Candidate 7+10)
+- 🚧 Auth hardening + Family multi-tenancy next
 - 📋 [View Development Progress](./docs/development/progress.md)
 
 ## 🚀 Quick Start (5 Minutes)

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@money-wise/backend",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "MoneyWise NestJS Backend API",
   "private": true,
   "//": "BUILD PROCESS: 'pnpm build' runs: (1) prisma generate → (2) nest build. Prisma Client MUST be generated before TypeScript compilation to avoid import errors. CI/CD workflows depend on this sequence. Pre-commit hooks verify generated/ exists.",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@money-wise/mobile",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "MoneyWise React Native Mobile Application",
   "private": true,
   "main": "expo-router/entry",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@money-wise/web",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "MoneyWise Next.js Web Application",
   "private": true,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "money-wise",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "Personal finance management application with cross-platform support",
   "private": true,
   "workspaces": [

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@money-wise/test-utils",
-  "version": "0.7.0",
+  "version": "0.6.1",
   "description": "Shared test utilities and fixtures for MoneyWise",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@money-wise/test-utils",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Shared test utilities and fixtures for MoneyWise",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@money-wise/types",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Shared TypeScript type definitions for MoneyWise",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@money-wise/ui",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Shared UI components for MoneyWise",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@money-wise/utils",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Shared utility functions for MoneyWise",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- Bump all workspace packages from 0.6.x to **0.7.0**
- CHANGELOG: add 0.7.0 section documenting Candidate 7+10, CI fixes, security overrides
- CHANGELOG: fix duplicate [Unreleased] section, remove obsolete Upcoming Releases (2025 dates)
- README: update version badge and status to reflect audit completion

## Test plan

- [ ] CI passes (no code changes, only version/docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)