### PR TITLE
fix(e2e): build app before starting production server in CI

### DIFF
--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -93,10 +93,10 @@ export default defineConfig({
   webServer: process.env.SKIP_WEBSERVER
     ? undefined
     : {
-        command: process.env.CI ? 'pnpm start' : 'pnpm dev',
+        command: process.env.CI ? 'pnpm -w build:web && pnpm start' : 'pnpm dev',
         url: 'http://localhost:3000',
         reuseExistingServer: !process.env.CI,
-        timeout: 120 * 1000,
+        timeout: process.env.CI ? 300 * 1000 : 120 * 1000,
       },
 
   /* Global test setup and teardown */

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -87,9 +87,14 @@ export default defineConfig({
     // },
   ],
 
-  /* Run your local dev server before starting the tests */
-  /* Post-Supabase migration: only the web dev server is needed.
-     The frontend connects directly to Supabase (no backend service). */
+  /* Run the web server before the test suite.
+     - Local: `pnpm dev` (Next.js dev mode, HMR, fast startup ~10s)
+     - CI:    `pnpm -w build:web && pnpm start` (production build + `next start`).
+              Uses workspace-root `build:web` script so turbo handles the
+              @money-wise/ui dependency graph. CI timeout bumped to 5 min to
+              accommodate the build step.
+     Post-Supabase migration: only the web server is needed — the frontend
+     connects directly to Supabase (no separate backend service). */
   webServer: process.env.SKIP_WEBSERVER
     ? undefined
     : {


### PR DESCRIPTION
## Summary

Fixes #429 — the E2E Tests job on develop has been failing since PR #427 merge with:

\`\`\`
[WebServer] Error: Could not find a production build in the '.next' directory.
Error: Process from config.webServer was not able to start. Exit code: 1
\`\`\`

**Root cause**: `apps/web/playwright.config.ts` configures `webServer.command` as `process.env.CI ? 'pnpm start' : 'pnpm dev'`. `pnpm start` needs a prior `pnpm build:web`, but the e2e-tests job in `ci-cd.yml` never ran it.

## Fix

Change the Playwright webServer command to chain the build before starting the server, and bump the CI timeout from 2 min → 5 min to accommodate build time.

\`\`\`diff
- command: process.env.CI ? 'pnpm start' : 'pnpm dev',
+ command: process.env.CI ? 'pnpm -w build:web && pnpm start' : 'pnpm dev',
  url: 'http://localhost:3000',
  reuseExistingServer: !process.env.CI,
- timeout: 120 * 1000,
+ timeout: process.env.CI ? 300 * 1000 : 120 * 1000,
\`\`\`

Uses `pnpm -w` (workspace root) to invoke `build:web`, which maps to `scripts/build-clean.sh --filter=@money-wise/web` and goes through turbo → respects the `packages/ui` dep graph.

## Credit

Investigation and fix authored by Claude via GitHub Actions (issue #429 tagged with `@claude`). Cherry-picked from `claude/issue-429-20260416-1110` onto a branch from develop (original branch was based on main, which lacks the recent merges).

## Test plan

- [x] Pre-commit hooks green (lint + typecheck + build)
- [ ] CI pipeline green on this PR — especially the e2e-tests job completing the webServer startup
- [ ] No regression on local dev (`pnpm dev` still works unchanged)

## Note on interaction with PR #428

PR #428 (path filters) is also open. The two PRs touch different files (#428: `ci-cd.yml`, `.eslintrc.js`, `BRANCH_PROTECTION.md`; this PR: `playwright.config.ts`) — no merge conflict expected. Merge order doesn't matter.

Closes #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)