### PR TITLE
ci: Sprint 0.3 — path-based change detection for faster CI feedback

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,6 +45,12 @@ module.exports = {
     // TODO: Track re-enablement in GitHub Issue #230 (create if not exists)
     // Priority: HIGH - Security rules should be re-enabled ASAP
     // Timeline: After ESLint 9 compatibility is verified
+    //
+    // NOTE: This root config applies only to scripts/* and untargeted files.
+    // apps/web has its own .eslintrc.json with "root": true and does NOT
+    // inherit these plugins. To re-enable security linting for apps/web,
+    // install eslint-plugin-security + eslint-plugin-no-secrets as devDeps
+    // of apps/web and extend "plugin:security/recommended" there.
     'security/detect-object-injection': 'off',
     'security/detect-non-literal-regexp': 'off',
     'security/detect-unsafe-regex': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -46,11 +46,14 @@ module.exports = {
     // Priority: HIGH - Security rules should be re-enabled ASAP
     // Timeline: After ESLint 9 compatibility is verified
     //
-    // NOTE: This root config applies only to scripts/* and untargeted files.
-    // apps/web has its own .eslintrc.json with "root": true and does NOT
-    // inherit these plugins. To re-enable security linting for apps/web,
-    // install eslint-plugin-security + eslint-plugin-no-secrets as devDeps
-    // of apps/web and extend "plugin:security/recommended" there.
+    // NOTE: This root config applies to any directory without its own
+    // `.eslintrc` declaring `root: true`. That covers packages/types,
+    // packages/utils, scripts/, and the repo root. It is NOT inherited by
+    // apps/web, apps/mobile, or packages/ui (each has its own `root: true`
+    // config). To re-enable security linting for those workspaces, install
+    // eslint-plugin-security + eslint-plugin-no-secrets as devDeps of the
+    // respective package and extend "plugin:security/recommended" there.
+    // See vault: memory/backlog_eslint_security_web.md
     'security/detect-object-injection': 'off',
     'security/detect-non-literal-regexp': 'off',
     'security/detect-unsafe-regex': 'off',

--- a/.github/BRANCH_PROTECTION.md
+++ b/.github/BRANCH_PROTECTION.md
@@ -64,9 +64,12 @@ Before any branch can be merged, ALL of the following must PASS:
   - Additional validation rules
   - Custom health checks
 
-- ✅ **codeql** - Security scanning
-  - CodeQL analysis for vulnerabilities
-  - SARIF report generation
+- ⏸️ ~~**codeql** - Security scanning~~ — REMOVED 2026-04-16
+  - CodeQL requires GitHub Advanced Security on private repos (~$49/user/month)
+  - Repo went private, so CodeQL is unavailable on the free tier
+  - SAST coverage now provided by Semgrep (3-tier progressive in `ci-cd.yml`)
+  - The `code_scanning` rule was removed from the develop ruleset
+  - Re-evaluate if/when repo returns to public or GHAS is adopted
 
 - ✅ **release** - Release workflow (main branch only)
   - Automated release generation

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -677,8 +677,19 @@ jobs:
   testing:
     name: 🧪 Testing Pipeline
     runs-on: ubuntu-latest
-    needs: [foundation, development]
-    if: needs.foundation.outputs.has_tests == 'true' || github.event.inputs.force_full_pipeline == 'true'
+    needs: [foundation, development, changes]
+    # Fail-open: runs if changes detection failed/skipped, or if relevant paths
+    # changed, or on protected branches, or if force flag set.
+    if: |
+      always() && needs.foundation.result == 'success' && (
+        needs.changes.result != 'success' ||
+        needs.changes.outputs.web == 'true' ||
+        needs.changes.outputs.tests == 'true' ||
+        needs.changes.outputs.root_config == 'true' ||
+        github.ref == 'refs/heads/main' ||
+        github.ref == 'refs/heads/develop' ||
+        github.event.inputs.force_full_pipeline == 'true'
+      )
     timeout-minutes: 35
 
     permissions:
@@ -803,8 +814,19 @@ jobs:
   build:
     name: 🏗️ Build Pipeline
     runs-on: ubuntu-latest
-    needs: [foundation, development]
-    if: needs.foundation.outputs.has_apps == 'true' || github.event.inputs.force_full_pipeline == 'true'
+    needs: [foundation, development, changes]
+    # Fail-open: runs if changes detection failed/skipped, or if app code
+    # or shared packages or root config changed, or on protected branches.
+    if: |
+      always() && needs.foundation.result == 'success' && (
+        needs.changes.result != 'success' ||
+        needs.changes.outputs.web == 'true' ||
+        needs.changes.outputs.mobile == 'true' ||
+        needs.changes.outputs.root_config == 'true' ||
+        github.ref == 'refs/heads/main' ||
+        github.ref == 'refs/heads/develop' ||
+        github.event.inputs.force_full_pipeline == 'true'
+      )
     timeout-minutes: 20
 
     strategy:
@@ -869,14 +891,29 @@ jobs:
     name: 🧪 E2E Tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: [foundation, development, testing]
-    # Run E2E tests on:
-    # - Push to main/develop/hotfix branches
-    # - Pull requests from hotfix branches (to ensure E2E before merge to main)
-    # - PR ready_for_review event
+    needs: [foundation, development, testing, changes]
+    # Run E2E tests only when trigger conditions met AND relevant code changed.
+    # Triggers:
+    #   - Push to main/develop/hotfix branches
+    #   - PR ready_for_review event
+    #   - PR from hotfix branch
+    # Paths (fail-open — always runs if changes detection failed):
+    #   - apps/web, packages/ui/types/utils (web output)
+    #   - supabase/migrations, supabase/config.toml (db output)
+    #   - supabase/functions (functions output)
+    #   - root config files
     if: |
-      (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/hotfix/'))) ||
-      (github.event_name == 'pull_request' && (github.event.action == 'ready_for_review' || startsWith(github.head_ref, 'hotfix/')))
+      always() && (
+        (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/hotfix/'))) ||
+        (github.event_name == 'pull_request' && (github.event.action == 'ready_for_review' || startsWith(github.head_ref, 'hotfix/')))
+      ) && (
+        needs.changes.result != 'success' ||
+        needs.changes.outputs.web == 'true' ||
+        needs.changes.outputs.db == 'true' ||
+        needs.changes.outputs.functions == 'true' ||
+        needs.changes.outputs.root_config == 'true' ||
+        github.event.inputs.force_full_pipeline == 'true'
+      )
 
     steps:
       - name: 📥 Checkout Repository
@@ -942,8 +979,15 @@ jobs:
     name: 📦 Bundle Size Check
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [foundation, development]
-    if: github.event_name == 'pull_request'
+    needs: [foundation, development, changes]
+    # PR-only, and only when web app or shared packages / root config changed.
+    if: |
+      always() && github.event_name == 'pull_request' && (
+        needs.changes.result != 'success' ||
+        needs.changes.outputs.web == 'true' ||
+        needs.changes.outputs.root_config == 'true' ||
+        github.event.inputs.force_full_pipeline == 'true'
+      )
 
     permissions:
       contents: read

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -78,6 +78,9 @@ jobs:
     name: 🔍 Detect Changes
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read  # required by dorny/paths-filter for PR events
     outputs:
       web: ${{ steps.filter.outputs.web }}
       mobile: ${{ steps.filter.outputs.mobile }}
@@ -120,18 +123,25 @@ jobs:
             workflows:
               - '.github/workflows/**'
             docs:
-              - '**.md'
+              - '**/*.md'
               - 'docs/**'
               - '.github/ISSUE_TEMPLATE/**'
               - '.github/PULL_REQUEST_TEMPLATE.md'
             root_config:
               - 'package.json'
               - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
               - 'turbo.json'
               - 'tsconfig*.json'
               - '.eslintrc*'
               - '.prettierrc*'
+              - '.npmrc'
+              - '.nvmrc'
               - 'vitest.config.*'
+              - 'jest.config.*'
+              - 'playwright.config.*'
+              - 'docker-compose*.yml'
+              - 'docker-compose*.yaml'
 
       - name: 🧮 Calculate docs_only flag
         id: calculate
@@ -678,10 +688,13 @@ jobs:
     name: 🧪 Testing Pipeline
     runs-on: ubuntu-latest
     needs: [foundation, development, changes]
-    # Fail-open: runs if changes detection failed/skipped, or if relevant paths
-    # changed, or on protected branches, or if force flag set.
+    # Gate on prerequisite jobs actually succeeding (foundation + development),
+    # then fail-open for `changes` (if detection fails or relevant paths changed,
+    # protected branch, or force flag → run).
     if: |
-      always() && needs.foundation.result == 'success' && (
+      always() &&
+      needs.foundation.result == 'success' &&
+      needs.development.result == 'success' && (
         needs.changes.result != 'success' ||
         needs.changes.outputs.web == 'true' ||
         needs.changes.outputs.tests == 'true' ||
@@ -815,10 +828,11 @@ jobs:
     name: 🏗️ Build Pipeline
     runs-on: ubuntu-latest
     needs: [foundation, development, changes]
-    # Fail-open: runs if changes detection failed/skipped, or if app code
-    # or shared packages or root config changed, or on protected branches.
+    # Gate on prerequisites succeeding, then fail-open for `changes`.
     if: |
-      always() && needs.foundation.result == 'success' && (
+      always() &&
+      needs.foundation.result == 'success' &&
+      needs.development.result == 'success' && (
         needs.changes.result != 'success' ||
         needs.changes.outputs.web == 'true' ||
         needs.changes.outputs.mobile == 'true' ||
@@ -892,18 +906,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: [foundation, development, testing, changes]
-    # Run E2E tests only when trigger conditions met AND relevant code changed.
-    # Triggers:
-    #   - Push to main/develop/hotfix branches
-    #   - PR ready_for_review event
-    #   - PR from hotfix branch
-    # Paths (fail-open — always runs if changes detection failed):
-    #   - apps/web, packages/ui/types/utils (web output)
-    #   - supabase/migrations, supabase/config.toml (db output)
-    #   - supabase/functions (functions output)
-    #   - root config files
+    # Gate on prerequisites succeeding (foundation, development, testing) AND
+    # trigger conditions met AND relevant code changed. Fail-open for `changes`.
     if: |
-      always() && (
+      always() &&
+      needs.foundation.result == 'success' &&
+      needs.development.result == 'success' &&
+      needs.testing.result == 'success' && (
         (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/hotfix/'))) ||
         (github.event_name == 'pull_request' && (github.event.action == 'ready_for_review' || startsWith(github.head_ref, 'hotfix/')))
       ) && (
@@ -980,9 +989,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [foundation, development, changes]
-    # PR-only, and only when web app or shared packages / root config changed.
+    # PR-only. Gate on prerequisites, then fail-open for `changes`.
     if: |
-      always() && github.event_name == 'pull_request' && (
+      always() &&
+      needs.foundation.result == 'success' &&
+      needs.development.result == 'success' &&
+      github.event_name == 'pull_request' && (
         needs.changes.result != 'success' ||
         needs.changes.outputs.web == 'true' ||
         needs.changes.outputs.root_config == 'true' ||

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -68,6 +68,98 @@ jobs:
       # The steps below are kept as reference but removed from execution
 
   # ===================================================================
+  # 🔍 CHANGES: Path-based change detection
+  # Determines which parts of the repo changed. Downstream jobs use
+  # these outputs to skip expensive work (tests, E2E, build) when
+  # irrelevant (e.g., docs-only PRs skip heavy pipelines entirely).
+  # ===================================================================
+
+  changes:
+    name: 🔍 Detect Changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      web: ${{ steps.filter.outputs.web }}
+      mobile: ${{ steps.filter.outputs.mobile }}
+      functions: ${{ steps.filter.outputs.functions }}
+      db: ${{ steps.filter.outputs.db }}
+      tests: ${{ steps.filter.outputs.tests }}
+      workflows: ${{ steps.filter.outputs.workflows }}
+      docs: ${{ steps.filter.outputs.docs }}
+      root_config: ${{ steps.filter.outputs.root_config }}
+      docs_only: ${{ steps.calculate.outputs.docs_only }}
+    steps:
+      - name: 📥 Checkout Repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: 🔍 Filter changed paths
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            web:
+              - 'apps/web/**'
+              - 'packages/ui/**'
+              - 'packages/types/**'
+              - 'packages/utils/**'
+            mobile:
+              - 'apps/mobile/**'
+              - 'packages/types/**'
+            functions:
+              - 'supabase/functions/**'
+            db:
+              - 'supabase/migrations/**'
+              - 'supabase/config.toml'
+            tests:
+              - 'apps/web/__tests__/**'
+              - 'apps/web/**/*.test.ts'
+              - 'apps/web/**/*.test.tsx'
+              - 'apps/web/e2e/**'
+            workflows:
+              - '.github/workflows/**'
+            docs:
+              - '**.md'
+              - 'docs/**'
+              - '.github/ISSUE_TEMPLATE/**'
+              - '.github/PULL_REQUEST_TEMPLATE.md'
+            root_config:
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'turbo.json'
+              - 'tsconfig*.json'
+              - '.eslintrc*'
+              - '.prettierrc*'
+              - 'vitest.config.*'
+
+      - name: 🧮 Calculate docs_only flag
+        id: calculate
+        run: |
+          DOCS_ONLY="false"
+          if [[ "${{ steps.filter.outputs.docs }}" == "true" && \
+                "${{ steps.filter.outputs.web }}" == "false" && \
+                "${{ steps.filter.outputs.mobile }}" == "false" && \
+                "${{ steps.filter.outputs.functions }}" == "false" && \
+                "${{ steps.filter.outputs.db }}" == "false" && \
+                "${{ steps.filter.outputs.tests }}" == "false" && \
+                "${{ steps.filter.outputs.workflows }}" == "false" && \
+                "${{ steps.filter.outputs.root_config }}" == "false" ]]; then
+            DOCS_ONLY="true"
+          fi
+          echo "docs_only=$DOCS_ONLY" >> $GITHUB_OUTPUT
+          echo "📊 Change detection summary:"
+          echo "  web:          ${{ steps.filter.outputs.web }}"
+          echo "  mobile:       ${{ steps.filter.outputs.mobile }}"
+          echo "  functions:    ${{ steps.filter.outputs.functions }}"
+          echo "  db:           ${{ steps.filter.outputs.db }}"
+          echo "  tests:        ${{ steps.filter.outputs.tests }}"
+          echo "  workflows:    ${{ steps.filter.outputs.workflows }}"
+          echo "  docs:         ${{ steps.filter.outputs.docs }}"
+          echo "  root_config:  ${{ steps.filter.outputs.root_config }}"
+          echo "  docs_only:    $DOCS_ONLY"
+
+  # ===================================================================
   # 📦 DEVELOPMENT: Code quality checks
   # ===================================================================
 


### PR DESCRIPTION
## Summary

Sprint 0.3 of the beta consolidation work. Introduces **path-based change detection** to skip expensive CI jobs when the changed files are irrelevant to them. This directly addresses the pain point observed during PR #426/#427: every small iteration (doc fix, review comment response) triggered the full ~45 min pipeline.

### Changes

| Commit | What |
|--------|------|
| `dff8d1f` | Add `changes` job using `dorny/paths-filter@v3` — classifies changed files into categories (web, mobile, functions, db, tests, workflows, docs, root_config) + computes a `docs_only` flag |
| `df56955` | Wire path-based conditionals into 4 heavy jobs (fail-open): `testing`, `build`, `e2e-tests`, `bundle-size` |
| `6ac8f7d` | Remove obsolete CodeQL references from `BRANCH_PROTECTION.md` + add inline NOTE in `.eslintrc.js` explaining the apps/web isolation |

### Expected savings

| Change type | Jobs that run | Jobs skipped | Est. time (before → after) |
|-------------|---------------|--------------|-----------------------------|
| Docs-only PR (e.g., `CLAUDE.md` fix) | foundation, development, security-lightweight | testing, build, e2e, bundle-size | ~45 min → ~5 min |
| Workflow-only (e.g., `ci-cd.yml` tweak) | foundation, development, security | testing, bundle-size | ~45 min → ~15 min |
| Web-only (`apps/web/*`) | all web-relevant | mobile build | ~45 min → ~35 min |
| DB migration only | foundation, security, testing, e2e | build, bundle-size | ~45 min → ~30 min |
| Full stack change | all | none | unchanged (~45 min) |

### Fail-open safety

Every conditional starts with `needs.changes.result != 'success'` — meaning **if the change-detection job fails or gets skipped, the downstream job runs anyway**. A broken detection cannot silently hide critical CI work.

### Deferred to follow-up

- **ESLint security plugins for `apps/web`**: documented in vault (`memory/backlog_eslint_security_web.md`). Root `.eslintrc.js` still has rules configured but `apps/web/.eslintrc.json` has `"root": true` and doesn't inherit. Requires adding devDeps to apps/web — scoped as dedicated task to keep this PR focused.
- **Test redundancy audit**: the original Sprint 0.3 plan mentioned dedup testing; deferred because it needs deeper analysis of which jobs run the same tests.

## Test plan

- [x] YAML syntax valid (`python3 -c 'yaml.safe_load'`)
- [x] Pre-commit hooks green on all 3 commits (lint + typecheck + build)
- [ ] CI pipeline runs on this PR (will test the changes live)
- [ ] Verify the `changes` job output matches expectations for this PR (should detect: `workflows=true`, `docs=true`, others=false → many jobs should skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)