### PR TITLE
feat(onboarding): gate first-access dashboard behind OnboardingWizard

### DIFF
--- a/apps/web/__tests__/components/onboarding/onboarding-gate.test.tsx
+++ b/apps/web/__tests__/components/onboarding/onboarding-gate.test.tsx
@@ -1,0 +1,206 @@
+/**
+ * Tests for OnboardingGate.
+ *
+ * Strategy: mock the underlying auth store + OnboardingWizard + service so we
+ * can assert the gate's branching and submission flow without rendering the
+ * real multi-step wizard or touching Supabase.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import type { User } from '../../../lib/auth';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks (vi.mock runs before imports, so shared state must be hoisted)
+// ---------------------------------------------------------------------------
+
+const mocks = vi.hoisted(() => ({
+  completeOnboardingMock: vi.fn(),
+  setUserMock: vi.fn(),
+  storeState: { user: null as unknown, setUser: null as unknown as (u: unknown) => void },
+}));
+
+vi.mock('../../../src/store/auth.store', () => ({
+  useAuthStore: () => mocks.storeState,
+}));
+
+vi.mock('../../../src/services/onboarding.client', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../../src/services/onboarding.client')
+  >('../../../src/services/onboarding.client');
+  return {
+    ...actual,
+    onboardingClient: {
+      completeOnboarding: mocks.completeOnboardingMock,
+    },
+  };
+});
+
+// Replace the wizard with a stub that exposes a button to trigger onComplete.
+vi.mock('../../../src/components/onboarding/OnboardingWizard', () => ({
+  OnboardingWizard: (props: {
+    userName: string;
+    onComplete: (data: unknown) => void;
+  }) => (
+    <div data-testid="wizard-stub">
+      <p>Ciao {props.userName}</p>
+      <button
+        type="button"
+        onClick={() =>
+          props.onComplete({
+            incomeRange: '1500-3000',
+            savingsGoal: 'emergency-fund',
+            goals: ['safety-net'],
+            aiPreferences: ['auto-categorize'],
+          })
+        }
+      >
+        finish-wizard
+      </button>
+    </div>
+  ),
+}));
+
+import { OnboardingGate } from '../../../src/components/onboarding/onboarding-gate';
+import { OnboardingApiError } from '../../../src/services/onboarding.client';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    id: 'user-1',
+    email: 'u@example.com',
+    firstName: 'Mario',
+    lastName: 'Rossi',
+    role: 'ADMIN',
+    status: 'ACTIVE',
+    currency: 'EUR',
+    onboarded: false,
+    createdAt: '2026-04-17T00:00:00Z',
+    updatedAt: '2026-04-17T00:00:00Z',
+    fullName: 'Mario Rossi',
+    isEmailVerified: true,
+    isActive: true,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('OnboardingGate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.storeState.user = null;
+    mocks.storeState.setUser = mocks.setUserMock;
+  });
+
+  it('renders children when user is null (auth still loading)', () => {
+    mocks.storeState.user = null;
+    render(
+      <OnboardingGate>
+        <div data-testid="dashboard">Dashboard</div>
+      </OnboardingGate>
+    );
+    expect(screen.getByTestId('dashboard')).toBeInTheDocument();
+    expect(screen.queryByTestId('wizard-stub')).not.toBeInTheDocument();
+  });
+
+  it('renders children when user is already onboarded', () => {
+    mocks.storeState.user = makeUser({ onboarded: true });
+    render(
+      <OnboardingGate>
+        <div data-testid="dashboard">Dashboard</div>
+      </OnboardingGate>
+    );
+    expect(screen.getByTestId('dashboard')).toBeInTheDocument();
+    expect(screen.queryByTestId('wizard-stub')).not.toBeInTheDocument();
+  });
+
+  it('renders the wizard (not children) when user is not onboarded', () => {
+    mocks.storeState.user = makeUser({ onboarded: false });
+    render(
+      <OnboardingGate>
+        <div data-testid="dashboard">Dashboard</div>
+      </OnboardingGate>
+    );
+    expect(screen.getByTestId('wizard-stub')).toBeInTheDocument();
+    expect(screen.queryByTestId('dashboard')).not.toBeInTheDocument();
+  });
+
+  it('passes firstName to the wizard as userName', () => {
+    mocks.storeState.user = makeUser({ firstName: 'Giulia', onboarded: false });
+    render(<OnboardingGate>{null}</OnboardingGate>);
+    expect(screen.getByText(/Ciao Giulia/)).toBeInTheDocument();
+  });
+
+  it('falls back to fullName when firstName is empty', () => {
+    mocks.storeState.user = makeUser({
+      firstName: '',
+      fullName: 'Utente Anonimo',
+      onboarded: false,
+    });
+    render(<OnboardingGate>{null}</OnboardingGate>);
+    expect(screen.getByText(/Ciao Utente Anonimo/)).toBeInTheDocument();
+  });
+
+  it('persists onboarding and marks the user onboarded on success', async () => {
+    mocks.completeOnboardingMock.mockResolvedValueOnce({
+      incomeRange: '1500-3000',
+      savingsGoal: 'emergency-fund',
+      goals: ['safety-net'],
+      aiPreferences: ['auto-categorize'],
+      completedAt: '2026-04-17T06:00:00.000Z',
+    });
+    mocks.storeState.user = makeUser({ onboarded: false });
+
+    render(<OnboardingGate>{null}</OnboardingGate>);
+    await userEvent.click(screen.getByText('finish-wizard'));
+
+    await waitFor(() => {
+      expect(mocks.completeOnboardingMock).toHaveBeenCalledWith(
+        'user-1',
+        expect.objectContaining({ incomeRange: '1500-3000' })
+      );
+    });
+
+    expect(mocks.setUserMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'user-1', onboarded: true })
+    );
+  });
+
+  it('shows an error message when persistence fails (OnboardingApiError)', async () => {
+    mocks.completeOnboardingMock.mockRejectedValueOnce(
+      new OnboardingApiError('salvataggio fallito', 500)
+    );
+    mocks.storeState.user = makeUser({ onboarded: false });
+
+    render(<OnboardingGate>{null}</OnboardingGate>);
+    await userEvent.click(screen.getByText('finish-wizard'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('salvataggio fallito');
+    });
+    expect(mocks.setUserMock).not.toHaveBeenCalled();
+  });
+
+  it('shows a generic message for non-OnboardingApiError failures', async () => {
+    mocks.completeOnboardingMock.mockRejectedValueOnce(new Error('network down'));
+    mocks.storeState.user = makeUser({ onboarded: false });
+
+    render(<OnboardingGate>{null}</OnboardingGate>);
+    await userEvent.click(screen.getByText('finish-wizard'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        /Impossibile salvare le preferenze/
+      );
+    });
+    expect(mocks.setUserMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/__tests__/services/onboarding.client.test.ts
+++ b/apps/web/__tests__/services/onboarding.client.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Tests for onboarding.client.
+ *
+ * Mocks the Supabase client with two chains:
+ *   from('profiles').select('preferences').eq('id', id).single() → read
+ *   from('profiles').update(payload).eq('id', id)                → write
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+type SelectChain = {
+  select: ReturnType<typeof vi.fn>;
+  eq: ReturnType<typeof vi.fn>;
+  single: ReturnType<typeof vi.fn>;
+};
+
+type UpdateChain = {
+  update: ReturnType<typeof vi.fn>;
+  eq: ReturnType<typeof vi.fn>;
+};
+
+const selectChain: SelectChain = {
+  select: vi.fn(),
+  eq: vi.fn(),
+  single: vi.fn(),
+};
+
+const updateChain: UpdateChain = {
+  update: vi.fn(),
+  eq: vi.fn(),
+};
+
+const fromMock = vi.fn();
+
+vi.mock('../../src/utils/supabase/client', () => ({
+  createClient: vi.fn(() => ({ from: fromMock })),
+}));
+
+import {
+  onboardingClient,
+  OnboardingApiError,
+} from '../../src/services/onboarding.client';
+import type { OnboardingData } from '../../src/types/onboarding';
+
+const USER_ID = '550e8400-e29b-41d4-a716-446655440000';
+
+const ONBOARDING: OnboardingData = {
+  incomeRange: '1500-3000',
+  savingsGoal: 'emergency-fund',
+  goals: ['safety-net'],
+  aiPreferences: ['auto-categorize'],
+};
+
+function primeSupabase(opts: {
+  existingPreferences?: Record<string, unknown> | null;
+  selectError?: { message: string } | null;
+  updateError?: { message: string } | null;
+}) {
+  const {
+    existingPreferences = null,
+    selectError = null,
+    updateError = null,
+  } = opts;
+
+  selectChain.single.mockResolvedValue({
+    data: existingPreferences === null
+      ? null
+      : { preferences: existingPreferences },
+    error: selectError,
+  });
+  selectChain.eq.mockReturnValue({ single: selectChain.single });
+  selectChain.select.mockReturnValue({ eq: selectChain.eq });
+
+  updateChain.eq.mockResolvedValue({ error: updateError });
+  updateChain.update.mockReturnValue({ eq: updateChain.eq });
+
+  fromMock.mockReset();
+  fromMock.mockImplementation(() => ({
+    select: selectChain.select,
+    update: updateChain.update,
+  }));
+}
+
+describe('onboardingClient.completeOnboarding', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    selectChain.select.mockReset();
+    selectChain.eq.mockReset();
+    selectChain.single.mockReset();
+    updateChain.update.mockReset();
+    updateChain.eq.mockReset();
+  });
+
+  it('rejects when userId is empty', async () => {
+    primeSupabase({});
+    await expect(
+      onboardingClient.completeOnboarding('', ONBOARDING)
+    ).rejects.toBeInstanceOf(OnboardingApiError);
+    expect(fromMock).not.toHaveBeenCalled();
+  });
+
+  it('writes onboarded=true and merges onboarding into preferences', async () => {
+    primeSupabase({ existingPreferences: { theme: 'dracula', notifications: { channels: { email: true } } } });
+
+    const result = await onboardingClient.completeOnboarding(USER_ID, ONBOARDING);
+
+    expect(selectChain.select).toHaveBeenCalledWith('preferences');
+    expect(selectChain.eq).toHaveBeenCalledWith('id', USER_ID);
+
+    const updatePayload = updateChain.update.mock.calls[0][0];
+    expect(updatePayload.onboarded).toBe(true);
+    expect(updatePayload.preferences.theme).toBe('dracula');
+    expect(updatePayload.preferences.notifications.channels.email).toBe(true);
+    expect(updatePayload.preferences.onboarding).toMatchObject(ONBOARDING);
+    expect(updatePayload.preferences.onboarding.completedAt).toEqual(
+      expect.any(String)
+    );
+    expect(updateChain.eq).toHaveBeenCalledWith('id', USER_ID);
+
+    // Return value echoes what was persisted under onboarding
+    expect(result).toMatchObject(ONBOARDING);
+    expect(result.completedAt).toEqual(expect.any(String));
+  });
+
+  it('treats null/empty existing preferences as {} and still writes onboarding', async () => {
+    primeSupabase({ existingPreferences: null });
+
+    await onboardingClient.completeOnboarding(USER_ID, ONBOARDING);
+
+    const updatePayload = updateChain.update.mock.calls[0][0];
+    expect(Object.keys(updatePayload.preferences)).toEqual(['onboarding']);
+    expect(updatePayload.onboarded).toBe(true);
+  });
+
+  it('wraps SELECT error in OnboardingApiError', async () => {
+    primeSupabase({
+      selectError: { message: 'RLS violation on SELECT' },
+    });
+
+    await expect(
+      onboardingClient.completeOnboarding(USER_ID, ONBOARDING)
+    ).rejects.toMatchObject({
+      name: 'OnboardingApiError',
+      statusCode: 500,
+      message: expect.stringContaining('RLS violation'),
+    });
+    expect(updateChain.update).not.toHaveBeenCalled();
+  });
+
+  it('wraps UPDATE error in OnboardingApiError', async () => {
+    primeSupabase({
+      existingPreferences: {},
+      updateError: { message: 'update failed' },
+    });
+
+    await expect(
+      onboardingClient.completeOnboarding(USER_ID, ONBOARDING)
+    ).rejects.toMatchObject({
+      name: 'OnboardingApiError',
+      statusCode: 500,
+      message: expect.stringContaining('update failed'),
+    });
+  });
+
+  it('uses fallback messages when Supabase errors lack .message', async () => {
+    primeSupabase({ selectError: { message: '' } as { message: string } });
+    await expect(
+      onboardingClient.completeOnboarding(USER_ID, ONBOARDING)
+    ).rejects.toMatchObject({
+      message: 'Failed to read profile preferences',
+    });
+
+    primeSupabase({
+      existingPreferences: {},
+      updateError: { message: '' } as { message: string },
+    });
+    await expect(
+      onboardingClient.completeOnboarding(USER_ID, ONBOARDING)
+    ).rejects.toMatchObject({
+      message: 'Failed to persist onboarding',
+    });
+  });
+
+  it('handles non-object preferences in DB by treating them as empty', async () => {
+    // Simulate a broken row with preferences being a scalar / array
+    primeSupabase({ existingPreferences: 'legacy-string' as unknown as Record<string, unknown> });
+
+    await onboardingClient.completeOnboarding(USER_ID, ONBOARDING);
+    const updatePayload = updateChain.update.mock.calls[0][0];
+    expect(updatePayload.preferences).toEqual(
+      expect.objectContaining({ onboarding: expect.objectContaining(ONBOARDING) })
+    );
+    // The "legacy-string" scalar does not leak into the merged object
+    expect(updatePayload.preferences.theme).toBeUndefined();
+  });
+});
+
+describe('OnboardingApiError', () => {
+  it('carries statusCode and optional details', () => {
+    const err = new OnboardingApiError('boom', 418, { x: 1 });
+    expect(err.message).toBe('boom');
+    expect(err.statusCode).toBe(418);
+    expect(err.details).toEqual({ x: 1 });
+    expect(err.name).toBe('OnboardingApiError');
+    expect(err).toBeInstanceOf(Error);
+  });
+});

--- a/apps/web/__tests__/types/onboarding.test.ts
+++ b/apps/web/__tests__/types/onboarding.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Tests for onboarding type helpers.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseOnboardingPayload } from '../../src/types/onboarding';
+
+describe('parseOnboardingPayload', () => {
+  it('returns null for null / undefined / primitive input', () => {
+    expect(parseOnboardingPayload(null)).toBeNull();
+    expect(parseOnboardingPayload(undefined)).toBeNull();
+    expect(parseOnboardingPayload('payload')).toBeNull();
+    expect(parseOnboardingPayload(42)).toBeNull();
+    expect(parseOnboardingPayload(false)).toBeNull();
+  });
+
+  it('returns null when completedAt is missing', () => {
+    expect(
+      parseOnboardingPayload({
+        incomeRange: '1500-3000',
+        savingsGoal: 'house',
+        goals: ['home', 'retire'],
+        aiPreferences: ['auto-categorize'],
+      })
+    ).toBeNull();
+  });
+
+  it('parses a well-formed payload', () => {
+    const raw = {
+      incomeRange: '3000-5000',
+      savingsGoal: 'emergency-fund',
+      goals: ['safety-net', 'travel'],
+      aiPreferences: ['auto-categorize', 'monthly-insights'],
+      completedAt: '2026-04-17T06:00:00.000Z',
+    };
+    expect(parseOnboardingPayload(raw)).toEqual(raw);
+  });
+
+  it('coerces missing string fields to empty string', () => {
+    const parsed = parseOnboardingPayload({
+      completedAt: '2026-04-17T06:00:00.000Z',
+    });
+    expect(parsed).toEqual({
+      incomeRange: '',
+      savingsGoal: '',
+      goals: [],
+      aiPreferences: [],
+      completedAt: '2026-04-17T06:00:00.000Z',
+    });
+  });
+
+  it('filters out non-string array entries', () => {
+    const parsed = parseOnboardingPayload({
+      incomeRange: 'under-1500',
+      savingsGoal: 'house',
+      goals: ['home', 42, null, 'retire', { nested: true }],
+      aiPreferences: [true, 'auto-categorize', 0],
+      completedAt: '2026-04-17T06:00:00.000Z',
+    });
+    expect(parsed?.goals).toEqual(['home', 'retire']);
+    expect(parsed?.aiPreferences).toEqual(['auto-categorize']);
+  });
+
+  it('ignores unknown keys without throwing', () => {
+    const parsed = parseOnboardingPayload({
+      incomeRange: 'over-5000',
+      savingsGoal: 'retire',
+      goals: ['retire'],
+      aiPreferences: [],
+      completedAt: '2026-04-17T06:00:00.000Z',
+      wizardVersion: 2,
+      extraSurvey: { foo: 'bar' },
+    });
+    expect(parsed).toEqual({
+      incomeRange: 'over-5000',
+      savingsGoal: 'retire',
+      goals: ['retire'],
+      aiPreferences: [],
+      completedAt: '2026-04-17T06:00:00.000Z',
+    });
+  });
+});

--- a/apps/web/app/dashboard/layout.tsx
+++ b/apps/web/app/dashboard/layout.tsx
@@ -4,6 +4,7 @@ import { ReactNode } from 'react';
 import { ProtectedRoute } from '@/components/auth/protected-route';
 import { DashboardLayout } from '@/components/layout/dashboard-layout';
 import { CommandPalette } from '@/components/dashboard/CommandPalette';
+import { OnboardingGate } from '@/components/onboarding/onboarding-gate';
 
 export default function DashboardRootLayout({
   children,
@@ -12,8 +13,10 @@ export default function DashboardRootLayout({
 }) {
   return (
     <ProtectedRoute>
-      <DashboardLayout>{children}</DashboardLayout>
-      <CommandPalette />
+      <OnboardingGate>
+        <DashboardLayout>{children}</DashboardLayout>
+        <CommandPalette />
+      </OnboardingGate>
     </ProtectedRoute>
   );
 }

--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -23,6 +23,7 @@ export interface User {
   timezone?: string | null
   currency: string
   preferences?: Record<string, unknown> | null
+  onboarded: boolean
   lastLoginAt?: string | null
   createdAt: string
   updatedAt: string
@@ -55,6 +56,7 @@ function profileToUser(profile: ProfileRow, email: string, emailConfirmedAt?: st
     timezone: profile.timezone,
     currency: profile.currency,
     preferences: profile.preferences as Record<string, unknown> | null,
+    onboarded: profile.onboarded,
     lastLoginAt: profile.last_login_at,
     createdAt: profile.created_at,
     updatedAt: profile.updated_at,
@@ -115,6 +117,7 @@ export const authService = {
           role: 'ADMIN',
           status: 'ACTIVE',
           currency: 'EUR',
+          onboarded: false,
           createdAt: data.user.created_at,
           updatedAt: data.user.created_at,
           fullName: `${credentials.firstName} ${credentials.lastName}`,

--- a/apps/web/src/components/onboarding/onboarding-gate.tsx
+++ b/apps/web/src/components/onboarding/onboarding-gate.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+/**
+ * OnboardingGate
+ *
+ * Renders between ProtectedRoute and the dashboard: if the authenticated
+ * user's `profiles.onboarded` flag is false, it shows the OnboardingWizard
+ * fullscreen instead of the children. When the wizard completes, the gate
+ * persists the result, marks the user onboarded in the auth store, and
+ * reveals the dashboard. Already-onboarded users pass through immediately.
+ *
+ * Defensively tolerant of an uninitialized user (still loading from the
+ * store): in that case it renders children — ProtectedRoute is the layer
+ * responsible for auth loading UX.
+ */
+
+import { ReactNode, useState } from 'react';
+import { useAuthStore } from '@/store/auth.store';
+import { OnboardingWizard } from '@/components/onboarding/OnboardingWizard';
+import type { OnboardingData } from '@/types/onboarding';
+import { onboardingClient, OnboardingApiError } from '@/services/onboarding.client';
+
+interface OnboardingGateProps {
+  children: ReactNode;
+}
+
+export function OnboardingGate({ children }: OnboardingGateProps) {
+  const { user, setUser } = useAuthStore();
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // No user yet (auth store still hydrating) — defer to ProtectedRoute loader.
+  if (!user) {
+    return <>{children}</>;
+  }
+
+  if (user.onboarded) {
+    return <>{children}</>;
+  }
+
+  const handleComplete = async (data: OnboardingData) => {
+    if (submitting) return;
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      await onboardingClient.completeOnboarding(user.id, data);
+      setUser({ ...user, onboarded: true });
+    } catch (err) {
+      const msg =
+        err instanceof OnboardingApiError
+          ? err.message
+          : 'Impossibile salvare le preferenze di onboarding. Riprova.';
+      setError(msg);
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="relative min-h-screen">
+      <OnboardingWizard
+        userName={user.firstName || user.fullName || 'utente'}
+        onComplete={handleComplete}
+      />
+      {error && (
+        <div
+          role="alert"
+          className="fixed bottom-6 left-1/2 z-50 -translate-x-1/2 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800 shadow-lg dark:border-red-900 dark:bg-red-950 dark:text-red-200"
+        >
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default OnboardingGate;

--- a/apps/web/src/services/onboarding.client.ts
+++ b/apps/web/src/services/onboarding.client.ts
@@ -1,0 +1,128 @@
+/**
+ * Onboarding Client — Supabase
+ *
+ * Persists OnboardingWizard completion to the `profiles` table.
+ * Atomic update: merges the new `onboarding` slice into `preferences` JSONB
+ * and flips `onboarded = true` in the same UPDATE statement, so a page
+ * refresh between the two steps cannot leave the user in a half-onboarded
+ * state.
+ *
+ * Caller responsibility: none. The service reads current preferences itself
+ * to preserve unrelated keys (e.g. `notifications` from the Settings tab).
+ *
+ * @module services/onboarding.client
+ */
+
+import { createClient } from '@/utils/supabase/client';
+import type { OnboardingData, OnboardingPayload } from '@/types/onboarding';
+
+// =============================================================================
+// Error class
+// =============================================================================
+
+export class OnboardingApiError extends Error {
+  constructor(
+    message: string,
+    public statusCode: number,
+    public details?: unknown
+  ) {
+    super(message);
+    this.name = 'OnboardingApiError';
+  }
+}
+
+// =============================================================================
+// Client
+// =============================================================================
+
+type SelectResult = Promise<{
+  data: { preferences: Record<string, unknown> | null } | null;
+  error: { message: string } | null;
+}>;
+
+type UpdateResult = Promise<{ error: { message: string } | null }>;
+
+type SupabaseLike = {
+  from: (table: string) => {
+    select: (columns: string) => {
+      eq: (column: string, value: string) => {
+        single: () => SelectResult;
+      };
+    };
+    update: (payload: Record<string, unknown>) => {
+      eq: (column: string, value: string) => UpdateResult;
+    };
+  };
+};
+
+async function readCurrentPreferences(
+  client: SupabaseLike,
+  userId: string
+): Promise<Record<string, unknown>> {
+  const { data, error } = await client
+    .from('profiles')
+    .select('preferences')
+    .eq('id', userId)
+    .single();
+
+  if (error) {
+    throw new OnboardingApiError(
+      error.message || 'Failed to read profile preferences',
+      500,
+      error
+    );
+  }
+
+  const raw = data?.preferences;
+  if (!raw || typeof raw !== 'object') return {};
+  return raw as Record<string, unknown>;
+}
+
+export const onboardingClient = {
+  /**
+   * Persist the OnboardingWizard result. Sets `profiles.onboarded = true` and
+   * merges `{ onboarding: { ...data, completedAt } }` into `preferences`,
+   * preserving all other keys in that JSONB column.
+   *
+   * @throws {OnboardingApiError} on validation or Supabase failure.
+   */
+  async completeOnboarding(
+    userId: string,
+    data: OnboardingData
+  ): Promise<OnboardingPayload> {
+    if (!userId) {
+      throw new OnboardingApiError('userId is required', 400);
+    }
+
+    const supabase = createClient() as unknown as SupabaseLike;
+
+    const existing = await readCurrentPreferences(supabase, userId);
+
+    const payload: OnboardingPayload = {
+      ...data,
+      completedAt: new Date().toISOString(),
+    };
+
+    const merged = {
+      ...existing,
+      onboarding: JSON.parse(JSON.stringify(payload)) as Record<string, unknown>,
+    };
+
+    const { error } = await supabase
+      .from('profiles')
+      .update({ preferences: merged, onboarded: true })
+      .eq('id', userId);
+
+    if (error) {
+      throw new OnboardingApiError(
+        error.message || 'Failed to persist onboarding',
+        500,
+        error
+      );
+    }
+
+    return payload;
+  },
+};
+
+export default onboardingClient;

--- a/apps/web/src/types/onboarding.ts
+++ b/apps/web/src/types/onboarding.ts
@@ -1,0 +1,75 @@
+/**
+ * Onboarding — Shared Types
+ *
+ * Schema for the `profiles.preferences.onboarding` JSON slice, persisted by
+ * the OnboardingWizard on first-access completion. Standalone from the
+ * broader user-preferences type on purpose: the wizard flow is orthogonal to
+ * settings/preferences and may ship before that type system lands on main.
+ *
+ * @module types/onboarding
+ */
+
+export interface OnboardingData {
+  /**
+   * Income bracket picked in the wizard, free-form token (e.g. "under-1500",
+   * "1500-3000", "3000-5000", "5000-plus"). No amount validation here — the
+   * wizard owns the bracket vocabulary.
+   */
+  incomeRange: string;
+  /**
+   * Savings goal bracket token (e.g. "emergency-fund", "house", "travel").
+   */
+  savingsGoal: string;
+  /** Free-form list of goal tokens chosen in step 3. */
+  goals: string[];
+  /** AI feature opt-ins (e.g. ["auto-categorize", "monthly-insights"]). */
+  aiPreferences: string[];
+}
+
+/**
+ * What we actually persist under `profiles.preferences.onboarding`:
+ * the OnboardingData plus a completion timestamp for audit/retention.
+ */
+export interface OnboardingPayload extends OnboardingData {
+  completedAt: string;
+}
+
+// =============================================================================
+// Parse helpers
+// =============================================================================
+
+function parseStringField(value: unknown, fallback: string): string {
+  return typeof value === 'string' ? value : fallback;
+}
+
+function parseStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((v): v is string => typeof v === 'string');
+}
+
+/**
+ * Parse a raw `preferences.onboarding` JSON value into the canonical shape.
+ * Returns `null` if the payload is absent or unrecognizable — callers treat
+ * that as "not onboarded yet" regardless of the DB flag.
+ */
+export function parseOnboardingPayload(raw: unknown): OnboardingPayload | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const source = raw as Record<string, unknown>;
+
+  const incomeRange = parseStringField(source.incomeRange, '');
+  const savingsGoal = parseStringField(source.savingsGoal, '');
+  const goals = parseStringArray(source.goals);
+  const aiPreferences = parseStringArray(source.aiPreferences);
+  const completedAt = parseStringField(source.completedAt, '');
+
+  // Minimum viable payload: at least one meaningful choice + completedAt.
+  if (!completedAt) return null;
+
+  return {
+    incomeRange,
+    savingsGoal,
+    goals,
+    aiPreferences,
+    completedAt,
+  };
+}

--- a/apps/web/src/utils/sanitize.ts
+++ b/apps/web/src/utils/sanitize.ts
@@ -275,6 +275,7 @@ export function sanitizeUser(data: unknown): User {
     status: sanitizeStatus(userData.status),
     currency: (userData.currency && typeof userData.currency === 'string')
       ? sanitizeString(userData.currency) : 'EUR',
+    onboarded: userData.onboarded === true,
     createdAt,
     updatedAt,
     fullName: `${firstName} ${lastName}`,

--- a/apps/web/src/utils/supabase/database.types.ts
+++ b/apps/web/src/utils/supabase/database.types.ts
@@ -844,6 +844,7 @@ export type Database = {
           id: string
           last_login_at: string | null
           last_name: string
+          onboarded: boolean
           preferences: Json | null
           role: Database["public"]["Enums"]["user_role"]
           status: Database["public"]["Enums"]["user_status"]
@@ -859,6 +860,7 @@ export type Database = {
           id: string
           last_login_at?: string | null
           last_name: string
+          onboarded?: boolean
           preferences?: Json | null
           role?: Database["public"]["Enums"]["user_role"]
           status?: Database["public"]["Enums"]["user_status"]
@@ -874,6 +876,7 @@ export type Database = {
           id?: string
           last_login_at?: string | null
           last_name?: string
+          onboarded?: boolean
           preferences?: Json | null
           role?: Database["public"]["Enums"]["user_role"]
           status?: Database["public"]["Enums"]["user_status"]

--- a/supabase/migrations/20260417010000_add_onboarded_to_profiles.sql
+++ b/supabase/migrations/20260417010000_add_onboarded_to_profiles.sql
@@ -1,0 +1,14 @@
+-- Add `onboarded` flag to profiles for first-access wizard gating.
+-- When FALSE, the dashboard renders the OnboardingWizard instead of the app.
+-- Flipped to TRUE atomically when the wizard completes and the user's
+-- onboarding data is persisted into profiles.preferences.onboarding.
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS onboarded BOOLEAN NOT NULL DEFAULT FALSE;
+
+COMMENT ON COLUMN public.profiles.onboarded IS
+  'True once the user has completed the OnboardingWizard. Controls first-access gating in the dashboard layout.';
+
+-- Existing rows keep DEFAULT FALSE — they are test users that should re-see
+-- the wizard the next time they open the app. If you need to bypass for
+-- seed/fixture accounts, UPDATE them explicitly post-migration.


### PR DESCRIPTION
## Summary

Sprint 1.5 — new users see the OnboardingWizard the first time they open the dashboard. When they finish, their preferences are persisted atomically and the wizard never appears again.

- New `profiles.onboarded` BOOLEAN column (migration `20260417010000`)
- New `OnboardingGate` wraps the dashboard layout; renders the existing `OnboardingWizard` fullscreen when `onboarded=false`
- New service `onboardingClient.completeOnboarding(userId, data)` — SELECT current `preferences`, merge onboarding slice, UPDATE with `onboarded=true` in a single statement (no half-onboarded window)
- `User` type extended with `onboarded: boolean` across `lib/auth.ts`, `sanitize.ts`, `database.types.ts`
- 22 new unit tests (types: 6, service: 8, gate: 8) — all green in the full suite (1406 pass / 2 skip)

## Design notes

- Self-contained from PR #438 pattern: own `types/onboarding.ts` + `services/onboarding.client.ts`, no dependency on the in-flight `user-preferences.ts` — zero merge risk, JSON keys disjoint (`preferences.notifications` vs `preferences.onboarding`).
- Idempotent: second call to `completeOnboarding` overwrites the `onboarding` slice but preserves the rest (`theme`, `language`, `notifications`, etc.).
- Error UX: failures render a non-modal alert overlay so the user can retry without losing wizard state.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 3 pre-existing warnings, 0 errors, 0 new warnings
- [x] `pnpm --filter @money-wise/web test` — 1406 pass / 2 skip / 0 fail
- [ ] **Manual browser verification (human, at wake-up)**:
  - [ ] Register a new user → first dashboard visit shows OnboardingWizard
  - [ ] Complete wizard → dashboard renders, refresh does NOT re-show wizard
  - [ ] Existing onboarded user → no wizard, straight to dashboard
  - [ ] Force error (e.g. drop network mid-submit) → alert shows, retry works
- [ ] Apply the migration on the Supabase project before merging (`supabase db push`) — the feature reads `profiles.onboarded` which the TypeScript types now require

## Out of scope

- Supabase types regeneration via CLI — hand-edited `database.types.ts` to match the new column. Regenerate on next full types sync.
- Seed/fixture accounts start with `onboarded=FALSE` and will re-see the wizard on first login. UPDATE them explicitly if that's undesired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)