### PR TITLE
chore: Sprint 0 consolidation — Obsidian vault docs + Trivy fix

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -403,21 +403,33 @@ jobs:
 
       - name: 🐳 Trivy Filesystem Scan
         if: steps.should-run.outputs.run == 'true'
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
-          format: 'sarif'
-          output: 'trivy-results.sarif'
+          format: 'table'
+          output: 'trivy-results.txt'
           severity: 'CRITICAL,HIGH'
+          exit-code: '0'
 
-      - name: 📤 Upload Trivy Results to GitHub Security
+      - name: 📤 Upload Trivy Report as Artifact
         if: steps.should-run.outputs.run == 'true' && always()
-        continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v3
+        uses: actions/upload-artifact@v4
         with:
-          sarif_file: 'trivy-results.sarif'
-          category: 'trivy-fs'
+          name: trivy-scan-${{ github.run_id }}
+          path: trivy-results.txt
+          retention-days: 30
+
+      - name: 📋 Display Trivy Summary
+        if: steps.should-run.outputs.run == 'true' && always()
+        run: |
+          if [ -f trivy-results.txt ]; then
+            echo "### 🐳 Trivy Filesystem Scan Results" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            head -50 trivy-results.txt >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "Full report available as artifact: trivy-scan-${{ github.run_id }}" >> $GITHUB_STEP_SUMMARY
+          fi
 
       - name: 🐳 Trivy Container Image Scan (if Dockerfiles exist)
         if: steps.should-run.outputs.run == 'true' && needs.foundation.outputs.has_docker == 'true'

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -413,7 +413,7 @@ jobs:
           exit-code: '0'
 
       - name: 📤 Upload Trivy Report as Artifact
-        if: steps.should-run.outputs.run == 'true' && always()
+        if: steps.should-run.outputs.run == 'true' && always() && hashFiles('trivy-results.txt') != ''
         uses: actions/upload-artifact@v4
         with:
           name: trivy-scan-${{ github.run_id }}
@@ -421,15 +421,13 @@ jobs:
           retention-days: 30
 
       - name: 📋 Display Trivy Summary
-        if: steps.should-run.outputs.run == 'true' && always()
+        if: steps.should-run.outputs.run == 'true' && always() && hashFiles('trivy-results.txt') != ''
         run: |
-          if [ -f trivy-results.txt ]; then
-            echo "### 🐳 Trivy Filesystem Scan Results" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            head -50 trivy-results.txt >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            echo "Full report available as artifact: trivy-scan-${{ github.run_id }}" >> $GITHUB_STEP_SUMMARY
-          fi
+          echo "### 🐳 Trivy Filesystem Scan Results" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          head -50 trivy-results.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "Full report available as artifact: trivy-scan-${{ github.run_id }}" >> $GITHUB_STEP_SUMMARY
 
       - name: 🐳 Trivy Container Image Scan (if Dockerfiles exist)
         if: steps.should-run.outputs.run == 'true' && needs.foundation.outputs.has_docker == 'true'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,7 +163,7 @@ Files allowed in root: README.md, CHANGELOG.md, CONTRIBUTING.md, FRONTEND_HANDOF
 Shared knowledge lives at `~/vault/moneywise/` — plain Markdown, Obsidian-compatible, outside the repo for privacy. It is the **single source of truth** for long-lived knowledge (memories, planning, postmortems, ADR, research).
 
 **Two access paths, same files**:
-- `~/.claude/projects/-home-deck-dev-money-wise/memory/` is now a **symlink** to `~/vault/moneywise/memory/`. Claude's auto-memory system writes there transparently.
+- `~/.claude/projects/<project-id>/memory/` is a **symlink** to `~/vault/moneywise/memory/`. Claude's auto-memory system writes there transparently. `<project-id>` is machine-specific (derived by Claude Code from the absolute repo path, e.g. `-home-deck-dev-money-wise` when the repo lives at `/home/deck/dev/money-wise`). To discover the correct directory on a fresh machine: `ls ~/.claude/projects/ | grep money-wise`.
 - `~/vault/moneywise/` exposes the full vault (planning, postmortems, decisions, research, references).
 
 **Entry points**: `README.md` (conventions) + `index.md` (navigation) + `memory/MEMORY.md` (auto-memory index).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,3 +157,22 @@ Files allowed in root: README.md, CHANGELOG.md, CONTRIBUTING.md, FRONTEND_HANDOF
 - Architecture decisions: `.claude/knowledge/architecture.md`
 - MVP planning: `docs/planning/README.md`
 - Development setup: `docs/development/setup.md`
+
+## Knowledge Vault (Obsidian)
+
+Shared knowledge lives at `~/vault/moneywise/` — plain Markdown, Obsidian-compatible, outside the repo for privacy. It is the **single source of truth** for long-lived knowledge (memories, planning, postmortems, ADR, research).
+
+**Two access paths, same files**:
+- `~/.claude/projects/-home-deck-dev-money-wise/memory/` is now a **symlink** to `~/vault/moneywise/memory/`. Claude's auto-memory system writes there transparently.
+- `~/vault/moneywise/` exposes the full vault (planning, postmortems, decisions, research, references).
+
+**Entry points**: `README.md` (conventions) + `index.md` (navigation) + `memory/MEMORY.md` (auto-memory index).
+
+**MCP integration**: `obsidian-mcp-server` is configured in `~/.claude.json`. When Obsidian is running with Local REST API plugin active, Claude can use `mcp__obsidian__*` tools for semantic search, tag queries, and frontmatter-aware ops. **Fallback**: filesystem Read/Write works always, even with Obsidian closed.
+
+**When to write where**:
+- New memory (feedback/project/reference/user) → `memory/` via auto-memory system
+- ADR (architectural decision) → `decisions/<name>.md` in vault
+- Incident/postmortem → `postmortems/<name>.md` in vault
+- Research note → `research/<name>.md` in vault
+- Active plan → `planning/<name>.md` in vault


### PR DESCRIPTION
## Summary

First batch of Sprint 0 consolidation work (see `~/vault/moneywise/planning/ultraplan-beta-privata.md`). Two independent improvements in a single PR because both are infrastructure/docs with minimal risk:

### 1. CLAUDE.md — Knowledge Vault architecture (Sprint 0.1 completion)
Documents the Obsidian-based vault now established at `~/vault/moneywise/`:
- Two-layer design: filesystem-first (always works) + optional MCP layer (when Obsidian running)
- Symlink strategy for `~/.claude/projects/.../memory/` → vault
- Writing conventions per content type

Full architectural decision captured in ADR-001 in the vault itself.

### 2. Trivy fix (Sprint 0.2)
Fixes two silent issues in `ci-cd.yml`:
- **Pin action to v0.35.0** instead of `@master` (security anti-pattern — action code can change under the workflow)
- **Replace SARIF upload with artifact upload**: repo is private without GitHub Advanced Security, so Code Scanning was disabled and `upload-sarif` was failing silently (masked by `continue-on-error: true`). New strategy: upload as 30-day artifact + write first 50 lines to Actions step summary for immediate visibility.

## Test plan
- [x] Local YAML validation (`python3 -c 'import yaml; yaml.safe_load(...)'`)
- [x] Pre-commit hooks green (lint + typecheck + doc governance)
- [ ] CI pipeline green on this PR
- [ ] Trivy scan artifact visible on Actions run summary

## Context
Part of the post-PR-#426 consolidation. Two more Sprint 0 tasks will follow in separate PRs:
- 0.3: CI consolidation (test redundancy, E2E skip on doc-only, ESLint security re-enable)
- 0.4: Banking deep-dive documentation (SaltEdge call prep + P.IVA options)

🤖 Generated with [Claude Code](https://claude.com/claude-code)