### PR TITLE
docs(ci): clarify validate-ci.sh level 8 vs 10 for no-Docker environments

### DIFF
--- a/.github/BRANCH_PROTECTION.md
+++ b/.github/BRANCH_PROTECTION.md
@@ -193,17 +193,16 @@ Active code owners review all changes to their respective areas:
 All developers must run ZERO TOLERANCE validation before pushing:
 
 ```bash
-# Automatic: git push will run this pre-push hook
-# Manual: for testing/validation
+# On machines with Docker + act:
 ./.claude/scripts/validate-ci.sh 10
+
+# On machines without Docker (e.g. Steam Deck):
+./.claude/scripts/validate-ci.sh 8
 ```
 
 **Levels 1-10 Status:**
-- Levels 1-8: Blocking (pre-push)
-- Levels 9-10: Blocking (comprehensive - NEW)
-- Requirements:
-  - act installed (for workflow simulation)
-  - Docker running (for act execution)
+- Levels 1-8: Always run locally (lint, typecheck, tests, yaml/actions syntax)
+- Levels 9-10: Require Docker + `act` — skip locally when unavailable; remote GitHub Actions is the authoritative gate for workflow simulation.
 
 ---
 
@@ -217,8 +216,9 @@ git checkout -b feature/your-feature develop
 
 ### Before Pushing
 ```bash
-# Run ZERO TOLERANCE validation (levels 1-10)
-./.claude/scripts/validate-ci.sh 10
+# Run validation (levels 1-8 always, 9-10 if Docker + act available)
+./.claude/scripts/validate-ci.sh 8    # Steam Deck / no-Docker
+./.claude/scripts/validate-ci.sh 10   # Full simulation
 
 # If all levels pass, safe to push
 git push origin feature/your-feature

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ i18n: next-intl (framework setup, messages in `messages/it.json` and `messages/e
 - Commit format: `type(scope): description` (commitlint enforced)
 - Types: fix, feat, refactor, test, docs, chore, ci, perf, style
 - Pre-commit hooks (Husky): doc governance, actionlint (if workflows staged), lint, typecheck, unit tests
-- Pre-push validation: `./.claude/scripts/validate-ci.sh 10` (all 10 levels must pass)
+- Pre-push validation: `./.claude/scripts/validate-ci.sh 8` on Steam Deck (no Docker → levels 9-10 can't run locally). Use `10` only on machines with Docker + `act` installed. Remote GitHub Actions is the authoritative gate.
 - Protected branches: main, develop, gh-pages, safety/*
 - After push: verify CI with `gh run list --branch [branch] --limit 1`
 
@@ -142,7 +142,7 @@ Banking sync via SaltEdge is implemented but **disabled by default** (`BANKING_I
 
 - Run `/resume-work` at session start to restore previous context
 - Run `./.claude/scripts/init-session.sh` to verify environment
-- Run `./.claude/scripts/validate-ci.sh 10` before any push (all levels must pass)
+- Run `./.claude/scripts/validate-ci.sh 8` before any push on Steam Deck (levels 1-8 cover lint/typecheck/tests/yaml/actions-syntax). Levels 9-10 require Docker + `act` and are validated in remote CI.
 - Never claim CI success without verifying via `gh run view`
 - Failed pipelines block all further work until fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -309,7 +309,7 @@ describe('Auth API (Integration)', () => {
 | Port 3000 already in use | Kill process: `lsof -ti:3000 \| xargs kill -9` |
 | TypeScript errors after pull | Clean and reinstall: `rm -rf node_modules && pnpm install` |
 | Tests fail locally but pass in CI | Check Node version matches CI (22.x): `node --version` |
-| Git pre-commit hook fails | Run validation manually: `./.claude/scripts/validate-ci.sh 10` |
+| Git pre-commit hook fails | Run validation manually: `./.claude/scripts/validate-ci.sh 8` (or `10` if Docker + `act` are installed) |
 
 ### Development Workflow Issues
 

--- a/docs/planning/claude-code-usage-strategy.md
+++ b/docs/planning/claude-code-usage-strategy.md
@@ -194,7 +194,7 @@ A partire da Phase 1, il sistema epic aggiunge valore reale:
 1. **Diff-first**: `git diff --stat` poi `git diff` dopo ogni sessione. Più efficiente che leggere file interi
 2. **RLS è il confine di sicurezza**: Ogni policy DEVE avere un test esplicito: "User A può vedere dati di User B?" → scrivi come asserzioni SQL via `execute_sql`. Non fidarti senza test
 3. **Esegui l'app**: Dopo ogni service file migrato → `pnpm dev:web` → click-through manuale della feature. I test unitari verificano correttezza del codice, non correttezza della feature
-4. **Sfrutta la CI**: esegui spesso `./.claude/scripts/validate-ci.sh 8` (controllo rapido, senza Docker) dopo ogni 2-3 sessioni, ma **prima di ogni push** esegui sempre `./.claude/scripts/validate-ci.sh 10`
+4. **Sfrutta la CI**: esegui spesso `./.claude/scripts/validate-ci.sh 8` (controllo rapido, senza Docker) dopo ogni 2-3 sessioni. Su Steam Deck (senza Docker) fermati al livello 8 e lascia che la CI remota validi i livelli 9-10; su macchine con Docker + `act` installati usa `./.claude/scripts/validate-ci.sh 10` prima di ogni push
 
 ### Plan mode vs esecuzione diretta
 

--- a/docs/testing/TESTING-STRATEGY-ASSESSMENT.md
+++ b/docs/testing/TESTING-STRATEGY-ASSESSMENT.md
@@ -459,7 +459,8 @@ Level 1-8:  Linting, types, tests, integration
 Level 9-10: Workflow simulation with `act` (requires Docker)
 
 # Usage:
-./.claude/scripts/validate-ci.sh 10
+./.claude/scripts/validate-ci.sh 8    # Without Docker (e.g. Steam Deck)
+./.claude/scripts/validate-ci.sh 10   # Full (requires Docker + act)
 ```
 
 **Git Hooks**:


### PR DESCRIPTION
## Summary
- Realigns docs with the fact that `validate-ci.sh` levels 9-10 need Docker + `act`, which aren't available on Steam Deck.
- Documents `validate-ci.sh 8` as the no-Docker pre-push baseline; `10` stays as the full option on machines with the toolchain installed.
- Remote GitHub Actions remains the authoritative CI gate.

## Files touched
- `CLAUDE.md` — Git Workflow + Session & CI Discipline sections
- `CONTRIBUTING.md` — troubleshooting table
- `.github/BRANCH_PROTECTION.md` — pre-push block + "Before Pushing" block
- `docs/planning/claude-code-usage-strategy.md` — review guidance
- `docs/testing/TESTING-STRATEGY-ASSESSMENT.md` — usage example

Historical reports under `docs/archive/` and `docs/development/` (CI-CD-*, PHASE-*, SECURITY_*, TRAIL-*) were intentionally left untouched — they describe past states, not current guidance.

## Test plan
- [x] Pre-commit hook green (lint, typecheck, doc-governance, commitlint)
- [ ] Remote CI pipeline green on this branch
- [ ] Manual review of diff to confirm no operational docs still prescribe only `10`

🤖 Generated with [Claude Code](https://claude.com/claude-code)