### PR TITLE
fix(ci): Pipeline Summary gate — order + hyphenated IDs syntax

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1148,26 +1148,6 @@ jobs:
     timeout-minutes: 3
 
     steps:
-      - name: 🚨 Fail if any critical job failed
-        # Pre-flight gate: the summary check is used as required status check
-        # on protected branches (main). To have correct semantics, fail the
-        # summary job when any of the critical jobs in `needs:` has failed.
-        # A job being 'skipped' (via path-filter or branch condition) does NOT
-        # count as failure — it means the job wasn't relevant for this change.
-        if: |
-          needs.foundation.result == 'failure' ||
-          needs.development.result == 'failure' ||
-          needs.testing.result == 'failure' ||
-          needs.build.result == 'failure' ||
-          needs.e2e-tests.result == 'failure' ||
-          needs.security-lightweight.result == 'failure' ||
-          needs.security-enhanced.result == 'failure' ||
-          needs.security-comprehensive.result == 'failure'
-        run: |
-          echo "::error::One or more critical CI jobs failed. Review the Pipeline Summary below for details."
-          echo "Failed jobs will be listed in the summary table."
-          exit 1
-
       - name: 📊 Comprehensive Pipeline Summary
         run: |
           echo "# 🚀 CI/CD Pipeline - Complete Report" >> $GITHUB_STEP_SUMMARY
@@ -1239,6 +1219,33 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "---" >> $GITHUB_STEP_SUMMARY
           echo "*Progressive CI/CD Pipeline v3.0 - 3-Tier Security Architecture*" >> $GITHUB_STEP_SUMMARY
+
+      - name: 🚨 Fail if any critical job failed
+        # Required-status-check gate: the summary job is the required check on
+        # protected branches (main). To have correct semantics, fail here when
+        # any of the critical jobs in `needs:` has conclusion=='failure'.
+        #
+        # A job being 'skipped' (via path-filter or branch condition) does NOT
+        # count as failure — it means the job wasn't relevant for this change.
+        #
+        # NOTE: hyphenated job IDs (e.g. `e2e-tests`) must use bracket notation
+        # in `needs[...]` expressions. Dot-notation `needs.e2e-tests` is parsed
+        # as arithmetic subtraction and always evaluates to empty.
+        #
+        # Runs AFTER the summary markdown step so reviewers see the result
+        # table even when this gate trips (previously the summary was skipped).
+        if: |
+          needs.foundation.result == 'failure' ||
+          needs.development.result == 'failure' ||
+          needs.testing.result == 'failure' ||
+          needs.build.result == 'failure' ||
+          needs['e2e-tests'].result == 'failure' ||
+          needs['security-lightweight'].result == 'failure' ||
+          needs['security-enhanced'].result == 'failure' ||
+          needs['security-comprehensive'].result == 'failure'
+        run: |
+          echo "::error::One or more critical CI jobs failed. See the Pipeline Summary above for the result table."
+          exit 1
 
   # ===================================================================
   # 🚀 TRIGGER RELEASE: Call release workflow on main success

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1171,35 +1171,35 @@ jobs:
           echo "| 🌱 Foundation | $FOUNDATION_ICON ${{ needs.foundation.result }} |" >> $GITHUB_STEP_SUMMARY
 
           DEV_RESULT="${{ needs.development.result || 'skipped' }}"
-          DEV_ICON="${{ needs.development.result == 'success' && '✅' || needs.development.result == 'failure' && '❌' || '⏭️' }}"
+          DEV_ICON="${{ needs.development.result == 'success' && '✅' || needs.development.result == 'failure' && '❌' || needs.development.result == 'cancelled' && '🚫' || '⏭️' }}"
           echo "| 📦 Development | $DEV_ICON $DEV_RESULT |" >> $GITHUB_STEP_SUMMARY
 
           SEC_LIGHT_RESULT="${{ needs['security-lightweight'].result || 'skipped' }}"
-          SEC_LIGHT_ICON="${{ needs['security-lightweight'].result == 'success' && '✅' || needs['security-lightweight'].result == 'failure' && '❌' || '⏭️' }}"
+          SEC_LIGHT_ICON="${{ needs['security-lightweight'].result == 'success' && '✅' || needs['security-lightweight'].result == 'failure' && '❌' || needs['security-lightweight'].result == 'cancelled' && '🚫' || '⏭️' }}"
           echo "| 🔒 Security (Lightweight) | $SEC_LIGHT_ICON $SEC_LIGHT_RESULT |" >> $GITHUB_STEP_SUMMARY
 
           SEC_ENH_RESULT="${{ needs['security-enhanced'].result || 'skipped' }}"
-          SEC_ENH_ICON="${{ needs['security-enhanced'].result == 'success' && '✅' || needs['security-enhanced'].result == 'failure' && '❌' || '⏭️' }}"
+          SEC_ENH_ICON="${{ needs['security-enhanced'].result == 'success' && '✅' || needs['security-enhanced'].result == 'failure' && '❌' || needs['security-enhanced'].result == 'cancelled' && '🚫' || '⏭️' }}"
           echo "| 🔒 Security (Enhanced) | $SEC_ENH_ICON $SEC_ENH_RESULT |" >> $GITHUB_STEP_SUMMARY
 
           SEC_COMP_RESULT="${{ needs['security-comprehensive'].result || 'skipped' }}"
-          SEC_COMP_ICON="${{ needs['security-comprehensive'].result == 'success' && '✅' || needs['security-comprehensive'].result == 'failure' && '❌' || '⏭️' }}"
+          SEC_COMP_ICON="${{ needs['security-comprehensive'].result == 'success' && '✅' || needs['security-comprehensive'].result == 'failure' && '❌' || needs['security-comprehensive'].result == 'cancelled' && '🚫' || '⏭️' }}"
           echo "| 🔒 Security (Comprehensive) | $SEC_COMP_ICON $SEC_COMP_RESULT |" >> $GITHUB_STEP_SUMMARY
 
           TEST_RESULT="${{ needs.testing.result || 'skipped' }}"
-          TEST_ICON="${{ needs.testing.result == 'success' && '✅' || needs.testing.result == 'failure' && '❌' || '⏭️' }}"
+          TEST_ICON="${{ needs.testing.result == 'success' && '✅' || needs.testing.result == 'failure' && '❌' || needs.testing.result == 'cancelled' && '🚫' || '⏭️' }}"
           echo "| 🧪 Testing | $TEST_ICON $TEST_RESULT |" >> $GITHUB_STEP_SUMMARY
 
           BUILD_RESULT="${{ needs.build.result || 'skipped' }}"
-          BUILD_ICON="${{ needs.build.result == 'success' && '✅' || needs.build.result == 'failure' && '❌' || '⏭️' }}"
+          BUILD_ICON="${{ needs.build.result == 'success' && '✅' || needs.build.result == 'failure' && '❌' || needs.build.result == 'cancelled' && '🚫' || '⏭️' }}"
           echo "| 🏗️ Build | $BUILD_ICON $BUILD_RESULT |" >> $GITHUB_STEP_SUMMARY
 
           E2E_RESULT="${{ needs['e2e-tests'].result || 'skipped' }}"
-          E2E_ICON="${{ needs['e2e-tests'].result == 'success' && '✅' || needs['e2e-tests'].result == 'failure' && '❌' || '⏭️' }}"
+          E2E_ICON="${{ needs['e2e-tests'].result == 'success' && '✅' || needs['e2e-tests'].result == 'failure' && '❌' || needs['e2e-tests'].result == 'cancelled' && '🚫' || '⏭️' }}"
           echo "| 🧪 E2E Tests | $E2E_ICON $E2E_RESULT |" >> $GITHUB_STEP_SUMMARY
 
           BUNDLE_RESULT="${{ needs['bundle-size'].result || 'skipped' }}"
-          BUNDLE_ICON="${{ needs['bundle-size'].result == 'success' && '✅' || needs['bundle-size'].result == 'failure' && '❌' || '⏭️' }}"
+          BUNDLE_ICON="${{ needs['bundle-size'].result == 'success' && '✅' || needs['bundle-size'].result == 'failure' && '❌' || needs['bundle-size'].result == 'cancelled' && '🚫' || '⏭️' }}"
           echo "| 📦 Bundle Size | $BUNDLE_ICON $BUNDLE_RESULT |" >> $GITHUB_STEP_SUMMARY
 
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -1223,10 +1223,17 @@ jobs:
       - name: 🚨 Fail if any critical job failed
         # Required-status-check gate: the summary job is the required check on
         # protected branches (main). To have correct semantics, fail here when
-        # any of the critical jobs in `needs:` has result=='failure'.
+        # any of the critical jobs in `needs:` did NOT reach a clean outcome.
         #
-        # A job being 'skipped' (via path-filter or branch condition) does NOT
-        # count as failure — it means the job wasn't relevant for this change.
+        # A result is "clean" when it is 'success' or 'skipped':
+        #   - 'success'  → job ran and passed
+        #   - 'skipped'  → job wasn't relevant for this change (path-filter /
+        #                  branch condition). Explicitly allowed.
+        # Anything else must trip the gate:
+        #   - 'failure'    → job ran and failed
+        #   - 'cancelled'  → job was cancelled (incl. timeouts). Means we do
+        #                    NOT have a signal for this job → treat as failure
+        #                    to prevent merges with incomplete critical checks.
         #
         # NOTE: hyphenated job IDs (e.g. `e2e-tests`) must use bracket notation
         # in `needs[...]` expressions. Dot-notation `needs.e2e-tests` is parsed
@@ -1235,14 +1242,14 @@ jobs:
         # Runs AFTER the summary markdown step so reviewers see the result
         # table even when this gate trips (previously the summary was skipped).
         if: |
-          needs.foundation.result == 'failure' ||
-          needs.development.result == 'failure' ||
-          needs.testing.result == 'failure' ||
-          needs.build.result == 'failure' ||
-          needs['e2e-tests'].result == 'failure' ||
-          needs['security-lightweight'].result == 'failure' ||
-          needs['security-enhanced'].result == 'failure' ||
-          needs['security-comprehensive'].result == 'failure'
+          (needs.foundation.result != 'success' && needs.foundation.result != 'skipped') ||
+          (needs.development.result != 'success' && needs.development.result != 'skipped') ||
+          (needs.testing.result != 'success' && needs.testing.result != 'skipped') ||
+          (needs.build.result != 'success' && needs.build.result != 'skipped') ||
+          (needs['e2e-tests'].result != 'success' && needs['e2e-tests'].result != 'skipped') ||
+          (needs['security-lightweight'].result != 'success' && needs['security-lightweight'].result != 'skipped') ||
+          (needs['security-enhanced'].result != 'success' && needs['security-enhanced'].result != 'skipped') ||
+          (needs['security-comprehensive'].result != 'success' && needs['security-comprehensive'].result != 'skipped')
         run: |
           echo "::error::One or more critical CI jobs failed. See the Pipeline Summary above for the result table."
           exit 1

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1174,16 +1174,16 @@ jobs:
           DEV_ICON="${{ needs.development.result == 'success' && '✅' || needs.development.result == 'failure' && '❌' || '⏭️' }}"
           echo "| 📦 Development | $DEV_ICON $DEV_RESULT |" >> $GITHUB_STEP_SUMMARY
 
-          SEC_LIGHT_RESULT="${{ needs.security-lightweight.result || 'skipped' }}"
-          SEC_LIGHT_ICON="${{ needs.security-lightweight.result == 'success' && '✅' || needs.security-lightweight.result == 'failure' && '❌' || '⏭️' }}"
+          SEC_LIGHT_RESULT="${{ needs['security-lightweight'].result || 'skipped' }}"
+          SEC_LIGHT_ICON="${{ needs['security-lightweight'].result == 'success' && '✅' || needs['security-lightweight'].result == 'failure' && '❌' || '⏭️' }}"
           echo "| 🔒 Security (Lightweight) | $SEC_LIGHT_ICON $SEC_LIGHT_RESULT |" >> $GITHUB_STEP_SUMMARY
 
-          SEC_ENH_RESULT="${{ needs.security-enhanced.result || 'skipped' }}"
-          SEC_ENH_ICON="${{ needs.security-enhanced.result == 'success' && '✅' || needs.security-enhanced.result == 'failure' && '❌' || '⏭️' }}"
+          SEC_ENH_RESULT="${{ needs['security-enhanced'].result || 'skipped' }}"
+          SEC_ENH_ICON="${{ needs['security-enhanced'].result == 'success' && '✅' || needs['security-enhanced'].result == 'failure' && '❌' || '⏭️' }}"
           echo "| 🔒 Security (Enhanced) | $SEC_ENH_ICON $SEC_ENH_RESULT |" >> $GITHUB_STEP_SUMMARY
 
-          SEC_COMP_RESULT="${{ needs.security-comprehensive.result || 'skipped' }}"
-          SEC_COMP_ICON="${{ needs.security-comprehensive.result == 'success' && '✅' || needs.security-comprehensive.result == 'failure' && '❌' || '⏭️' }}"
+          SEC_COMP_RESULT="${{ needs['security-comprehensive'].result || 'skipped' }}"
+          SEC_COMP_ICON="${{ needs['security-comprehensive'].result == 'success' && '✅' || needs['security-comprehensive'].result == 'failure' && '❌' || '⏭️' }}"
           echo "| 🔒 Security (Comprehensive) | $SEC_COMP_ICON $SEC_COMP_RESULT |" >> $GITHUB_STEP_SUMMARY
 
           TEST_RESULT="${{ needs.testing.result || 'skipped' }}"
@@ -1194,12 +1194,12 @@ jobs:
           BUILD_ICON="${{ needs.build.result == 'success' && '✅' || needs.build.result == 'failure' && '❌' || '⏭️' }}"
           echo "| 🏗️ Build | $BUILD_ICON $BUILD_RESULT |" >> $GITHUB_STEP_SUMMARY
 
-          E2E_RESULT="${{ needs.e2e-tests.result || 'skipped' }}"
-          E2E_ICON="${{ needs.e2e-tests.result == 'success' && '✅' || needs.e2e-tests.result == 'failure' && '❌' || '⏭️' }}"
+          E2E_RESULT="${{ needs['e2e-tests'].result || 'skipped' }}"
+          E2E_ICON="${{ needs['e2e-tests'].result == 'success' && '✅' || needs['e2e-tests'].result == 'failure' && '❌' || '⏭️' }}"
           echo "| 🧪 E2E Tests | $E2E_ICON $E2E_RESULT |" >> $GITHUB_STEP_SUMMARY
 
-          BUNDLE_RESULT="${{ needs.bundle-size.result || 'skipped' }}"
-          BUNDLE_ICON="${{ needs.bundle-size.result == 'success' && '✅' || needs.bundle-size.result == 'failure' && '❌' || '⏭️' }}"
+          BUNDLE_RESULT="${{ needs['bundle-size'].result || 'skipped' }}"
+          BUNDLE_ICON="${{ needs['bundle-size'].result == 'success' && '✅' || needs['bundle-size'].result == 'failure' && '❌' || '⏭️' }}"
           echo "| 📦 Bundle Size | $BUNDLE_ICON $BUNDLE_RESULT |" >> $GITHUB_STEP_SUMMARY
 
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1099,7 +1099,7 @@ jobs:
             // Access job results from needs context
             const devResult = '${{ needs.development.result }}';
             const testResult = '${{ needs.testing.result }}';
-            const e2eResult = '${{ needs.e2e-tests.result }}';
+            const e2eResult = '${{ needs['e2e-tests'].result }}';
 
             const failed = [devResult, testResult, e2eResult].filter(r => r === 'failure').length;
             const emoji = failed === 0 ? '✅' : '❌';
@@ -1223,7 +1223,7 @@ jobs:
       - name: 🚨 Fail if any critical job failed
         # Required-status-check gate: the summary job is the required check on
         # protected branches (main). To have correct semantics, fail here when
-        # any of the critical jobs in `needs:` has conclusion=='failure'.
+        # any of the critical jobs in `needs:` has result=='failure'.
         #
         # A job being 'skipped' (via path-filter or branch condition) does NOT
         # count as failure — it means the job wasn't relevant for this change.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -499,11 +499,11 @@ jobs:
           echo "| 📦 Sentry Release | $SENTRY_ICON ${{ needs['sentry-release'].result }} |" >> $GITHUB_STEP_SUMMARY
 
           GITHUB_RESULT="${{ needs['github-release'].result || 'skipped' }}"
-          GITHUB_ICON="${{ needs['github-release'].result == 'success' && '✅' || needs['github-release'].result == 'failure' && '❌' || '⏭️' }}"
+          GITHUB_ICON="${{ needs['github-release'].result == 'success' && '✅' || needs['github-release'].result == 'failure' && '❌' || needs['github-release'].result == 'cancelled' && '🚫' || '⏭️' }}"
           echo "| 🚀 GitHub Release | $GITHUB_ICON $GITHUB_RESULT |" >> $GITHUB_STEP_SUMMARY
 
           DOCKER_RESULT="${{ needs['docker-release'].result || 'skipped' }}"
-          DOCKER_ICON="${{ needs['docker-release'].result == 'success' && '✅' || needs['docker-release'].result == 'failure' && '❌' || '⏭️' }}"
+          DOCKER_ICON="${{ needs['docker-release'].result == 'success' && '✅' || needs['docker-release'].result == 'failure' && '❌' || needs['docker-release'].result == 'cancelled' && '🚫' || '⏭️' }}"
           echo "| 🐳 Docker Images | $DOCKER_ICON $DOCKER_RESULT |" >> $GITHUB_STEP_SUMMARY
 
           DEPLOY_ICON="${{ needs['deploy-notification'].result == 'success' && '✅' || '❌' }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,7 +146,7 @@ jobs:
           echo "🏗️ Rebuilding web..."
           pnpm build:web
         env:
-          SENTRY_RELEASE: ${{ needs.validate-release.outputs.version }}
+          SENTRY_RELEASE: ${{ needs['validate-release'].outputs.version }}
           SENTRY_ORG: ${{ env.SENTRY_ORG }}
           SENTRY_AUTH_TOKEN: ${{ env.SENTRY_AUTH_TOKEN }}
 
@@ -155,7 +155,7 @@ jobs:
 
       - name: 📦 Create Sentry Release
         run: |
-          VERSION="${{ needs.validate-release.outputs.version }}"
+          VERSION="${{ needs['validate-release'].outputs.version }}"
 
           sentry-cli releases new -p $SENTRY_PROJECT_WEB $VERSION
           sentry-cli releases set-commits --auto $VERSION
@@ -165,7 +165,7 @@ jobs:
       - name: 📤 Upload Source Maps (Web)
         if: hashFiles('apps/web/.next/**/*.map') != ''
         run: |
-          VERSION="${{ needs.validate-release.outputs.version }}"
+          VERSION="${{ needs['validate-release'].outputs.version }}"
           sentry-cli sourcemaps upload \
             --release=$VERSION \
             --project=$SENTRY_PROJECT_WEB \
@@ -173,7 +173,7 @@ jobs:
 
       - name: ✅ Finalize Sentry Release
         run: |
-          VERSION="${{ needs.validate-release.outputs.version }}"
+          VERSION="${{ needs['validate-release'].outputs.version }}"
 
           sentry-cli releases finalize -p $SENTRY_PROJECT_WEB $VERSION
           echo "✅ Finalized Sentry release: $VERSION"
@@ -200,7 +200,7 @@ jobs:
 
       - name: 📱 Create Mobile Sentry Release
         run: |
-          VERSION="${{ needs.validate-release.outputs.version }}"
+          VERSION="${{ needs['validate-release'].outputs.version }}"
 
           sentry-cli releases new -p $SENTRY_PROJECT_MOBILE $VERSION
           sentry-cli releases set-commits --auto $VERSION
@@ -231,7 +231,7 @@ jobs:
       - name: 📝 Generate changelog
         id: changelog
         run: |
-          VERSION="${{ needs.validate-release.outputs.version }}"
+          VERSION="${{ needs['validate-release'].outputs.version }}"
           PREVIOUS_TAG=$(git tag -l --sort=-version:refname | grep -v "^$VERSION$" | head -n1)
 
           if [ -n "$PREVIOUS_TAG" ]; then
@@ -306,10 +306,10 @@ jobs:
 
           cat > version-info.json << EOF
           {
-            "version": "${{ needs.validate-release.outputs.version }}",
+            "version": "${{ needs['validate-release'].outputs.version }}",
             "commit": "${{ github.sha }}",
             "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-            "is_prerelease": ${{ needs.validate-release.outputs.is_prerelease }},
+            "is_prerelease": ${{ needs['validate-release'].outputs.is_prerelease }},
             "build_number": "${{ github.run_number }}"
           }
           EOF
@@ -319,10 +319,10 @@ jobs:
       - name: 🚀 Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ needs.validate-release.outputs.version }}
-          name: Release ${{ needs.validate-release.outputs.version }}
+          tag_name: ${{ needs['validate-release'].outputs.version }}
+          name: Release ${{ needs['validate-release'].outputs.version }}
           body_path: changelog.md
-          prerelease: ${{ needs.validate-release.outputs.is_prerelease }}
+          prerelease: ${{ needs['validate-release'].outputs.is_prerelease }}
           files: |
             version-info.json
         env:
@@ -381,8 +381,8 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}/${{ matrix.app }}
           tags: |
-            type=semver,pattern={{version}},value=${{ needs.validate-release.outputs.version }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ needs.validate-release.outputs.version }}
+            type=semver,pattern={{version}},value=${{ needs['validate-release'].outputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs['validate-release'].outputs.version }}
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: 🏗️ Build and push Docker image
@@ -406,7 +406,7 @@ jobs:
     name: 📢 Deployment Notification
     runs-on: ubuntu-latest
     needs: [validate-release, sentry-release, sentry-mobile, github-release, docker-release]
-    if: always() && needs.validate-release.result == 'success'
+    if: always() && needs['validate-release'].result == 'success'
     timeout-minutes: 8
 
     steps:
@@ -415,7 +415,7 @@ jobs:
 
       - name: 📢 Create Sentry Deployment
         run: |
-          VERSION="${{ needs.validate-release.outputs.version }}"
+          VERSION="${{ needs['validate-release'].outputs.version }}"
           ENVIRONMENT=$([ "${{ github.ref }}" = "refs/heads/main" ] && echo "production" || echo "staging")
 
           sentry-cli releases deploys $VERSION new -e $ENVIRONMENT -p $SENTRY_PROJECT_WEB || true
@@ -425,14 +425,14 @@ jobs:
 
       - name: 📢 Deployment Summary
         run: |
-          echo "📢 Release ${{ needs.validate-release.outputs.version }} deployed!"
+          echo "📢 Release ${{ needs['validate-release'].outputs.version }} deployed!"
           echo "📋 Status Summary:"
-          echo "  - Sentry Releases: ${{ needs.sentry-release.result }}"
-          echo "  - GitHub Release: ${{ needs.github-release.result || 'skipped' }}"
-          echo "  - Docker Images: ${{ needs.docker-release.result || 'skipped' }}"
+          echo "  - Sentry Releases: ${{ needs['sentry-release'].result }}"
+          echo "  - GitHub Release: ${{ needs['github-release'].result || 'skipped' }}"
+          echo "  - Docker Images: ${{ needs['docker-release'].result || 'skipped' }}"
           echo ""
 
-          if [[ "${{ needs.sentry-release.result }}" == "success" ]]; then
+          if [[ "${{ needs['sentry-release'].result }}" == "success" ]]; then
             echo "✅ Sentry releases created successfully"
           fi
 
@@ -444,7 +444,7 @@ jobs:
     name: 🏥 Monitor Deployment Health
     runs-on: ubuntu-latest
     needs: [validate-release, deploy-notification]
-    if: always() && needs.validate-release.result == 'success' && github.ref == 'refs/heads/main'
+    if: always() && needs['validate-release'].result == 'success' && github.ref == 'refs/heads/main'
     timeout-minutes: 15
 
     steps:
@@ -455,7 +455,7 @@ jobs:
 
       - name: 🏥 Health Check
         run: |
-          VERSION="${{ needs.validate-release.outputs.version }}"
+          VERSION="${{ needs['validate-release'].outputs.version }}"
           ENVIRONMENT="production"
 
           echo "🏥 Monitoring release health for version: $VERSION"
@@ -485,8 +485,8 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Property | Value |" >> $GITHUB_STEP_SUMMARY
           echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Version | **${{ needs.validate-release.outputs.version }}** |" >> $GITHUB_STEP_SUMMARY
-          echo "| Pre-release | ${{ needs.validate-release.outputs.is_prerelease }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Version | **${{ needs['validate-release'].outputs.version }}** |" >> $GITHUB_STEP_SUMMARY
+          echo "| Pre-release | ${{ needs['validate-release'].outputs.is_prerelease }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Trigger | ${{ github.event_name }} |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
@@ -495,19 +495,19 @@ jobs:
           echo "| Stage | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
 
-          SENTRY_ICON="${{ needs.sentry-release.result == 'success' && '✅' || '❌' }}"
-          echo "| 📦 Sentry Release | $SENTRY_ICON ${{ needs.sentry-release.result }} |" >> $GITHUB_STEP_SUMMARY
+          SENTRY_ICON="${{ needs['sentry-release'].result == 'success' && '✅' || '❌' }}"
+          echo "| 📦 Sentry Release | $SENTRY_ICON ${{ needs['sentry-release'].result }} |" >> $GITHUB_STEP_SUMMARY
 
-          GITHUB_RESULT="${{ needs.github-release.result || 'skipped' }}"
-          GITHUB_ICON="${{ needs.github-release.result == 'success' && '✅' || needs.github-release.result == 'failure' && '❌' || '⏭️' }}"
+          GITHUB_RESULT="${{ needs['github-release'].result || 'skipped' }}"
+          GITHUB_ICON="${{ needs['github-release'].result == 'success' && '✅' || needs['github-release'].result == 'failure' && '❌' || '⏭️' }}"
           echo "| 🚀 GitHub Release | $GITHUB_ICON $GITHUB_RESULT |" >> $GITHUB_STEP_SUMMARY
 
-          DOCKER_RESULT="${{ needs.docker-release.result || 'skipped' }}"
-          DOCKER_ICON="${{ needs.docker-release.result == 'success' && '✅' || needs.docker-release.result == 'failure' && '❌' || '⏭️' }}"
+          DOCKER_RESULT="${{ needs['docker-release'].result || 'skipped' }}"
+          DOCKER_ICON="${{ needs['docker-release'].result == 'success' && '✅' || needs['docker-release'].result == 'failure' && '❌' || '⏭️' }}"
           echo "| 🐳 Docker Images | $DOCKER_ICON $DOCKER_RESULT |" >> $GITHUB_STEP_SUMMARY
 
-          DEPLOY_ICON="${{ needs.deploy-notification.result == 'success' && '✅' || '❌' }}"
-          echo "| 📢 Deployment | $DEPLOY_ICON ${{ needs.deploy-notification.result }} |" >> $GITHUB_STEP_SUMMARY
+          DEPLOY_ICON="${{ needs['deploy-notification'].result == 'success' && '✅' || '❌' }}"
+          echo "| 📢 Deployment | $DEPLOY_ICON ${{ needs['deploy-notification'].result }} |" >> $GITHUB_STEP_SUMMARY
 
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "---" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/specialized-gates.yml
+++ b/.github/workflows/specialized-gates.yml
@@ -246,12 +246,12 @@ jobs:
           echo "| Gate | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
 
-          DOCKER_ICON="${{ needs.dockerfile-security.result == 'success' && '✅' || needs.dockerfile-security.result == 'failure' && '❌' || '⏭️' }}"
-          DOCKER_RESULT="${{ needs.dockerfile-security.result || 'skipped' }}"
+          DOCKER_ICON="${{ needs['dockerfile-security'].result == 'success' && '✅' || needs['dockerfile-security'].result == 'failure' && '❌' || '⏭️' }}"
+          DOCKER_RESULT="${{ needs['dockerfile-security'].result || 'skipped' }}"
           echo "| 🐳 Dockerfile Security | $DOCKER_ICON $DOCKER_RESULT |" >> $GITHUB_STEP_SUMMARY
 
-          SUPABASE_ICON="${{ needs.supabase-validation.result == 'success' && '✅' || needs.supabase-validation.result == 'failure' && '❌' || '⏭️' }}"
-          SUPABASE_RESULT="${{ needs.supabase-validation.result || 'skipped' }}"
+          SUPABASE_ICON="${{ needs['supabase-validation'].result == 'success' && '✅' || needs['supabase-validation'].result == 'failure' && '❌' || '⏭️' }}"
+          SUPABASE_RESULT="${{ needs['supabase-validation'].result || 'skipped' }}"
           echo "| 🗃️ Supabase Schema | $SUPABASE_ICON $SUPABASE_RESULT |" >> $GITHUB_STEP_SUMMARY
 
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/specialized-gates.yml
+++ b/.github/workflows/specialized-gates.yml
@@ -246,11 +246,11 @@ jobs:
           echo "| Gate | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
 
-          DOCKER_ICON="${{ needs['dockerfile-security'].result == 'success' && '✅' || needs['dockerfile-security'].result == 'failure' && '❌' || '⏭️' }}"
+          DOCKER_ICON="${{ needs['dockerfile-security'].result == 'success' && '✅' || needs['dockerfile-security'].result == 'failure' && '❌' || needs['dockerfile-security'].result == 'cancelled' && '🚫' || '⏭️' }}"
           DOCKER_RESULT="${{ needs['dockerfile-security'].result || 'skipped' }}"
           echo "| 🐳 Dockerfile Security | $DOCKER_ICON $DOCKER_RESULT |" >> $GITHUB_STEP_SUMMARY
 
-          SUPABASE_ICON="${{ needs['supabase-validation'].result == 'success' && '✅' || needs['supabase-validation'].result == 'failure' && '❌' || '⏭️' }}"
+          SUPABASE_ICON="${{ needs['supabase-validation'].result == 'success' && '✅' || needs['supabase-validation'].result == 'failure' && '❌' || needs['supabase-validation'].result == 'cancelled' && '🚫' || '⏭️' }}"
           SUPABASE_RESULT="${{ needs['supabase-validation'].result || 'skipped' }}"
           echo "| 🗃️ Supabase Schema | $SUPABASE_ICON $SUPABASE_RESULT |" >> $GITHUB_STEP_SUMMARY
 


### PR DESCRIPTION
## Summary

Addresses both Copilot review comments from PR #432 (arrived 35s after merge — applied retroactively).

### Bug 1 — Gate step ordering
The fail-gate step ran BEFORE the `📊 Comprehensive Pipeline Summary` step. On failure, the job exited without writing the result table to `$GITHUB_STEP_SUMMARY`, so reviewers saw "Review the Pipeline Summary below" with nothing below. **Fix**: move the gate to the END of the job, so the summary table always renders first.

### Bug 2 — Expression syntax for hyphenated job IDs (**CRITICAL**)
GitHub Actions parses `needs.e2e-tests.result` as `needs.e2e MINUS tests.result` (arithmetic subtraction), which returns empty. The gate condition NEVER matched for jobs with hyphens in their ID:
- `e2e-tests`
- `security-lightweight`
- `security-enhanced`
- `security-comprehensive`

Meaning: the required status check on `main` was effectively **50% broken** — it gated correctly only for non-hyphenated jobs (foundation/development/testing/build) and silently passed for the 4 hyphenated ones.

**Fix**: use bracket notation `needs['e2e-tests'].result == 'failure'` and similar.

## Context

Both issues were flagged by Copilot on PR #432 after I had already merged. The fix on that PR (#432) was supposed to make `✅ Pipeline Summary` a real required-status gate on main. Without this follow-up, the gate is functional only for a subset of jobs.

This is exactly the kind of bug where bot review is invaluable — the hyphenated-ID arithmetic trap is easy to miss for humans.

## Test plan

- [x] YAML valid
- [x] Pre-commit hooks green (lint + typecheck + build)
- [ ] CI pipeline green on this PR
- [ ] Manually verify behavior in a future failing PR (summary table visible + gate trips correctly for hyphenated jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)