### PR TITLE
fix(ci): add --allowed-tools whitelist to autofix dual-agents

### DIFF
--- a/.github/workflows/claude-autofix.yml
+++ b/.github/workflows/claude-autofix.yml
@@ -119,7 +119,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model claude-sonnet-4-6 --max-turns 50"
+          # --allowed-tools is REQUIRED for destructive Bash commands.
+          # Without it, Claude Code Action sandbox silently denies gh/git writes
+          # (visible as permission_denials_count in run logs). Keep the list
+          # tight: only what fix-agent actually needs to work.
+          claude_args: >-
+            --model claude-sonnet-4-6
+            --max-turns 50
+            --allowed-tools "Bash(gh pr:*),Bash(gh api:*),Bash(gh run:*),Bash(gh label:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git diff:*),Bash(git log:*),Bash(git status:*),Bash(git fetch:*),Bash(sleep:*),Bash(echo:*),Bash(grep:*),Bash(jq:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(seq:*),Bash(pnpm:*)"
           additional_permissions: |
             actions: read
           prompt: |
@@ -227,7 +234,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model claude-opus-4-6 --max-turns 20"
+          # --allowed-tools: review-agent posts reviews and enables auto-merge.
+          # No git/push/commit needed — it reviews, never commits. Tighter
+          # whitelist than fix-agent.
+          claude_args: >-
+            --model claude-opus-4-6
+            --max-turns 20
+            --allowed-tools "Bash(gh pr:*),Bash(gh api:*),Bash(gh run:*),Bash(sleep:*),Bash(echo:*),Bash(grep:*),Bash(jq:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(seq:*)"
           additional_permissions: |
             actions: read
           prompt: |

--- a/.github/workflows/claude-autofix.yml
+++ b/.github/workflows/claude-autofix.yml
@@ -106,6 +106,17 @@ jobs:
             echo "skip=false" >> $GITHUB_OUTPUT
           fi
 
+      # Configure git committer identity before fix-agent attempts any commit.
+      # GitHub-hosted runners have no default user.name/user.email — without
+      # these, `git commit` fails. We use the github-actions[bot] identity so
+      # the commits appear authored by automation (and are correctly matched
+      # by the loop-prevention regex on subsequent runs).
+      - name: ⚙️ Configure git committer identity
+        if: steps.loop-check.outputs.skip != 'true'
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
       # =======================================================================
       # FIX AGENT — Sonnet 4.6, max 50 turns
       # Does the heavy lifting: wait for Copilot, apply fixes, monitor CI
@@ -126,7 +137,7 @@ jobs:
           claude_args: >-
             --model claude-sonnet-4-6
             --max-turns 50
-            --allowed-tools "Bash(gh pr:*),Bash(gh api:*),Bash(gh run:*),Bash(gh label:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git diff:*),Bash(git log:*),Bash(git status:*),Bash(git fetch:*),Bash(sleep:*),Bash(echo:*),Bash(grep:*),Bash(jq:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(seq:*),Bash(pnpm:*)"
+            --allowed-tools "Bash(gh pr:*),Bash(gh api:*),Bash(gh run:*),Bash(gh label:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git diff:*),Bash(git log:*),Bash(git status:*),Bash(git fetch:*),Bash(git config:*),Bash(sleep:*),Bash(echo:*),Bash(grep:*),Bash(jq:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(seq:*),Bash(pnpm:*)"
           additional_permissions: |
             actions: read
           prompt: |


### PR DESCRIPTION
## Summary

First live test of the dual-agent autofix workflow (on PR #435) revealed that Opus review-agent had `permission_denials_count: 4` in the run log — meaning 4 attempted Bash operations were silently denied by the Claude Code Action default sandbox. Result: Opus ran for 7 turns (~\$0.29) but never posted a review and never enabled auto-merge.

## Root cause

Claude Code Action denies destructive Bash commands by default. Specifically:
- `gh pr review --approve|--request-changes`
- `gh pr merge --auto`
- `gh api -X POST/PATCH/PUT`
- `git push`

These require explicit whitelist via `--allowed-tools`. Pattern from `claude.yml` commented example:
```yaml
# claude_args: '--allowed-tools Bash(gh pr:*)'
```

## Fix

Pass tight `--allowed-tools` lists to both agents via `claude_args`:

**Fix-agent (Sonnet)** — needs to commit + push + monitor CI:
`gh pr:*`, `gh api:*`, `gh run:*`, `gh label:*`, `git add/commit/push/diff/log/status/fetch`, plus shell utilities (sleep, echo, grep, jq, cat, head, tail, wc, seq), plus `pnpm:*` for CI failure diagnosis.

**Review-agent (Opus)** — reads + posts reviews, never commits:
`gh pr:*`, `gh api:*`, `gh run:*`, plus the shell utilities. **No** git/commit/push — it only reads and reviews.

## Impact

Before this PR: the workflow **appears** to succeed but is a no-op — Opus can analyze the diff but cannot actually post its decision or trigger merge. The entire "Opus vetoes Sonnet" design is broken.

After this PR: the next PR opened should trigger a real Opus review with APPROVE/REQUEST_CHANGES and auto-merge enabled when appropriate.

## Test plan

- [x] YAML valid
- [x] Pre-commit hooks green
- [ ] CI green on this PR (path-filter should skip heavy jobs since only `.github/workflows/claude-autofix.yml` changed)
- [ ] **Meta-test**: this PR itself is another smoke test. If the fix works, the workflow should now post a visible Opus review on this very PR.

## Reference

- First smoke test: PR #435 (MERGED) — revealed the permission_denials issue
- Run log: https://github.com/kdantuono/money-wise/actions/runs/24522438896
- ADR-003 (dual-agent autofix) stays unchanged — this is an implementation fix, not a design change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)