### PR TITLE
ci: make Pipeline Summary gate critical job failures + branch strategy docs

### DIFF
--- a/.github/BRANCH_PROTECTION.md
+++ b/.github/BRANCH_PROTECTION.md
@@ -53,12 +53,14 @@
 Before any branch can be merged, ALL of the following must PASS:
 
 ### CI/CD Pipeline (GitHub Actions)
-- ✅ **ci-cd** - Main continuous integration workflow
+- ✅ **✅ Pipeline Summary** (aggregator job from `ci-cd.yml`) - the required status check
   - Linting (ESLint, TypeScript)
   - Type checking
   - Unit tests
   - Integration tests
   - Build verification
+  - Fails explicitly when any critical job in the pipeline failed (see `summary` job in `.github/workflows/ci-cd.yml`)
+  - Updated 2026-04-16: replaced ghost `CI/CD Pipeline` context (which was never produced because it's the workflow name, not a check name)
 
 - ✅ **specialized-gates** - Quality gates workflow
   - Additional validation rules

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1148,6 +1148,26 @@ jobs:
     timeout-minutes: 3
 
     steps:
+      - name: 🚨 Fail if any critical job failed
+        # Pre-flight gate: the summary check is used as required status check
+        # on protected branches (main). To have correct semantics, fail the
+        # summary job when any of the critical jobs in `needs:` has failed.
+        # A job being 'skipped' (via path-filter or branch condition) does NOT
+        # count as failure — it means the job wasn't relevant for this change.
+        if: |
+          needs.foundation.result == 'failure' ||
+          needs.development.result == 'failure' ||
+          needs.testing.result == 'failure' ||
+          needs.build.result == 'failure' ||
+          needs.e2e-tests.result == 'failure' ||
+          needs.security-lightweight.result == 'failure' ||
+          needs.security-enhanced.result == 'failure' ||
+          needs.security-comprehensive.result == 'failure'
+        run: |
+          echo "::error::One or more critical CI jobs failed. Review the Pipeline Summary below for details."
+          echo "Failed jobs will be listed in the summary table."
+          exit 1
+
       - name: 📊 Comprehensive Pipeline Summary
         run: |
           echo "# 🚀 CI/CD Pipeline - Complete Report" >> $GITHUB_STEP_SUMMARY

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,8 @@ i18n: next-intl (framework setup, messages in `messages/it.json` and `messages/e
 
 ## Git Workflow
 
-- **Never work directly on main** - always use feature branches
+- **Default branch: `develop`** (from 2026-04-16). Source of truth for ongoing work. `main` = release branch, updated bi-weekly via deliberate `develop` → `main` PR. See ADR-002 in vault.
+- **Never work directly on develop or main** - always use feature/fix/chore branches
 - Commit format: `type(scope): description` (commitlint enforced)
 - Types: fix, feat, refactor, test, docs, chore, ci, perf, style
 - Pre-commit hooks (Husky): doc governance, actionlint (if workflows staged), lint, typecheck, unit tests


### PR DESCRIPTION
## Summary

Sprint 0.5 of the beta consolidation plan (see ADR-002 in vault).

### 1. Required check semantic fix (main protection)
The `main` branch protection rule required a status check named `CI/CD Pipeline`, but no check with that exact name is ever produced — it's the workflow name, not a check run name. As a result every PR to main stayed perpetually in "Expected — Waiting for status to be reported".

This commit modifies the existing `✅ Pipeline Summary` aggregator job in `ci-cd.yml` to fail explicitly when any critical job has `conclusion == 'failure'`. The job was cosmetic-only before (always exited 0 regardless of upstream state), making it unsuitable as a required check. Now it's a real gate.

Skipped jobs (from path-filter or branch conditions) do NOT count as failure — that's "not relevant for this change", not a red flag.

After this PR merges, the main branch protection required context will be changed from `CI/CD Pipeline` (ghost) to `✅ Pipeline Summary` (real) via `gh api`.

### 2. Branch strategy documentation
- `CLAUDE.md`: document the 2026-04-16 default branch pivot to `develop`. Rationale: see ADR-002 in vault.
- `BRANCH_PROTECTION.md`: update required check entry to reflect the rename.

Default branch was changed on GitHub via `gh repo edit --default-branch develop` (separately). This commit is the in-repo documentation pair.

## Context

Part of the Sprint 0.5 consolidation following ADR-002 (Modified GitFlow). Closes open issues around bot auto-targeting (they now default to develop instead of stale main).

## Test plan

- [x] YAML valid (`python3 -c 'yaml.safe_load'`)
- [x] Pre-commit hooks green (lint + typecheck + build)
- [ ] CI green on this PR (the summary job itself should PASS since all critical jobs pass here)
- [ ] Manually verify: force a failure in a downstream job locally, confirm summary fails

## Follow-up (not in this PR)

After merge:
1. `gh api -X PUT repos/kdantuono/money-wise/branches/main/protection/required_status_checks -F "contexts[]=✅ Pipeline Summary"`
2. Cleanup stale feature branches on remote (old claude/* and chore/* branches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)