### PR TITLE
feat(settings): persist Notifiche tab a profiles.preferences.notifications

### DIFF
--- a/apps/web/__tests__/components/settings/NotificationsTab.test.tsx
+++ b/apps/web/__tests__/components/settings/NotificationsTab.test.tsx
@@ -1,0 +1,364 @@
+/**
+ * Tests for NotificationsTab component
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent } from '@testing-library/react';
+import { render, screen, waitFor } from '../../utils/test-utils';
+
+// Hoisted so the vi.mock factory can reference it safely (vi.mock is hoisted
+// to the top of the file before any const declarations evaluate).
+const { updateNotificationsMock, setUserMock } = vi.hoisted(() => ({
+  updateNotificationsMock: vi.fn(),
+  setUserMock: vi.fn(),
+}));
+
+// Mock framer-motion (same pattern as existing settings.test.tsx)
+vi.mock('framer-motion', () => ({
+  motion: new Proxy({}, {
+    get: (_t: unknown, prop: string | symbol) => {
+      if (prop === '__esModule') return false;
+      return ({
+        children,
+        initial: _initial,
+        animate: _animate,
+        exit: _exit,
+        transition: _transition,
+        whileHover: _whileHover,
+        whileTap: _whileTap,
+        whileInView: _whileInView,
+        variants: _variants,
+        ...rest
+      }: Record<string, unknown>) => {
+        const Tag = typeof prop === 'string' ? prop : 'div';
+        return React.createElement(Tag as string, rest, children as React.ReactNode);
+      };
+    },
+  }),
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+// Mock auth store
+vi.mock('../../../src/store/auth.store', () => ({
+  useAuthStore: vi.fn(),
+}));
+
+// Mock the preferences client (service)
+vi.mock('../../../src/services/user-preferences.client', () => ({
+  userPreferencesClient: {
+    update: vi.fn(),
+    updateNotifications: updateNotificationsMock,
+  },
+  UserPreferencesApiError: class extends Error {},
+}));
+
+import { NotificationsTab } from '../../../src/components/settings/NotificationsTab';
+import { useAuthStore } from '../../../src/store/auth.store';
+const mockUseAuthStore = useAuthStore as unknown as ReturnType<typeof vi.fn>;
+
+const USER_ID = '550e8400-e29b-41d4-a716-446655440000';
+
+function mockUser(preferences?: Record<string, unknown> | null) {
+  return {
+    id: USER_ID,
+    email: 'john@example.com',
+    firstName: 'John',
+    lastName: 'Doe',
+    role: 'USER',
+    status: 'ACTIVE',
+    timezone: 'Europe/Rome',
+    currency: 'EUR',
+    preferences,
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    fullName: 'John Doe',
+    isEmailVerified: true,
+    isActive: true,
+  };
+}
+
+describe('<NotificationsTab />', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setUserMock.mockReset();
+    updateNotificationsMock.mockReset();
+    mockUseAuthStore.mockReturnValue({
+      user: mockUser(),
+      setUser: setUserMock,
+    });
+    updateNotificationsMock.mockResolvedValue({
+      notifications: {
+        channels: { email: true, push: true, inApp: true },
+        types: {},
+        quietHours: { enabled: false, from: '22:00', to: '08:00' },
+      },
+    });
+  });
+
+  describe('Rendering & hydration', () => {
+    it('renders channel headings and the 3 channel toggles', () => {
+      render(<NotificationsTab />);
+      expect(screen.getByText('Canali di Notifica')).toBeInTheDocument();
+      expect(
+        screen.getByLabelText('Notifiche Email')
+      ).toBeInTheDocument();
+      expect(screen.getByLabelText('Notifiche Push')).toBeInTheDocument();
+      expect(screen.getByLabelText('Notifiche In-App')).toBeInTheDocument();
+    });
+
+    it('renders all 8 notification types', () => {
+      render(<NotificationsTab />);
+      expect(screen.getByLabelText('Rapporto Mensile AI')).toBeInTheDocument();
+      expect(screen.getByLabelText('Alert Budget')).toBeInTheDocument();
+      expect(
+        screen.getByLabelText('Consigli AI Personalizzati')
+      ).toBeInTheDocument();
+      expect(
+        screen.getByLabelText('Aggiornamenti Investimenti')
+      ).toBeInTheDocument();
+      expect(screen.getByLabelText('Scadenze Ricorrenti')).toBeInTheDocument();
+      expect(screen.getByLabelText('Obiettivi Raggiunti')).toBeInTheDocument();
+      expect(screen.getByLabelText('Nuove Funzionalità')).toBeInTheDocument();
+      expect(screen.getByLabelText('Promozioni e Offerte')).toBeInTheDocument();
+    });
+
+    it('renders quiet hours controls with defaults', () => {
+      render(<NotificationsTab />);
+      expect(screen.getByText('Orario Silenziamento')).toBeInTheDocument();
+      expect(screen.getByLabelText('Dalle')).toHaveValue('22:00');
+      expect(screen.getByLabelText('Alle')).toHaveValue('08:00');
+      // disabled initially
+      expect(screen.getByLabelText('Dalle')).toBeDisabled();
+      expect(screen.getByLabelText('Alle')).toBeDisabled();
+    });
+
+    it('hydrates toggles from user.preferences.notifications (nested shape)', () => {
+      mockUseAuthStore.mockReturnValue({
+        user: mockUser({
+          notifications: {
+            channels: { email: false, push: true, inApp: false },
+            types: {
+              monthlyReport: false,
+              budgetAlerts: true,
+              aiAdvice: true,
+              investmentUpdates: true,
+              recurringDeadlines: true,
+              goalsAchieved: true,
+              newFeatures: true,
+              promotions: false,
+            },
+            quietHours: { enabled: true, from: '23:30', to: '07:15' },
+          },
+        }),
+        setUser: setUserMock,
+      });
+
+      render(<NotificationsTab />);
+
+      expect(screen.getByLabelText('Notifiche Email')).not.toBeChecked();
+      expect(screen.getByLabelText('Notifiche Push')).toBeChecked();
+      expect(screen.getByLabelText('Notifiche In-App')).not.toBeChecked();
+      expect(screen.getByLabelText('Rapporto Mensile AI')).not.toBeChecked();
+      expect(screen.getByLabelText('Nuove Funzionalità')).toBeChecked();
+      expect(screen.getByLabelText('Dalle')).toHaveValue('23:30');
+      expect(screen.getByLabelText('Alle')).toHaveValue('07:15');
+      expect(screen.getByLabelText('Dalle')).not.toBeDisabled();
+    });
+
+    it('hydrates from legacy flat preferences shape', () => {
+      mockUseAuthStore.mockReturnValue({
+        user: mockUser({
+          notifications: {
+            email: false,
+            push: true,
+            categories: true,
+            budgets: false,
+          },
+        }),
+        setUser: setUserMock,
+      });
+      render(<NotificationsTab />);
+      expect(screen.getByLabelText('Notifiche Email')).not.toBeChecked();
+      expect(screen.getByLabelText('Notifiche Push')).toBeChecked();
+      expect(screen.getByLabelText('Alert Budget')).not.toBeChecked();
+    });
+
+    it('renders nothing breaking when preferences is null', () => {
+      mockUseAuthStore.mockReturnValue({
+        user: mockUser(null),
+        setUser: setUserMock,
+      });
+      render(<NotificationsTab />);
+      // All channels default to true, all types default reasonable
+      expect(screen.getByLabelText('Notifiche Email')).toBeChecked();
+      expect(screen.getByLabelText('Promozioni e Offerte')).not.toBeChecked();
+    });
+  });
+
+  describe('Toggle interactions', () => {
+    it('toggles a channel when clicked', async () => {
+      const { user } = render(<NotificationsTab />);
+      const email = screen.getByLabelText('Notifiche Email') as HTMLInputElement;
+      expect(email).toBeChecked();
+      await user.click(email);
+      expect(email).not.toBeChecked();
+      await user.click(email);
+      expect(email).toBeChecked();
+    });
+
+    it('toggles a notification type when clicked', async () => {
+      const { user } = render(<NotificationsTab />);
+      const promos = screen.getByLabelText(
+        'Promozioni e Offerte'
+      ) as HTMLInputElement;
+      expect(promos).not.toBeChecked();
+      await user.click(promos);
+      expect(promos).toBeChecked();
+    });
+
+    it('enables quiet hours inputs when the switch is toggled on', async () => {
+      const { user } = render(<NotificationsTab />);
+      const qhSwitch = screen.getByLabelText(
+        'Abilita silenziamento'
+      ) as HTMLInputElement;
+      expect(screen.getByLabelText('Dalle')).toBeDisabled();
+      await user.click(qhSwitch);
+      expect(qhSwitch).toBeChecked();
+      expect(screen.getByLabelText('Dalle')).not.toBeDisabled();
+    });
+
+    it('updates quiet hours times', async () => {
+      const { user } = render(<NotificationsTab />);
+      await user.click(screen.getByLabelText('Abilita silenziamento'));
+      const from = screen.getByLabelText('Dalle') as HTMLInputElement;
+      // time inputs in jsdom don't accept keyboard typing reliably — use change event
+      fireEvent.change(from, { target: { value: '23:45' } });
+      expect(from).toHaveValue('23:45');
+    });
+  });
+
+  describe('Save flow', () => {
+    it('calls updateNotifications with the current state on save', async () => {
+      const { user } = render(<NotificationsTab />);
+      // Flip a couple of toggles
+      await user.click(screen.getByLabelText('Notifiche Email'));
+      await user.click(screen.getByLabelText('Promozioni e Offerte'));
+      await user.click(
+        screen.getByRole('button', { name: /Salva Preferenze/i })
+      );
+
+      expect(updateNotificationsMock).toHaveBeenCalledTimes(1);
+      const [uid, existing, payload] = updateNotificationsMock.mock.calls[0];
+      expect(uid).toBe(USER_ID);
+      expect(existing).toEqual(mockUser().preferences);
+      expect(payload.channels.email).toBe(false);
+      expect(payload.types.promotions).toBe(true);
+      expect(payload.quietHours.enabled).toBe(false);
+    });
+
+    it('calls setUser with merged preferences on successful save', async () => {
+      const merged = {
+        theme: 'dracula',
+        notifications: {
+          channels: { email: false, push: true, inApp: true },
+          types: {},
+          quietHours: { enabled: false, from: '22:00', to: '08:00' },
+        },
+      };
+      updateNotificationsMock.mockResolvedValueOnce(merged);
+
+      const { user } = render(<NotificationsTab />);
+      await user.click(
+        screen.getByRole('button', { name: /Salva Preferenze/i })
+      );
+
+      await waitFor(() => {
+        expect(setUserMock).toHaveBeenCalledTimes(1);
+      });
+      const updatedUser = setUserMock.mock.calls[0][0];
+      expect(updatedUser.preferences).toEqual(merged);
+      expect(updatedUser.id).toBe(USER_ID);
+    });
+
+    it('shows "Salvato!" feedback after successful save', async () => {
+      render(<NotificationsTab />);
+      fireEvent.click(
+        screen.getByRole('button', { name: /Salva Preferenze/i })
+      );
+      expect(
+        await screen.findByRole('button', { name: /Salvato/i })
+      ).toBeInTheDocument();
+    });
+
+    it('shows error message when service rejects', async () => {
+      updateNotificationsMock.mockRejectedValueOnce(
+        new Error('Network boom')
+      );
+      render(<NotificationsTab />);
+      fireEvent.click(
+        screen.getByRole('button', { name: /Salva Preferenze/i })
+      );
+      const alert = await screen.findByRole('alert');
+      expect(alert).toHaveTextContent(/Network boom/);
+      expect(setUserMock).not.toHaveBeenCalled();
+    });
+
+    it('shows a generic error message if the rejection is not an Error instance', async () => {
+      updateNotificationsMock.mockRejectedValueOnce('some string');
+      render(<NotificationsTab />);
+      fireEvent.click(
+        screen.getByRole('button', { name: /Salva Preferenze/i })
+      );
+      const alert = await screen.findByRole('alert');
+      expect(alert).toHaveTextContent(
+        /Impossibile salvare le preferenze notifiche/
+      );
+    });
+
+    it('shows error and skips service call when user is missing id', async () => {
+      mockUseAuthStore.mockReturnValue({
+        user: { ...mockUser(), id: '' },
+        setUser: setUserMock,
+      });
+      render(<NotificationsTab />);
+      fireEvent.click(
+        screen.getByRole('button', { name: /Salva Preferenze/i })
+      );
+      const alert = await screen.findByRole('alert');
+      expect(alert).toHaveTextContent(/Utente non trovato/i);
+      expect(updateNotificationsMock).not.toHaveBeenCalled();
+    });
+
+    it('disables save button while saving', async () => {
+      let resolvePromise: ((v: unknown) => void) | undefined;
+      updateNotificationsMock.mockImplementationOnce(
+        () => new Promise((r) => (resolvePromise = r))
+      );
+
+      render(<NotificationsTab />);
+      fireEvent.click(
+        screen.getByRole('button', { name: /Salva Preferenze/i })
+      );
+      // Button re-renders with "Salvataggio..." label while isSaving=true
+      const savingBtn = await screen.findByRole('button', {
+        name: /Salvataggio/i,
+      });
+      expect(savingBtn).toBeDisabled();
+
+      resolvePromise!({ notifications: {} });
+      await screen.findByRole('button', { name: /Salvato/i });
+    });
+  });
+
+  describe('User absent', () => {
+    it('renders defaults and no crash when user is null', () => {
+      mockUseAuthStore.mockReturnValue({
+        user: null,
+        setUser: setUserMock,
+      });
+      render(<NotificationsTab />);
+      expect(screen.getByText('Canali di Notifica')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/__tests__/components/settings/NotificationsTab.test.tsx
+++ b/apps/web/__tests__/components/settings/NotificationsTab.test.tsx
@@ -316,6 +316,31 @@ describe('<NotificationsTab />', () => {
       );
     });
 
+    it('blocks save and shows an error when quiet hours are enabled with invalid time values', async () => {
+      mockUseAuthStore.mockReturnValue({
+        user: mockUser({
+          notifications: {
+            channels: { email: true, push: true, inApp: true },
+            types: {},
+            // Seed a valid payload; we'll make it invalid via the UI below.
+            quietHours: { enabled: true, from: '22:00', to: '08:00' },
+          },
+        }),
+        setUser: setUserMock,
+      });
+      render(<NotificationsTab />);
+      // Clear `from` — <input type="time"> can emit an empty string.
+      fireEvent.change(screen.getByLabelText('Dalle'), {
+        target: { value: '' },
+      });
+      fireEvent.click(
+        screen.getByRole('button', { name: /Salva Preferenze/i })
+      );
+      const alert = await screen.findByRole('alert');
+      expect(alert).toHaveTextContent(/Orari di silenziamento non validi/i);
+      expect(updateNotificationsMock).not.toHaveBeenCalled();
+    });
+
     it('shows error and skips service call when user is missing id', async () => {
       mockUseAuthStore.mockReturnValue({
         user: { ...mockUser(), id: '' },

--- a/apps/web/__tests__/services/user-preferences.client.test.ts
+++ b/apps/web/__tests__/services/user-preferences.client.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Tests for user-preferences.client
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock Supabase client BEFORE importing the module under test
+type MockChain = {
+  update: ReturnType<typeof vi.fn>;
+  eq: ReturnType<typeof vi.fn>;
+};
+
+const chain: MockChain = {
+  update: vi.fn(),
+  eq: vi.fn(),
+};
+const fromMock = vi.fn(() => chain);
+
+vi.mock('../../src/utils/supabase/client', () => ({
+  createClient: vi.fn(() => ({ from: fromMock })),
+}));
+
+import {
+  userPreferencesClient,
+  UserPreferencesApiError,
+} from '../../src/services/user-preferences.client';
+import {
+  defaultNotificationPreferences,
+  type UserPreferences,
+} from '../../src/types/user-preferences';
+
+const USER_ID = '550e8400-e29b-41d4-a716-446655440000';
+
+function makeEqResolver(error: { message: string } | null) {
+  return { error };
+}
+
+describe('userPreferencesClient.update', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    chain.update.mockReset().mockReturnValue(chain);
+    chain.eq.mockReset().mockResolvedValue(makeEqResolver(null));
+  });
+
+  it('rejects when userId is empty', async () => {
+    await expect(
+      userPreferencesClient.update('', { theme: 'dracula' })
+    ).rejects.toBeInstanceOf(UserPreferencesApiError);
+  });
+
+  it('writes preferences to the profiles table, targeting the user row', async () => {
+    const prefs: UserPreferences = {
+      theme: 'dracula',
+      language: 'it',
+      notifications: defaultNotificationPreferences(),
+    };
+
+    await userPreferencesClient.update(USER_ID, prefs);
+
+    expect(fromMock).toHaveBeenCalledWith('profiles');
+    expect(chain.update).toHaveBeenCalledTimes(1);
+    const call = chain.update.mock.calls[0][0];
+    expect(call).toHaveProperty('preferences');
+    // The payload must be JSON-safe (plain object, not class instance)
+    expect(JSON.parse(JSON.stringify(call.preferences))).toEqual(prefs);
+    expect(chain.eq).toHaveBeenCalledWith('id', USER_ID);
+  });
+
+  it('wraps Supabase errors in UserPreferencesApiError', async () => {
+    chain.eq.mockResolvedValueOnce(
+      makeEqResolver({ message: 'RLS violation' })
+    );
+
+    await expect(
+      userPreferencesClient.update(USER_ID, { theme: 'system' })
+    ).rejects.toMatchObject({
+      name: 'UserPreferencesApiError',
+      statusCode: 500,
+      message: expect.stringContaining('RLS violation'),
+    });
+  });
+
+  it('uses a fallback message when Supabase error has no message', async () => {
+    chain.eq.mockResolvedValueOnce(
+      makeEqResolver({ message: '' } as { message: string })
+    );
+    await expect(
+      userPreferencesClient.update(USER_ID, {})
+    ).rejects.toMatchObject({
+      message: 'Failed to update preferences',
+      statusCode: 500,
+    });
+  });
+
+  it('strips non-serializable values (functions, undefined) before persisting', async () => {
+    const prefs = {
+      theme: 'italian',
+      extra: () => 'should be dropped',
+      dropMe: undefined,
+      notifications: defaultNotificationPreferences(),
+    } as unknown as UserPreferences;
+
+    await userPreferencesClient.update(USER_ID, prefs);
+
+    const payload = chain.update.mock.calls[0][0].preferences;
+    expect(payload).not.toHaveProperty('extra');
+    expect(payload).not.toHaveProperty('dropMe');
+    expect(payload.theme).toBe('italian');
+    expect(payload.notifications).toBeDefined();
+  });
+});
+
+describe('userPreferencesClient.updateNotifications', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    chain.update.mockReset().mockReturnValue(chain);
+    chain.eq.mockReset().mockResolvedValue(makeEqResolver(null));
+  });
+
+  it('merges notifications into existing preferences and returns the merged object', async () => {
+    const current: UserPreferences = {
+      theme: 'dracula',
+      language: 'it',
+    };
+    const nextNotifications = defaultNotificationPreferences();
+
+    const merged = await userPreferencesClient.updateNotifications(
+      USER_ID,
+      current,
+      nextNotifications
+    );
+
+    expect(merged).toEqual({
+      theme: 'dracula',
+      language: 'it',
+      notifications: nextNotifications,
+    });
+    const payload = chain.update.mock.calls[0][0].preferences;
+    expect(payload).toEqual(merged);
+  });
+
+  it('handles null/undefined existing preferences', async () => {
+    const nextNotifications = defaultNotificationPreferences();
+
+    const mergedUndefined = await userPreferencesClient.updateNotifications(
+      USER_ID,
+      undefined,
+      nextNotifications
+    );
+    expect(mergedUndefined).toEqual({ notifications: nextNotifications });
+
+    const mergedNull = await userPreferencesClient.updateNotifications(
+      USER_ID,
+      null,
+      nextNotifications
+    );
+    expect(mergedNull).toEqual({ notifications: nextNotifications });
+  });
+
+  it('overwrites previous notifications value (does not deep-merge channels)', async () => {
+    const current: UserPreferences = {
+      notifications: {
+        channels: { email: false, push: false, inApp: false },
+        types: defaultNotificationPreferences().types,
+        quietHours: defaultNotificationPreferences().quietHours,
+      },
+    };
+    const next = defaultNotificationPreferences();
+
+    const merged = await userPreferencesClient.updateNotifications(
+      USER_ID,
+      current,
+      next
+    );
+
+    expect(merged.notifications).toEqual(next);
+    expect(merged.notifications?.channels.email).toBe(true);
+  });
+
+  it('rethrows when Supabase returns an error', async () => {
+    chain.eq.mockResolvedValueOnce(
+      makeEqResolver({ message: 'timeout' })
+    );
+    await expect(
+      userPreferencesClient.updateNotifications(
+        USER_ID,
+        {},
+        defaultNotificationPreferences()
+      )
+    ).rejects.toBeInstanceOf(UserPreferencesApiError);
+  });
+
+  it('rejects when userId is empty', async () => {
+    await expect(
+      userPreferencesClient.updateNotifications(
+        '',
+        {},
+        defaultNotificationPreferences()
+      )
+    ).rejects.toBeInstanceOf(UserPreferencesApiError);
+  });
+});
+
+describe('UserPreferencesApiError', () => {
+  it('carries statusCode and optional details', () => {
+    const err = new UserPreferencesApiError('boom', 418, { x: 1 });
+    expect(err.message).toBe('boom');
+    expect(err.statusCode).toBe(418);
+    expect(err.details).toEqual({ x: 1 });
+    expect(err.name).toBe('UserPreferencesApiError');
+    expect(err).toBeInstanceOf(Error);
+  });
+});

--- a/apps/web/__tests__/types/user-preferences.test.ts
+++ b/apps/web/__tests__/types/user-preferences.test.ts
@@ -107,6 +107,35 @@ describe('parseNotificationPreferences — legacy flat shape', () => {
     expect(parsed.channels.push).toBe(true);
     expect(parsed.types).toEqual(defaultNotificationTypes());
   });
+
+  it('recognizes legacy shape when only `categories` key is present', () => {
+    // Regression: a legacy payload with only `categories` must not be
+    // misclassified and fall back to full defaults.
+    const parsed = parseNotificationPreferences({ categories: true });
+    // Detected as legacy flat → channels defaulted, quietHours defaulted
+    expect(parsed.channels).toEqual(defaultNotificationChannels());
+    expect(parsed.quietHours).toEqual(defaultQuietHours());
+  });
+});
+
+describe('parseNotificationPreferences — prototype safety', () => {
+  it('ignores inherited `channels` properties (prototype pollution guard)', () => {
+    const polluted = Object.create({
+      channels: { email: false, push: false, inApp: false },
+    });
+    const parsed = parseNotificationPreferences(polluted);
+    // The inherited `channels` must not be treated as a nested shape marker
+    // (own keys absent → defaults returned).
+    expect(parsed).toEqual(defaultNotificationPreferences());
+  });
+
+  it('ignores inherited legacy keys (prototype pollution guard)', () => {
+    const polluted = Object.create({ email: false, budgets: false });
+    const parsed = parseNotificationPreferences(polluted);
+    // Inherited `email`/`budgets` shouldn't flip the shape into legacy mode.
+    expect(parsed.channels.email).toBe(true);
+    expect(parsed.types.budgetAlerts).toBe(true);
+  });
 });
 
 describe('parseNotificationPreferences — nested (current) shape', () => {

--- a/apps/web/__tests__/types/user-preferences.test.ts
+++ b/apps/web/__tests__/types/user-preferences.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Tests for user-preferences types + parse helpers
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  defaultNotificationChannels,
+  defaultNotificationPreferences,
+  defaultNotificationTypes,
+  defaultQuietHours,
+  parseNotificationPreferences,
+} from '../../src/types/user-preferences';
+
+describe('default factories', () => {
+  it('defaultNotificationChannels has all channels enabled', () => {
+    expect(defaultNotificationChannels()).toEqual({
+      email: true,
+      push: true,
+      inApp: true,
+    });
+  });
+
+  it('defaultNotificationTypes has sensible defaults (promos/newFeatures off)', () => {
+    const types = defaultNotificationTypes();
+    expect(types.monthlyReport).toBe(true);
+    expect(types.budgetAlerts).toBe(true);
+    expect(types.aiAdvice).toBe(true);
+    expect(types.investmentUpdates).toBe(true);
+    expect(types.recurringDeadlines).toBe(true);
+    expect(types.goalsAchieved).toBe(true);
+    expect(types.newFeatures).toBe(false);
+    expect(types.promotions).toBe(false);
+  });
+
+  it('defaultQuietHours is disabled by default, 22:00 → 08:00', () => {
+    expect(defaultQuietHours()).toEqual({
+      enabled: false,
+      from: '22:00',
+      to: '08:00',
+    });
+  });
+
+  it('defaultNotificationPreferences composes the three sub-defaults', () => {
+    expect(defaultNotificationPreferences()).toEqual({
+      channels: defaultNotificationChannels(),
+      types: defaultNotificationTypes(),
+      quietHours: defaultQuietHours(),
+    });
+  });
+});
+
+describe('parseNotificationPreferences — invalid / empty input', () => {
+  it('returns defaults for null', () => {
+    expect(parseNotificationPreferences(null)).toEqual(
+      defaultNotificationPreferences()
+    );
+  });
+
+  it('returns defaults for undefined', () => {
+    expect(parseNotificationPreferences(undefined)).toEqual(
+      defaultNotificationPreferences()
+    );
+  });
+
+  it('returns defaults for scalar input', () => {
+    expect(parseNotificationPreferences('hello')).toEqual(
+      defaultNotificationPreferences()
+    );
+    expect(parseNotificationPreferences(42)).toEqual(
+      defaultNotificationPreferences()
+    );
+    expect(parseNotificationPreferences(true)).toEqual(
+      defaultNotificationPreferences()
+    );
+  });
+
+  it('returns defaults for empty object', () => {
+    expect(parseNotificationPreferences({})).toEqual(
+      defaultNotificationPreferences()
+    );
+  });
+});
+
+describe('parseNotificationPreferences — legacy flat shape', () => {
+  it('migrates {email,push,budgets,categories} to nested shape', () => {
+    const parsed = parseNotificationPreferences({
+      email: false,
+      push: false,
+      categories: true,
+      budgets: false,
+    });
+    expect(parsed.channels.email).toBe(false);
+    expect(parsed.channels.push).toBe(false);
+    // inApp not in legacy → falls back to default
+    expect(parsed.channels.inApp).toBe(true);
+    // legacy `budgets` → new `budgetAlerts`
+    expect(parsed.types.budgetAlerts).toBe(false);
+    // `categories` has no slot in new schema; other types remain at defaults
+    expect(parsed.types.monthlyReport).toBe(true);
+    expect(parsed.quietHours).toEqual(defaultQuietHours());
+  });
+
+  it('treats missing legacy booleans as fallback to defaults', () => {
+    // Only `email: false`; others should default
+    const parsed = parseNotificationPreferences({ email: false });
+    expect(parsed.channels.email).toBe(false);
+    expect(parsed.channels.push).toBe(true);
+    expect(parsed.types).toEqual(defaultNotificationTypes());
+  });
+});
+
+describe('parseNotificationPreferences — nested (current) shape', () => {
+  it('round-trips a full valid payload unchanged', () => {
+    const payload = defaultNotificationPreferences();
+    expect(parseNotificationPreferences(payload)).toEqual(payload);
+  });
+
+  it('fills missing sub-keys with defaults', () => {
+    const partial = {
+      channels: { email: false }, // push/inApp missing
+      types: { promotions: true }, // others missing
+      quietHours: { enabled: true }, // from/to missing
+    };
+    const parsed = parseNotificationPreferences(partial);
+    expect(parsed.channels).toEqual({
+      email: false,
+      push: true,
+      inApp: true,
+    });
+    expect(parsed.types.promotions).toBe(true);
+    expect(parsed.types.monthlyReport).toBe(true); // default
+    expect(parsed.quietHours).toEqual({
+      enabled: true,
+      from: '22:00',
+      to: '08:00',
+    });
+  });
+
+  it('rejects malformed time strings (defaults to fallback)', () => {
+    const parsed = parseNotificationPreferences({
+      quietHours: { enabled: true, from: 'not-a-time', to: '25:99' },
+    });
+    expect(parsed.quietHours.from).toBe('22:00');
+    expect(parsed.quietHours.to).toBe('08:00');
+    expect(parsed.quietHours.enabled).toBe(true);
+  });
+
+  it('accepts valid HH:MM boundary values', () => {
+    const parsed = parseNotificationPreferences({
+      quietHours: { from: '00:00', to: '23:59' },
+    });
+    expect(parsed.quietHours.from).toBe('00:00');
+    expect(parsed.quietHours.to).toBe('23:59');
+  });
+
+  it('rejects non-boolean values for flags', () => {
+    const parsed = parseNotificationPreferences({
+      channels: { email: 'yes', push: 1, inApp: null },
+      types: { monthlyReport: 'true' },
+    });
+    expect(parsed.channels.email).toBe(true); // defaulted
+    expect(parsed.channels.push).toBe(true); // defaulted
+    expect(parsed.channels.inApp).toBe(true);
+    expect(parsed.types.monthlyReport).toBe(true); // defaulted
+  });
+
+  it('ignores unknown top-level keys', () => {
+    const parsed = parseNotificationPreferences({
+      channels: { email: false, push: true, inApp: true },
+      types: defaultNotificationTypes(),
+      quietHours: defaultQuietHours(),
+      foo: 'bar',
+      __proto__: { evil: true },
+    });
+    expect(parsed.channels.email).toBe(false);
+    expect((parsed as unknown as Record<string, unknown>).foo).toBeUndefined();
+  });
+});

--- a/apps/web/app/dashboard/settings/page.tsx
+++ b/apps/web/app/dashboard/settings/page.tsx
@@ -70,15 +70,12 @@ type TabKey =
   | 'security'
   | 'data';
 
-interface UserPreferences {
+// Profile-form-owned slice of preferences. Notifications are owned and
+// persisted by <NotificationsTab /> — don't add them here or handleSaveProfile
+// will clobber the nested notifications schema.
+interface ProfileFormPreferences {
   theme?: 'system' | 'dracula' | 'italian';
   language?: string;
-  notifications?: {
-    email?: boolean;
-    push?: boolean;
-    categories?: boolean;
-    budgets?: boolean;
-  };
 }
 
 interface FormData {
@@ -89,7 +86,7 @@ interface FormData {
   bio: string;
   timezone: string;
   currency: string;
-  preferences: UserPreferences;
+  preferences: ProfileFormPreferences;
 }
 
 const TABS: { key: TabKey; label: string }[] = [
@@ -206,7 +203,6 @@ export default function SettingsPage() {
     preferences: {
       theme: 'system',
       language: 'it',
-      notifications: { email: true, push: true, categories: true, budgets: true },
     },
   });
 
@@ -233,7 +229,6 @@ export default function SettingsPage() {
   useEffect(() => {
     if (user) {
       const prefs = user.preferences as Record<string, unknown> | null;
-      const notif = prefs?.notifications as Record<string, boolean> | undefined;
       setFormData({
         firstName: user.firstName || '',
         lastName: user.lastName || '',
@@ -245,12 +240,6 @@ export default function SettingsPage() {
         preferences: {
           theme: (prefs?.theme as Theme) || 'system',
           language: (prefs?.language as string) || 'it',
-          notifications: {
-            email: notif?.email ?? true,
-            push: notif?.push ?? true,
-            categories: notif?.categories ?? true,
-            budgets: notif?.budgets ?? true,
-          },
         },
       });
     }
@@ -277,13 +266,22 @@ export default function SettingsPage() {
     try {
       const supabase = createClient();
 
+      // Merge profile-form prefs with the existing stored preferences so we
+      // preserve keys owned by other tabs (e.g. `notifications` from <NotificationsTab />).
+      const existingPrefs =
+        (user.preferences as Record<string, unknown> | null) ?? {};
+      const mergedPreferences = {
+        ...existingPrefs,
+        ...formData.preferences,
+      };
+
       // Type-safe update with explicit casting to avoid Next.js build type inference issues
       const updateData = {
         first_name: formData.firstName,
         last_name: formData.lastName,
         timezone: formData.timezone,
         currency: formData.currency,
-        preferences: JSON.parse(JSON.stringify(formData.preferences)),
+        preferences: JSON.parse(JSON.stringify(mergedPreferences)),
       };
 
       const { error: profileError } = await (supabase
@@ -298,7 +296,7 @@ export default function SettingsPage() {
         lastName: formData.lastName,
         timezone: formData.timezone,
         currency: formData.currency,
-        preferences: formData.preferences as Record<string, unknown>,
+        preferences: mergedPreferences,
         fullName: `${formData.firstName} ${formData.lastName}`,
       });
       setProfileSaved(true);

--- a/apps/web/app/dashboard/settings/page.tsx
+++ b/apps/web/app/dashboard/settings/page.tsx
@@ -13,6 +13,7 @@ import { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { createClient } from '@/utils/supabase/client';
 import { CategoryManager } from '@/components/categories/CategoryManager';
+import { NotificationsTab } from '@/components/settings/NotificationsTab';
 import {
   User,
   CreditCard,
@@ -36,9 +37,7 @@ import {
   Trash2,
   Key,
   Monitor,
-  Clock,
   Mail,
-  MessageSquare,
   TrendingUp,
   Wallet,
   Sparkles,
@@ -223,9 +222,6 @@ export default function SettingsPage() {
   const [showApiKeys, setShowApiKeys] = useState<Record<string, boolean>>({});
   const [apiKeys, setApiKeys] = useState({ openai: '', anthropic: '', gemini: '', coinbase: '', plaid: '' });
   const [apiKeyFeedback, setApiKeyFeedback] = useState<string | null>(null);
-
-  // Notification state
-  const [notifFeedback, setNotifFeedback] = useState<string | null>(null);
 
   // Security state
   const [securityFeedback, setSecurityFeedback] = useState<string | null>(null);
@@ -885,88 +881,9 @@ export default function SettingsPage() {
       )}
 
       {/* ================================================================= */}
-      {/* Notifications Tab */}
+      {/* Notifications Tab — real persistence to profiles.preferences.notifications */}
       {/* ================================================================= */}
-      {activeTab === 'notifications' && (
-        <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }}>
-          <Card className="p-6 rounded-2xl border-0 shadow-sm">
-            <h3 className="text-lg font-semibold text-foreground mb-6">Canali di Notifica</h3>
-            <div className="space-y-6">
-              {[
-                { icon: Mail, title: 'Notifiche Email', desc: 'Ricevi aggiornamenti via email', defaultOn: true },
-                { icon: Smartphone, title: 'Notifiche Push', desc: 'Ricevi notifiche sul dispositivo', defaultOn: true },
-                { icon: MessageSquare, title: 'Notifiche In-App', desc: "Badge e popup nell'applicazione", defaultOn: true },
-              ].map((item) => (
-                <div key={item.title} className="flex items-center justify-between">
-                  <div className="flex items-center gap-3">
-                    <item.icon className="w-5 h-5 text-muted-foreground" />
-                    <div>
-                      <p className="font-medium text-foreground">{item.title}</p>
-                      <p className="text-sm text-muted-foreground">{item.desc}</p>
-                    </div>
-                  </div>
-                  <input type="checkbox" defaultChecked={item.defaultOn} className={TOGGLE_CLASS} />
-                </div>
-              ))}
-
-              <div className="border-t border-border pt-6">
-                <h4 className="font-medium text-foreground mb-4">Tipologia Notifiche</h4>
-                <div className="space-y-4">
-                  {[
-                    { label: 'Rapporto Mensile AI', desc: 'Analisi mensile delle tue finanze', defaultOn: true },
-                    { label: 'Alert Budget', desc: "Quando superi l'80% di un budget", defaultOn: true },
-                    { label: 'Consigli AI Personalizzati', desc: 'Suggerimenti per ottimizzare', defaultOn: true },
-                    { label: 'Aggiornamenti Investimenti', desc: 'Variazioni significative del portafoglio', defaultOn: true },
-                    { label: 'Scadenze Ricorrenti', desc: 'Promemoria pagamenti in scadenza', defaultOn: true },
-                    { label: 'Obiettivi Raggiunti', desc: 'Celebra i tuoi traguardi', defaultOn: true },
-                    { label: 'Nuove Funzionalità', desc: "Scopri le novità dell'app", defaultOn: false },
-                    { label: 'Promozioni e Offerte', desc: 'Offerte speciali e sconti', defaultOn: false },
-                  ].map((item) => (
-                    <div key={item.label} className="flex items-center justify-between">
-                      <div>
-                        <p className="font-medium text-sm text-foreground">{item.label}</p>
-                        <p className="text-xs text-muted-foreground">{item.desc}</p>
-                      </div>
-                      <input type="checkbox" defaultChecked={item.defaultOn} className={TOGGLE_CLASS} />
-                    </div>
-                  ))}
-                </div>
-              </div>
-
-              <div className="border-t border-border pt-6">
-                <h4 className="font-medium text-foreground mb-4">Orario Silenziamento</h4>
-                <div className="flex items-center gap-4 flex-wrap">
-                  <div className="flex items-center gap-2">
-                    <Clock className="w-4 h-4 text-muted-foreground" />
-                    <Label>Dalle</Label>
-                    <Input type="time" defaultValue="22:00" className="w-32" />
-                  </div>
-                  <span className="text-muted-foreground">&mdash;</span>
-                  <div className="flex items-center gap-2">
-                    <Label>Alle</Label>
-                    <Input type="time" defaultValue="08:00" className="w-32" />
-                  </div>
-                </div>
-              </div>
-
-              <div className="flex justify-end">
-                {notifFeedback ? (
-                  <span className="flex items-center gap-2 text-[13px] text-emerald-600">
-                    <Check className="w-4 h-4" /> {notifFeedback}
-                  </span>
-                ) : (
-                  <Button
-                    onClick={() => showFeedback(setNotifFeedback, 'Preferenze notifiche salvate!')}
-                    className="bg-gradient-to-r from-emerald-500 to-teal-500 hover:from-emerald-600 hover:to-teal-600 text-white border-0"
-                  >
-                    Salva Preferenze
-                  </Button>
-                )}
-              </div>
-            </div>
-          </Card>
-        </motion.div>
-      )}
+      {activeTab === 'notifications' && <NotificationsTab />}
 
       {/* ================================================================= */}
       {/* Integrations Tab */}

--- a/apps/web/src/components/settings/NotificationsTab.tsx
+++ b/apps/web/src/components/settings/NotificationsTab.tsx
@@ -9,7 +9,7 @@
 
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { motion } from 'framer-motion';
 import {
   AlertCircle,
@@ -29,6 +29,7 @@ import { userPreferencesClient } from '@/services/user-preferences.client';
 import {
   defaultNotificationPreferences,
   parseNotificationPreferences,
+  TIME_REGEX,
   type NotificationChannels,
   type NotificationPreferences,
   type NotificationTypes,
@@ -146,6 +147,7 @@ export function NotificationsTab() {
   const [isSaving, setIsSaving] = useState(false);
   const [savedAt, setSavedAt] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const savedResetTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Re-hydrate when the auth user object changes (e.g. session refresh)
   useEffect(() => {
@@ -153,6 +155,16 @@ export function NotificationsTab() {
     setTypes(initial.types);
     setQuietHours(initial.quietHours);
   }, [initial]);
+
+  // Clear any pending "Salvato!" reset timer on unmount
+  useEffect(() => {
+    return () => {
+      if (savedResetTimer.current) {
+        clearTimeout(savedResetTimer.current);
+        savedResetTimer.current = null;
+      }
+    };
+  }, []);
 
   const handleChannelToggle = (key: keyof NotificationChannels) => {
     setChannels((prev) => ({ ...prev, [key]: !prev[key] }));
@@ -175,6 +187,17 @@ export function NotificationsTab() {
       setError('Utente non trovato. Effettua nuovamente il login.');
       return;
     }
+    // Guard against malformed time values before persisting. `<input type="time">`
+    // can emit an empty string, and quietHours could be set programmatically.
+    if (
+      quietHours.enabled &&
+      (!TIME_REGEX.test(quietHours.from) || !TIME_REGEX.test(quietHours.to))
+    ) {
+      setError(
+        'Orari di silenziamento non validi. Usa il formato HH:MM (es. 22:00).'
+      );
+      return;
+    }
     setIsSaving(true);
     setError(null);
     try {
@@ -193,7 +216,13 @@ export function NotificationsTab() {
         preferences: mergedPreferences as unknown as Record<string, unknown>,
       });
       setSavedAt(Date.now());
-      setTimeout(() => setSavedAt(null), 2500);
+      if (savedResetTimer.current) {
+        clearTimeout(savedResetTimer.current);
+      }
+      savedResetTimer.current = setTimeout(() => {
+        setSavedAt(null);
+        savedResetTimer.current = null;
+      }, 2500);
     } catch (err) {
       console.error('Failed to save notification preferences:', err);
       setError(

--- a/apps/web/src/components/settings/NotificationsTab.tsx
+++ b/apps/web/src/components/settings/NotificationsTab.tsx
@@ -1,0 +1,370 @@
+/**
+ * NotificationsTab — Settings > Notifiche tab
+ *
+ * Persists notification preferences (channels, types, quiet hours) to
+ * `profiles.preferences.notifications` JSONB via the user-preferences service.
+ *
+ * @module components/settings/NotificationsTab
+ */
+
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { motion } from 'framer-motion';
+import {
+  AlertCircle,
+  Check,
+  Clock,
+  Loader2,
+  Mail,
+  MessageSquare,
+  Smartphone,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useAuthStore } from '@/store/auth.store';
+import { userPreferencesClient } from '@/services/user-preferences.client';
+import {
+  defaultNotificationPreferences,
+  parseNotificationPreferences,
+  type NotificationChannels,
+  type NotificationPreferences,
+  type NotificationTypes,
+  type QuietHours,
+  type UserPreferences,
+} from '@/types/user-preferences';
+
+// =============================================================================
+// Static definitions (pure — rendered by JSX)
+// =============================================================================
+
+interface ChannelDef {
+  key: keyof NotificationChannels;
+  icon: typeof Mail;
+  title: string;
+  desc: string;
+}
+
+const CHANNELS: ChannelDef[] = [
+  {
+    key: 'email',
+    icon: Mail,
+    title: 'Notifiche Email',
+    desc: 'Ricevi aggiornamenti via email',
+  },
+  {
+    key: 'push',
+    icon: Smartphone,
+    title: 'Notifiche Push',
+    desc: 'Ricevi notifiche sul dispositivo',
+  },
+  {
+    key: 'inApp',
+    icon: MessageSquare,
+    title: 'Notifiche In-App',
+    desc: "Badge e popup nell'applicazione",
+  },
+];
+
+interface TypeDef {
+  key: keyof NotificationTypes;
+  label: string;
+  desc: string;
+}
+
+const TYPES: TypeDef[] = [
+  {
+    key: 'monthlyReport',
+    label: 'Rapporto Mensile AI',
+    desc: 'Analisi mensile delle tue finanze',
+  },
+  {
+    key: 'budgetAlerts',
+    label: 'Alert Budget',
+    desc: "Quando superi l'80% di un budget",
+  },
+  {
+    key: 'aiAdvice',
+    label: 'Consigli AI Personalizzati',
+    desc: 'Suggerimenti per ottimizzare',
+  },
+  {
+    key: 'investmentUpdates',
+    label: 'Aggiornamenti Investimenti',
+    desc: 'Variazioni significative del portafoglio',
+  },
+  {
+    key: 'recurringDeadlines',
+    label: 'Scadenze Ricorrenti',
+    desc: 'Promemoria pagamenti in scadenza',
+  },
+  {
+    key: 'goalsAchieved',
+    label: 'Obiettivi Raggiunti',
+    desc: 'Celebra i tuoi traguardi',
+  },
+  {
+    key: 'newFeatures',
+    label: 'Nuove Funzionalità',
+    desc: "Scopri le novità dell'app",
+  },
+  {
+    key: 'promotions',
+    label: 'Promozioni e Offerte',
+    desc: 'Offerte speciali e sconti',
+  },
+];
+
+const TOGGLE_CLASS =
+  "appearance-none w-10 h-5 bg-muted rounded-full relative cursor-pointer checked:bg-emerald-500 after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:w-4 after:h-4 after:bg-white after:rounded-full after:transition-transform checked:after:translate-x-5";
+
+// =============================================================================
+// Component
+// =============================================================================
+
+export function NotificationsTab() {
+  const { user, setUser } = useAuthStore();
+
+  const initial = useMemo<NotificationPreferences>(
+    () =>
+      user
+        ? parseNotificationPreferences(
+            (user.preferences as Record<string, unknown> | undefined)
+              ?.notifications
+          )
+        : defaultNotificationPreferences(),
+    [user]
+  );
+
+  const [channels, setChannels] = useState<NotificationChannels>(
+    initial.channels
+  );
+  const [types, setTypes] = useState<NotificationTypes>(initial.types);
+  const [quietHours, setQuietHours] = useState<QuietHours>(initial.quietHours);
+  const [isSaving, setIsSaving] = useState(false);
+  const [savedAt, setSavedAt] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Re-hydrate when the auth user object changes (e.g. session refresh)
+  useEffect(() => {
+    setChannels(initial.channels);
+    setTypes(initial.types);
+    setQuietHours(initial.quietHours);
+  }, [initial]);
+
+  const handleChannelToggle = (key: keyof NotificationChannels) => {
+    setChannels((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  const handleTypeToggle = (key: keyof NotificationTypes) => {
+    setTypes((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  const handleQuietToggle = () => {
+    setQuietHours((prev) => ({ ...prev, enabled: !prev.enabled }));
+  };
+
+  const handleQuietTimeChange = (field: 'from' | 'to', value: string) => {
+    setQuietHours((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSave = async () => {
+    if (!user?.id) {
+      setError('Utente non trovato. Effettua nuovamente il login.');
+      return;
+    }
+    setIsSaving(true);
+    setError(null);
+    try {
+      const nextNotifications: NotificationPreferences = {
+        channels,
+        types,
+        quietHours,
+      };
+      const mergedPreferences = await userPreferencesClient.updateNotifications(
+        user.id,
+        user.preferences as UserPreferences | null | undefined,
+        nextNotifications
+      );
+      setUser({
+        ...user,
+        preferences: mergedPreferences as unknown as Record<string, unknown>,
+      });
+      setSavedAt(Date.now());
+      setTimeout(() => setSavedAt(null), 2500);
+    } catch (err) {
+      console.error('Failed to save notification preferences:', err);
+      setError(
+        err instanceof Error
+          ? err.message
+          : 'Impossibile salvare le preferenze notifiche'
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }}>
+      <Card className="p-6 rounded-2xl border-0 shadow-sm">
+        <h3 className="text-lg font-semibold text-foreground mb-6">
+          Canali di Notifica
+        </h3>
+
+        {error && (
+          <div
+            role="alert"
+            className="flex items-center gap-3 p-4 mb-6 bg-rose-500/5 border border-rose-500/10 rounded-2xl"
+          >
+            <AlertCircle className="h-5 w-5 text-rose-500 flex-shrink-0" />
+            <p className="text-[13px] text-rose-600">{error}</p>
+          </div>
+        )}
+
+        <div className="space-y-6">
+          {CHANNELS.map((channel) => {
+            const Icon = channel.icon;
+            const inputId = `notif-channel-${channel.key}`;
+            return (
+              <div
+                key={channel.key}
+                className="flex items-center justify-between"
+              >
+                <div className="flex items-center gap-3">
+                  <Icon className="w-5 h-5 text-muted-foreground" />
+                  <div>
+                    <Label
+                      htmlFor={inputId}
+                      className="font-medium text-foreground"
+                    >
+                      {channel.title}
+                    </Label>
+                    <p className="text-sm text-muted-foreground">
+                      {channel.desc}
+                    </p>
+                  </div>
+                </div>
+                <input
+                  id={inputId}
+                  type="checkbox"
+                  checked={channels[channel.key]}
+                  onChange={() => handleChannelToggle(channel.key)}
+                  className={TOGGLE_CLASS}
+                />
+              </div>
+            );
+          })}
+
+          <div className="border-t border-border pt-6">
+            <h4 className="font-medium text-foreground mb-4">
+              Tipologia Notifiche
+            </h4>
+            <div className="space-y-4">
+              {TYPES.map((type) => {
+                const inputId = `notif-type-${type.key}`;
+                return (
+                  <div
+                    key={type.key}
+                    className="flex items-center justify-between"
+                  >
+                    <div>
+                      <Label
+                        htmlFor={inputId}
+                        className="font-medium text-sm text-foreground"
+                      >
+                        {type.label}
+                      </Label>
+                      <p className="text-xs text-muted-foreground">
+                        {type.desc}
+                      </p>
+                    </div>
+                    <input
+                      id={inputId}
+                      type="checkbox"
+                      checked={types[type.key]}
+                      onChange={() => handleTypeToggle(type.key)}
+                      className={TOGGLE_CLASS}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="border-t border-border pt-6">
+            <div className="flex items-center justify-between mb-4">
+              <div>
+                <h4 className="font-medium text-foreground">
+                  Orario Silenziamento
+                </h4>
+                <p className="text-xs text-muted-foreground">
+                  Sospendi le notifiche in determinate fasce orarie
+                </p>
+              </div>
+              <input
+                id="notif-quiet-enabled"
+                type="checkbox"
+                checked={quietHours.enabled}
+                onChange={handleQuietToggle}
+                className={TOGGLE_CLASS}
+                aria-label="Abilita silenziamento"
+              />
+            </div>
+            <div className="flex items-center gap-4 flex-wrap">
+              <div className="flex items-center gap-2">
+                <Clock className="w-4 h-4 text-muted-foreground" />
+                <Label htmlFor="notif-quiet-from">Dalle</Label>
+                <Input
+                  id="notif-quiet-from"
+                  type="time"
+                  value={quietHours.from}
+                  onChange={(e) =>
+                    handleQuietTimeChange('from', e.target.value)
+                  }
+                  disabled={!quietHours.enabled}
+                  className="w-32"
+                />
+              </div>
+              <span className="text-muted-foreground">&mdash;</span>
+              <div className="flex items-center gap-2">
+                <Label htmlFor="notif-quiet-to">Alle</Label>
+                <Input
+                  id="notif-quiet-to"
+                  type="time"
+                  value={quietHours.to}
+                  onChange={(e) => handleQuietTimeChange('to', e.target.value)}
+                  disabled={!quietHours.enabled}
+                  className="w-32"
+                />
+              </div>
+            </div>
+          </div>
+
+          <div className="flex justify-end">
+            <Button
+              onClick={handleSave}
+              disabled={isSaving}
+              className="bg-gradient-to-r from-emerald-500 to-teal-500 hover:from-emerald-600 hover:to-teal-600 text-white border-0"
+            >
+              {isSaving ? (
+                <>
+                  <Loader2 className="w-4 h-4 mr-2 animate-spin" /> Salvataggio...
+                </>
+              ) : savedAt ? (
+                <>
+                  <Check className="w-4 h-4 mr-2" /> Salvato!
+                </>
+              ) : (
+                'Salva Preferenze'
+              )}
+            </Button>
+          </div>
+        </div>
+      </Card>
+    </motion.div>
+  );
+}
+
+export default NotificationsTab;

--- a/apps/web/src/services/user-preferences.client.ts
+++ b/apps/web/src/services/user-preferences.client.ts
@@ -1,0 +1,105 @@
+/**
+ * User Preferences Client — Supabase
+ *
+ * Persists user preferences (theme, language, notifications) to
+ * `profiles.preferences` JSONB column. RLS enforces user_id = auth.uid().
+ *
+ * @module services/user-preferences.client
+ */
+
+import { createClient } from '@/utils/supabase/client';
+import type {
+  NotificationPreferences,
+  UserPreferences,
+} from '@/types/user-preferences';
+
+// =============================================================================
+// Error class
+// =============================================================================
+
+export class UserPreferencesApiError extends Error {
+  constructor(
+    message: string,
+    public statusCode: number,
+    public details?: unknown
+  ) {
+    super(message);
+    this.name = 'UserPreferencesApiError';
+  }
+}
+
+// =============================================================================
+// Client
+// =============================================================================
+
+type SupabaseLike = {
+  from: (table: string) => {
+    update: (payload: Record<string, unknown>) => {
+      eq: (
+        column: string,
+        value: string
+      ) => Promise<{ error: { message: string } | null }>;
+    };
+  };
+};
+
+async function persistPreferences(
+  userId: string,
+  preferences: UserPreferences
+): Promise<void> {
+  if (!userId) {
+    throw new UserPreferencesApiError('userId is required', 400);
+  }
+
+  const supabase = createClient() as unknown as SupabaseLike;
+
+  // Clone to a plain object — avoids serialization issues with class instances
+  // and matches the Supabase JSONB contract.
+  const payload = JSON.parse(JSON.stringify(preferences)) as Record<
+    string,
+    unknown
+  >;
+
+  const { error } = await supabase
+    .from('profiles')
+    .update({ preferences: payload })
+    .eq('id', userId);
+
+  if (error) {
+    throw new UserPreferencesApiError(
+      error.message || 'Failed to update preferences',
+      500,
+      error
+    );
+  }
+}
+
+export const userPreferencesClient = {
+  /**
+   * Persist the full preferences object. Caller is responsible for merging
+   * with existing values before calling — this replaces the whole JSON column.
+   */
+  async update(userId: string, preferences: UserPreferences): Promise<void> {
+    return persistPreferences(userId, preferences);
+  },
+
+  /**
+   * Convenience: update just the notification slice, preserving the rest.
+   * Callers that already have the full preferences object should prefer
+   * `update()` to save a read round-trip.
+   */
+  async updateNotifications(
+    userId: string,
+    currentPreferences: UserPreferences | null | undefined,
+    notifications: NotificationPreferences
+  ): Promise<UserPreferences> {
+    const merged: UserPreferences = {
+      ...(currentPreferences ?? {}),
+      notifications,
+    };
+    await persistPreferences(userId, merged);
+    return merged;
+  },
+};
+
+export default userPreferencesClient;

--- a/apps/web/src/types/user-preferences.ts
+++ b/apps/web/src/types/user-preferences.ts
@@ -1,0 +1,180 @@
+/**
+ * User Preferences — Shared Types
+ *
+ * Schema for the JSONB `profiles.preferences` column.
+ * Structured nested shape over the legacy flat shape, with a parse helper
+ * that migrates old payloads forward at read time.
+ *
+ * @module types/user-preferences
+ */
+
+export type ThemePreference = 'system' | 'dracula' | 'italian';
+
+export interface NotificationChannels {
+  email: boolean;
+  push: boolean;
+  inApp: boolean;
+}
+
+export interface NotificationTypes {
+  monthlyReport: boolean;
+  budgetAlerts: boolean;
+  aiAdvice: boolean;
+  investmentUpdates: boolean;
+  recurringDeadlines: boolean;
+  goalsAchieved: boolean;
+  newFeatures: boolean;
+  promotions: boolean;
+}
+
+export interface QuietHours {
+  enabled: boolean;
+  /** HH:MM 24h format */
+  from: string;
+  /** HH:MM 24h format */
+  to: string;
+}
+
+export interface NotificationPreferences {
+  channels: NotificationChannels;
+  types: NotificationTypes;
+  quietHours: QuietHours;
+}
+
+export interface UserPreferences {
+  theme?: ThemePreference;
+  language?: string;
+  notifications?: NotificationPreferences;
+}
+
+// =============================================================================
+// Defaults
+// =============================================================================
+
+export function defaultNotificationChannels(): NotificationChannels {
+  return { email: true, push: true, inApp: true };
+}
+
+export function defaultNotificationTypes(): NotificationTypes {
+  return {
+    monthlyReport: true,
+    budgetAlerts: true,
+    aiAdvice: true,
+    investmentUpdates: true,
+    recurringDeadlines: true,
+    goalsAchieved: true,
+    newFeatures: false,
+    promotions: false,
+  };
+}
+
+export function defaultQuietHours(): QuietHours {
+  return { enabled: false, from: '22:00', to: '08:00' };
+}
+
+export function defaultNotificationPreferences(): NotificationPreferences {
+  return {
+    channels: defaultNotificationChannels(),
+    types: defaultNotificationTypes(),
+    quietHours: defaultQuietHours(),
+  };
+}
+
+// =============================================================================
+// Parse / migration helpers
+// =============================================================================
+
+const TIME_REGEX = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+function parseBool(value: unknown, fallback: boolean): boolean {
+  return typeof value === 'boolean' ? value : fallback;
+}
+
+function parseTime(value: unknown, fallback: string): string {
+  return typeof value === 'string' && TIME_REGEX.test(value) ? value : fallback;
+}
+
+/**
+ * Parse a raw preferences.notifications payload into the canonical nested
+ * shape. Accepts:
+ *   - the current nested shape { channels, types, quietHours }
+ *   - the legacy flat shape { email, push, categories, budgets }
+ *   - null / undefined / any invalid input (returns full defaults)
+ *
+ * Unknown keys are ignored. Missing keys use defaults.
+ */
+export function parseNotificationPreferences(
+  raw: unknown
+): NotificationPreferences {
+  const defaults = defaultNotificationPreferences();
+  if (!raw || typeof raw !== 'object') {
+    return defaults;
+  }
+  const source = raw as Record<string, unknown>;
+
+  // Detect legacy flat shape: has `email`/`push` at top-level, no `channels` nested
+  const isLegacyFlat =
+    !('channels' in source) &&
+    ('email' in source || 'push' in source || 'budgets' in source);
+
+  if (isLegacyFlat) {
+    return {
+      channels: {
+        email: parseBool(source.email, defaults.channels.email),
+        push: parseBool(source.push, defaults.channels.push),
+        inApp: defaults.channels.inApp,
+      },
+      types: {
+        ...defaults.types,
+        // map legacy `budgets` → budgetAlerts
+        budgetAlerts: parseBool(source.budgets, defaults.types.budgetAlerts),
+      },
+      quietHours: defaults.quietHours,
+    };
+  }
+
+  const channelsSource = (source.channels ?? {}) as Record<string, unknown>;
+  const typesSource = (source.types ?? {}) as Record<string, unknown>;
+  const quietSource = (source.quietHours ?? {}) as Record<string, unknown>;
+
+  return {
+    channels: {
+      email: parseBool(channelsSource.email, defaults.channels.email),
+      push: parseBool(channelsSource.push, defaults.channels.push),
+      inApp: parseBool(channelsSource.inApp, defaults.channels.inApp),
+    },
+    types: {
+      monthlyReport: parseBool(
+        typesSource.monthlyReport,
+        defaults.types.monthlyReport
+      ),
+      budgetAlerts: parseBool(
+        typesSource.budgetAlerts,
+        defaults.types.budgetAlerts
+      ),
+      aiAdvice: parseBool(typesSource.aiAdvice, defaults.types.aiAdvice),
+      investmentUpdates: parseBool(
+        typesSource.investmentUpdates,
+        defaults.types.investmentUpdates
+      ),
+      recurringDeadlines: parseBool(
+        typesSource.recurringDeadlines,
+        defaults.types.recurringDeadlines
+      ),
+      goalsAchieved: parseBool(
+        typesSource.goalsAchieved,
+        defaults.types.goalsAchieved
+      ),
+      newFeatures: parseBool(
+        typesSource.newFeatures,
+        defaults.types.newFeatures
+      ),
+      promotions: parseBool(typesSource.promotions, defaults.types.promotions),
+    },
+    quietHours: {
+      enabled: parseBool(quietSource.enabled, defaults.quietHours.enabled),
+      from: parseTime(quietSource.from, defaults.quietHours.from),
+      to: parseTime(quietSource.to, defaults.quietHours.to),
+    },
+  };
+}

--- a/apps/web/src/types/user-preferences.ts
+++ b/apps/web/src/types/user-preferences.ts
@@ -84,7 +84,7 @@ export function defaultNotificationPreferences(): NotificationPreferences {
 // Parse / migration helpers
 // =============================================================================
 
-const TIME_REGEX = /^([01]\d|2[0-3]):[0-5]\d$/;
+export const TIME_REGEX = /^([01]\d|2[0-3]):[0-5]\d$/;
 
 function parseBool(value: unknown, fallback: boolean): boolean {
   return typeof value === 'boolean' ? value : fallback;
@@ -92,6 +92,21 @@ function parseBool(value: unknown, fallback: boolean): boolean {
 
 function parseTime(value: unknown, fallback: string): string {
   return typeof value === 'string' && TIME_REGEX.test(value) ? value : fallback;
+}
+
+// Use own-property checks to avoid prototype-pollution influencing parsing.
+function hasOwn(obj: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(obj, key);
+}
+
+function getOwn(obj: Record<string, unknown>, key: string): unknown {
+  return hasOwn(obj, key) ? obj[key] : undefined;
+}
+
+function asOwnObject(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object'
+    ? (value as Record<string, unknown>)
+    : {};
 }
 
 /**
@@ -112,69 +127,90 @@ export function parseNotificationPreferences(
   }
   const source = raw as Record<string, unknown>;
 
-  // Detect legacy flat shape: has `email`/`push` at top-level, no `channels` nested
+  // Detect legacy flat shape: has any documented legacy top-level key, no `channels` nested
   const isLegacyFlat =
-    !('channels' in source) &&
-    ('email' in source || 'push' in source || 'budgets' in source);
+    !hasOwn(source, 'channels') &&
+    (hasOwn(source, 'email') ||
+      hasOwn(source, 'push') ||
+      hasOwn(source, 'categories') ||
+      hasOwn(source, 'budgets'));
 
   if (isLegacyFlat) {
     return {
       channels: {
-        email: parseBool(source.email, defaults.channels.email),
-        push: parseBool(source.push, defaults.channels.push),
+        email: parseBool(getOwn(source, 'email'), defaults.channels.email),
+        push: parseBool(getOwn(source, 'push'), defaults.channels.push),
         inApp: defaults.channels.inApp,
       },
       types: {
         ...defaults.types,
         // map legacy `budgets` → budgetAlerts
-        budgetAlerts: parseBool(source.budgets, defaults.types.budgetAlerts),
+        budgetAlerts: parseBool(
+          getOwn(source, 'budgets'),
+          defaults.types.budgetAlerts
+        ),
       },
       quietHours: defaults.quietHours,
     };
   }
 
-  const channelsSource = (source.channels ?? {}) as Record<string, unknown>;
-  const typesSource = (source.types ?? {}) as Record<string, unknown>;
-  const quietSource = (source.quietHours ?? {}) as Record<string, unknown>;
+  const channelsSource = asOwnObject(getOwn(source, 'channels'));
+  const typesSource = asOwnObject(getOwn(source, 'types'));
+  const quietSource = asOwnObject(getOwn(source, 'quietHours'));
 
   return {
     channels: {
-      email: parseBool(channelsSource.email, defaults.channels.email),
-      push: parseBool(channelsSource.push, defaults.channels.push),
-      inApp: parseBool(channelsSource.inApp, defaults.channels.inApp),
+      email: parseBool(
+        getOwn(channelsSource, 'email'),
+        defaults.channels.email
+      ),
+      push: parseBool(getOwn(channelsSource, 'push'), defaults.channels.push),
+      inApp: parseBool(
+        getOwn(channelsSource, 'inApp'),
+        defaults.channels.inApp
+      ),
     },
     types: {
       monthlyReport: parseBool(
-        typesSource.monthlyReport,
+        getOwn(typesSource, 'monthlyReport'),
         defaults.types.monthlyReport
       ),
       budgetAlerts: parseBool(
-        typesSource.budgetAlerts,
+        getOwn(typesSource, 'budgetAlerts'),
         defaults.types.budgetAlerts
       ),
-      aiAdvice: parseBool(typesSource.aiAdvice, defaults.types.aiAdvice),
+      aiAdvice: parseBool(
+        getOwn(typesSource, 'aiAdvice'),
+        defaults.types.aiAdvice
+      ),
       investmentUpdates: parseBool(
-        typesSource.investmentUpdates,
+        getOwn(typesSource, 'investmentUpdates'),
         defaults.types.investmentUpdates
       ),
       recurringDeadlines: parseBool(
-        typesSource.recurringDeadlines,
+        getOwn(typesSource, 'recurringDeadlines'),
         defaults.types.recurringDeadlines
       ),
       goalsAchieved: parseBool(
-        typesSource.goalsAchieved,
+        getOwn(typesSource, 'goalsAchieved'),
         defaults.types.goalsAchieved
       ),
       newFeatures: parseBool(
-        typesSource.newFeatures,
+        getOwn(typesSource, 'newFeatures'),
         defaults.types.newFeatures
       ),
-      promotions: parseBool(typesSource.promotions, defaults.types.promotions),
+      promotions: parseBool(
+        getOwn(typesSource, 'promotions'),
+        defaults.types.promotions
+      ),
     },
     quietHours: {
-      enabled: parseBool(quietSource.enabled, defaults.quietHours.enabled),
-      from: parseTime(quietSource.from, defaults.quietHours.from),
-      to: parseTime(quietSource.to, defaults.quietHours.to),
+      enabled: parseBool(
+        getOwn(quietSource, 'enabled'),
+        defaults.quietHours.enabled
+      ),
+      from: parseTime(getOwn(quietSource, 'from'), defaults.quietHours.from),
+      to: parseTime(getOwn(quietSource, 'to'), defaults.quietHours.to),
     },
   };
 }


### PR DESCRIPTION
## Sommario

Cabla la tab **Settings → Notifiche** a Supabase: ora ogni toggle di canale (email/push/in-app), ogni tipologia di notifica (8 in totale) e l'orario di silenziamento persistono davvero sulla colonna `profiles.preferences` (JSONB).

**Prima**: tutti i toggle erano `defaultChecked`, il bottone "Salva Preferenze" mostrava solo un messaggio feedback fake e ricaricando la pagina si perdeva tutto.

**Dopo**: la tab è estratta in un componente dedicato `<NotificationsTab />` con un service `userPreferencesClient` che scrive su Supabase tramite RLS. Stato idratato da `user.preferences.notifications` con supporto sia per lo shape nested nuovo sia per lo shape flat legacy (`{email, push, budgets, categories}`) — i payload legacy si auto-migrano al primo save.

## Schema persistito

```ts
notifications: {
  channels: { email, push, inApp }
  types: {
    monthlyReport, budgetAlerts, aiAdvice, investmentUpdates,
    recurringDeadlines, goalsAchieved, newFeatures, promotions
  }
  quietHours: { enabled, from, to } // HH:MM validato
}
```

## Nessuna migrazione DB o RLS richiesta
`profiles.preferences` è già JSONB; la policy RLS di `profiles` permette già all'utente proprietario di aggiornare i propri campi. Il wire è puramente frontend — stesso pattern già usato da `handleSaveProfile` per gli altri campi del profilo.

## Qualità (barra 80% coverage)

Coverage sui file nuovi (v8 reporter):

| File | Stmts | Branches | Funcs | Lines |
|------|-------|----------|-------|-------|
| `src/types/user-preferences.ts` | 100% | 100% | 100% | 100% |
| `src/services/user-preferences.client.ts` | 100% | 100% | 100% | 100% |
| `src/components/settings/NotificationsTab.tsx` | 95.7% | 100% | 83.3% | 97.6% |

- 44 test unit+component aggiunti (18 su `<NotificationsTab />`, 10 sul service, 16 sui type parsers).
- Suite completa: **1428 test passed**, 2 skipped, 0 failed.
- Typecheck pulito, lint 0 errori (3 warning preesistenti su file non toccati).
- Stress coverage per edge cases: null/undefined preferences, legacy flat shape, malformed time strings, non-boolean flag values, prototype-pollution-like keys, unresolved promise for disabled-while-saving, non-Error rejection paths.

## Files changed

- **NEW** `apps/web/src/types/user-preferences.ts` — schema + parse/migration helpers
- **NEW** `apps/web/src/services/user-preferences.client.ts` — Supabase update layer
- **NEW** `apps/web/src/components/settings/NotificationsTab.tsx` — componente estratto
- **MOD** `apps/web/app/dashboard/settings/page.tsx` — sostituito blocco inline (89 righe) con `<NotificationsTab />`
- **NEW** 3 test file (`__tests__/types/`, `__tests__/services/`, `__tests__/components/settings/`)

## Test plan

- [x] `pnpm --filter @money-wise/web test` — 1428 passed
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 errors
- [x] `pnpm --filter @money-wise/web build` — clean build
- [ ] Manuale in browser: `pnpm dev:web` → login → Settings → Notifiche → flip toggle → Salva → reload → stato persistito
- [ ] DB verify: `select preferences->'notifications' from profiles where id='...'` mostra shape nested

## Sprint context

Sprint 1 "Da cartonato a reale" — task 1.1 del todo file `zecca-sprint1-kickoff-2026-04-17.json` nel vault. Next up: 1.2 Sicurezza tab (cambio password).

🤖 Generated with [Claude Code](https://claude.com/claude-code)