### PR TITLE
feat(settings): Security tab with password change via Supabase Auth

### DIFF
--- a/apps/web/__tests__/components/settings/SecurityTab.test.tsx
+++ b/apps/web/__tests__/components/settings/SecurityTab.test.tsx
@@ -1,0 +1,197 @@
+/**
+ * Tests for SecurityTab — password change happy/error paths.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import type { User } from '../../../lib/auth';
+
+const mocks = vi.hoisted(() => ({
+  changePassword: vi.fn(),
+  storeState: { user: null as unknown as User | null },
+}));
+
+vi.mock('../../../src/store/auth.store', () => ({
+  useAuthStore: <T,>(selector: (s: { user: User | null }) => T) =>
+    selector({ user: mocks.storeState.user }),
+}));
+
+vi.mock('../../../src/services/security.client', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../../src/services/security.client')
+  >('../../../src/services/security.client');
+  return {
+    ...actual,
+    securityClient: {
+      changePassword: mocks.changePassword,
+    },
+  };
+});
+
+import { SecurityTab } from '../../../src/components/settings/SecurityTab';
+import { SecurityApiError } from '../../../src/services/security.client';
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    id: 'user-1',
+    email: 'mario@example.com',
+    firstName: 'Mario',
+    lastName: 'Rossi',
+    role: 'ADMIN',
+    status: 'ACTIVE',
+    currency: 'EUR',
+    onboarded: true,
+    createdAt: '2026-04-17T00:00:00Z',
+    updatedAt: '2026-04-17T00:00:00Z',
+    fullName: 'Mario Rossi',
+    isEmailVerified: true,
+    isActive: true,
+    ...overrides,
+  };
+}
+
+describe('SecurityTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.storeState.user = makeUser();
+  });
+
+  it('renders all four sections (password form + 3 placeholders)', () => {
+    render(<SecurityTab />);
+    expect(screen.getByText('Sicurezza Account')).toBeInTheDocument();
+    expect(screen.getByText('Cambia Password')).toBeInTheDocument();
+    expect(screen.getByText('Autenticazione a Due Fattori')).toBeInTheDocument();
+    expect(screen.getByText('Sessioni Attive')).toBeInTheDocument();
+    expect(screen.getByText('Log Attività')).toBeInTheDocument();
+  });
+
+  it('shows client-side validation errors when newPassword is too short', async () => {
+    render(<SecurityTab />);
+
+    await userEvent.type(screen.getByLabelText('Password Attuale'), 'old-password');
+    await userEvent.type(screen.getByLabelText('Nuova Password'), 'short');
+    await userEvent.type(screen.getByLabelText('Conferma Password'), 'short');
+    await userEvent.click(screen.getByRole('button', { name: /Aggiorna Password/i }));
+
+    expect(await screen.findByText(/almeno 8 caratteri/i)).toBeInTheDocument();
+    expect(mocks.changePassword).not.toHaveBeenCalled();
+  });
+
+  it('shows mismatch error when confirmPassword differs', async () => {
+    render(<SecurityTab />);
+
+    await userEvent.type(screen.getByLabelText('Password Attuale'), 'OldSecure1');
+    await userEvent.type(screen.getByLabelText('Nuova Password'), 'NewSecure22');
+    await userEvent.type(screen.getByLabelText('Conferma Password'), 'NewSecure33');
+    await userEvent.click(screen.getByRole('button', { name: /Aggiorna Password/i }));
+
+    expect(await screen.findByText(/non coincidono/i)).toBeInTheDocument();
+    expect(mocks.changePassword).not.toHaveBeenCalled();
+  });
+
+  it('shows "must differ" error when new equals current', async () => {
+    render(<SecurityTab />);
+
+    await userEvent.type(screen.getByLabelText('Password Attuale'), 'SamePass123');
+    await userEvent.type(screen.getByLabelText('Nuova Password'), 'SamePass123');
+    await userEvent.type(screen.getByLabelText('Conferma Password'), 'SamePass123');
+    await userEvent.click(screen.getByRole('button', { name: /Aggiorna Password/i }));
+
+    expect(await screen.findByText(/diversa da quella attuale/i)).toBeInTheDocument();
+    expect(mocks.changePassword).not.toHaveBeenCalled();
+  });
+
+  it('calls the service with email + passwords and shows success on happy path', async () => {
+    mocks.changePassword.mockResolvedValueOnce({ changedAt: '2026-04-17T10:00:00Z' });
+    render(<SecurityTab />);
+
+    await userEvent.type(screen.getByLabelText('Password Attuale'), 'OldSecure1');
+    await userEvent.type(screen.getByLabelText('Nuova Password'), 'NewSecure22');
+    await userEvent.type(screen.getByLabelText('Conferma Password'), 'NewSecure22');
+    await userEvent.click(screen.getByRole('button', { name: /Aggiorna Password/i }));
+
+    await waitFor(() => {
+      expect(mocks.changePassword).toHaveBeenCalledWith({
+        email: 'mario@example.com',
+        currentPassword: 'OldSecure1',
+        newPassword: 'NewSecure22',
+      });
+    });
+
+    expect(await screen.findByText(/aggiornata con successo/i)).toBeInTheDocument();
+  });
+
+  it('routes current_password_mismatch error to the currentPassword field', async () => {
+    mocks.changePassword.mockRejectedValueOnce(
+      new SecurityApiError(
+        'La password attuale non è corretta',
+        401,
+        'current_password_mismatch'
+      )
+    );
+    render(<SecurityTab />);
+
+    await userEvent.type(screen.getByLabelText('Password Attuale'), 'WrongOld1');
+    await userEvent.type(screen.getByLabelText('Nuova Password'), 'NewSecure22');
+    await userEvent.type(screen.getByLabelText('Conferma Password'), 'NewSecure22');
+    await userEvent.click(screen.getByRole('button', { name: /Aggiorna Password/i }));
+
+    expect(
+      await screen.findByText(/La password attuale non è corretta/i)
+    ).toBeInTheDocument();
+    // No generic alert banner should appear for field-specific errors
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('shows a top-level alert for update_failed server errors', async () => {
+    mocks.changePassword.mockRejectedValueOnce(
+      new SecurityApiError('server rejected policy', 500, 'update_failed')
+    );
+    render(<SecurityTab />);
+
+    await userEvent.type(screen.getByLabelText('Password Attuale'), 'OldSecure1');
+    await userEvent.type(screen.getByLabelText('Nuova Password'), 'NewSecure22');
+    await userEvent.type(screen.getByLabelText('Conferma Password'), 'NewSecure22');
+    await userEvent.click(screen.getByRole('button', { name: /Aggiorna Password/i }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/server rejected policy/i);
+  });
+
+  it('shows generic error message for non-SecurityApiError failures', async () => {
+    mocks.changePassword.mockRejectedValueOnce(new Error('network down'));
+    render(<SecurityTab />);
+
+    await userEvent.type(screen.getByLabelText('Password Attuale'), 'OldSecure1');
+    await userEvent.type(screen.getByLabelText('Nuova Password'), 'NewSecure22');
+    await userEvent.type(screen.getByLabelText('Conferma Password'), 'NewSecure22');
+    await userEvent.click(screen.getByRole('button', { name: /Aggiorna Password/i }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/errore imprevisto/i);
+  });
+
+  it('shows an inline message when user is missing email (session invalid)', async () => {
+    mocks.storeState.user = makeUser({ email: '' });
+    render(<SecurityTab />);
+
+    await userEvent.type(screen.getByLabelText('Password Attuale'), 'OldSecure1');
+    await userEvent.type(screen.getByLabelText('Nuova Password'), 'NewSecure22');
+    await userEvent.type(screen.getByLabelText('Conferma Password'), 'NewSecure22');
+    await userEvent.click(screen.getByRole('button', { name: /Aggiorna Password/i }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/Sessione non valida/i);
+    expect(mocks.changePassword).not.toHaveBeenCalled();
+  });
+
+  it('marks 2FA toggles as disabled (placeholder)', () => {
+    render(<SecurityTab />);
+    const toggles = screen.getAllByRole('checkbox');
+    for (const t of toggles) {
+      expect(t).toBeDisabled();
+    }
+  });
+});

--- a/apps/web/__tests__/services/security.client.test.ts
+++ b/apps/web/__tests__/services/security.client.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for services/security.client — two-step password change flow.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  signInWithPassword: vi.fn(),
+  updateUser: vi.fn(),
+}));
+
+vi.mock('../../src/utils/supabase/client', () => ({
+  createClient: vi.fn(() => ({
+    auth: {
+      signInWithPassword: mocks.signInWithPassword,
+      updateUser: mocks.updateUser,
+    },
+  })),
+}));
+
+import {
+  securityClient,
+  SecurityApiError,
+} from '../../src/services/security.client';
+
+const EMAIL = 'user@example.com';
+const CURR = 'OldSecure123';
+const NEW = 'NewSecure456';
+
+describe('securityClient.changePassword', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.signInWithPassword.mockReset();
+    mocks.updateUser.mockReset();
+  });
+
+  it('rejects when email is missing', async () => {
+    await expect(
+      securityClient.changePassword({
+        email: '',
+        currentPassword: CURR,
+        newPassword: NEW,
+      })
+    ).rejects.toMatchObject({
+      name: 'SecurityApiError',
+      statusCode: 400,
+      code: 'missing_email',
+    });
+    expect(mocks.signInWithPassword).not.toHaveBeenCalled();
+    expect(mocks.updateUser).not.toHaveBeenCalled();
+  });
+
+  it('re-verifies current password before updating', async () => {
+    mocks.signInWithPassword.mockResolvedValueOnce({ error: null });
+    mocks.updateUser.mockResolvedValueOnce({ error: null });
+
+    const result = await securityClient.changePassword({
+      email: EMAIL,
+      currentPassword: CURR,
+      newPassword: NEW,
+    });
+
+    expect(mocks.signInWithPassword).toHaveBeenCalledWith({
+      email: EMAIL,
+      password: CURR,
+    });
+    expect(mocks.updateUser).toHaveBeenCalledWith({ password: NEW });
+    expect(result.changedAt).toEqual(expect.any(String));
+    expect(new Date(result.changedAt).toString()).not.toBe('Invalid Date');
+  });
+
+  it('throws current_password_mismatch when re-verification fails', async () => {
+    mocks.signInWithPassword.mockResolvedValueOnce({
+      error: { message: 'invalid login' },
+    });
+
+    await expect(
+      securityClient.changePassword({
+        email: EMAIL,
+        currentPassword: CURR,
+        newPassword: NEW,
+      })
+    ).rejects.toMatchObject({
+      name: 'SecurityApiError',
+      statusCode: 401,
+      code: 'current_password_mismatch',
+    });
+    expect(mocks.updateUser).not.toHaveBeenCalled();
+  });
+
+  it('throws update_failed when updateUser rejects', async () => {
+    mocks.signInWithPassword.mockResolvedValueOnce({ error: null });
+    mocks.updateUser.mockResolvedValueOnce({
+      error: { message: 'weak password per server policy' },
+    });
+
+    await expect(
+      securityClient.changePassword({
+        email: EMAIL,
+        currentPassword: CURR,
+        newPassword: NEW,
+      })
+    ).rejects.toMatchObject({
+      name: 'SecurityApiError',
+      statusCode: 500,
+      code: 'update_failed',
+      message: expect.stringContaining('weak password'),
+    });
+  });
+
+  it('uses a fallback message when update error has no message', async () => {
+    mocks.signInWithPassword.mockResolvedValueOnce({ error: null });
+    mocks.updateUser.mockResolvedValueOnce({
+      error: { message: '' } as { message: string },
+    });
+
+    await expect(
+      securityClient.changePassword({
+        email: EMAIL,
+        currentPassword: CURR,
+        newPassword: NEW,
+      })
+    ).rejects.toMatchObject({
+      code: 'update_failed',
+      message: expect.stringContaining('Impossibile'),
+    });
+  });
+});
+
+describe('SecurityApiError', () => {
+  it('carries code + statusCode + optional details', () => {
+    const err = new SecurityApiError(
+      'boom',
+      418,
+      'unknown',
+      { extra: 1 }
+    );
+    expect(err.message).toBe('boom');
+    expect(err.statusCode).toBe(418);
+    expect(err.code).toBe('unknown');
+    expect(err.details).toEqual({ extra: 1 });
+    expect(err.name).toBe('SecurityApiError');
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it('defaults code to "unknown" when not provided', () => {
+    const err = new SecurityApiError('oops', 500);
+    expect(err.code).toBe('unknown');
+  });
+});

--- a/apps/web/__tests__/types/security.test.ts
+++ b/apps/web/__tests__/types/security.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for types/security — passwordChangeSchema validation.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  passwordChangeSchema,
+  PASSWORD_MIN_LENGTH,
+} from '../../src/types/security';
+
+describe('passwordChangeSchema', () => {
+  const valid = {
+    currentPassword: 'OldSecure123',
+    newPassword: 'NewSecure456',
+    confirmPassword: 'NewSecure456',
+  };
+
+  it('accepts a valid change', () => {
+    const r = passwordChangeSchema.safeParse(valid);
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects empty currentPassword', () => {
+    const r = passwordChangeSchema.safeParse({ ...valid, currentPassword: '' });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(
+        r.error.issues.some(
+          (i) => i.path[0] === 'currentPassword' && i.message.includes('obbligatoria')
+        )
+      ).toBe(true);
+    }
+  });
+
+  it('rejects newPassword shorter than the minimum', () => {
+    const short = 'a'.repeat(PASSWORD_MIN_LENGTH - 1);
+    const r = passwordChangeSchema.safeParse({
+      ...valid,
+      newPassword: short,
+      confirmPassword: short,
+    });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(
+        r.error.issues.some(
+          (i) =>
+            i.path[0] === 'newPassword' &&
+            i.message.includes(String(PASSWORD_MIN_LENGTH))
+        )
+      ).toBe(true);
+    }
+  });
+
+  it('rejects when confirmPassword does not match newPassword', () => {
+    const r = passwordChangeSchema.safeParse({
+      ...valid,
+      confirmPassword: 'DifferentValue99',
+    });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(
+        r.error.issues.some(
+          (i) =>
+            i.path[0] === 'confirmPassword' &&
+            i.message.toLowerCase().includes('coincidono')
+        )
+      ).toBe(true);
+    }
+  });
+
+  it('rejects when newPassword equals currentPassword (must differ)', () => {
+    const r = passwordChangeSchema.safeParse({
+      currentPassword: 'SamePass999',
+      newPassword: 'SamePass999',
+      confirmPassword: 'SamePass999',
+    });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(
+        r.error.issues.some(
+          (i) =>
+            i.path[0] === 'newPassword' &&
+            i.message.toLowerCase().includes('diversa')
+        )
+      ).toBe(true);
+    }
+  });
+
+  it('reports multiple issues at once when relevant', () => {
+    const r = passwordChangeSchema.safeParse({
+      currentPassword: '',
+      newPassword: 'short',
+      confirmPassword: 'mismatch',
+    });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      const paths = r.error.issues.map((i) => i.path[0]);
+      expect(paths).toContain('currentPassword');
+      expect(paths).toContain('newPassword');
+    }
+  });
+});
+
+describe('PASSWORD_MIN_LENGTH', () => {
+  it('is aligned with the register flow (min 8)', () => {
+    expect(PASSWORD_MIN_LENGTH).toBe(8);
+  });
+});

--- a/apps/web/app/dashboard/settings/page.tsx
+++ b/apps/web/app/dashboard/settings/page.tsx
@@ -14,12 +14,12 @@ import { motion } from 'framer-motion';
 import { createClient } from '@/utils/supabase/client';
 import { CategoryManager } from '@/components/categories/CategoryManager';
 import { NotificationsTab } from '@/components/settings/NotificationsTab';
+import { SecurityTab } from '@/components/settings/SecurityTab';
 import {
   User,
   CreditCard,
   Shield,
   Globe,
-  Smartphone,
   Link as LinkIcon,
   Check,
   AlertCircle,
@@ -37,7 +37,6 @@ import {
   Trash2,
   Key,
   Monitor,
-  Mail,
   TrendingUp,
   Wallet,
   Sparkles,
@@ -218,9 +217,6 @@ export default function SettingsPage() {
   const [showApiKeys, setShowApiKeys] = useState<Record<string, boolean>>({});
   const [apiKeys, setApiKeys] = useState({ openai: '', anthropic: '', gemini: '', coinbase: '', plaid: '' });
   const [apiKeyFeedback, setApiKeyFeedback] = useState<string | null>(null);
-
-  // Security state
-  const [securityFeedback, setSecurityFeedback] = useState<string | null>(null);
 
   // Data state
   const [dataFeedback, setDataFeedback] = useState<string | null>(null);
@@ -984,110 +980,7 @@ export default function SettingsPage() {
         </motion.div>
       )}
 
-      {/* ================================================================= */}
-      {/* Security Tab */}
-      {/* ================================================================= */}
-      {activeTab === 'security' && (
-        <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }}>
-          <Card className="p-6 rounded-2xl border-0 shadow-sm">
-            <h3 className="text-lg font-semibold text-foreground mb-6">Sicurezza Account</h3>
-            <div className="space-y-6">
-              {/* Change Password */}
-              <div>
-                <h4 className="font-medium text-foreground mb-4">Cambia Password</h4>
-                <div className="space-y-4 max-w-md">
-                  <div className="space-y-2">
-                    <Label htmlFor="currentPassword">Password Attuale</Label>
-                    <Input id="currentPassword" type="password" />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="newPassword">Nuova Password</Label>
-                    <Input id="newPassword" type="password" />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="confirmPassword">Conferma Password</Label>
-                    <Input id="confirmPassword" type="password" />
-                  </div>
-                  {securityFeedback ? (
-                    <span className="flex items-center gap-2 text-[13px] text-emerald-600">
-                      <Check className="w-4 h-4" /> {securityFeedback}
-                    </span>
-                  ) : (
-                    <Button
-                      onClick={() => showFeedback(setSecurityFeedback, 'Password aggiornata!')}
-                      className="bg-gradient-to-r from-emerald-500 to-teal-500 hover:from-emerald-600 hover:to-teal-600 text-white border-0"
-                    >
-                      Aggiorna Password
-                    </Button>
-                  )}
-                </div>
-              </div>
-
-              {/* 2FA */}
-              <div className="border-t border-border pt-6">
-                <h4 className="font-medium text-foreground mb-4">Autenticazione a Due Fattori</h4>
-                <div className="space-y-3">
-                  {[
-                    { icon: Smartphone, title: '2FA con SMS', desc: 'Codice via SMS al tuo telefono' },
-                    { icon: Key, title: 'Authenticator App', desc: 'Google Authenticator o simili' },
-                    { icon: Mail, title: '2FA via Email', desc: 'Codice di verifica via email' },
-                  ].map((item) => (
-                    <div key={item.title} className="flex items-center justify-between p-4 bg-muted/50 rounded-xl">
-                      <div className="flex items-center gap-3">
-                        <item.icon className="w-5 h-5 text-muted-foreground" />
-                        <div>
-                          <p className="font-medium text-foreground">{item.title}</p>
-                          <p className="text-sm text-muted-foreground">{item.desc}</p>
-                        </div>
-                      </div>
-                      <input type="checkbox" className={TOGGLE_CLASS} />
-                    </div>
-                  ))}
-                </div>
-              </div>
-
-              {/* Active Sessions */}
-              <div className="border-t border-border pt-6">
-                <h4 className="font-medium text-foreground mb-4">Sessioni Attive</h4>
-                <div className="space-y-3">
-                  <div className="p-4 bg-muted/50 rounded-xl">
-                    <div className="flex items-center justify-between">
-                      <div className="flex items-center gap-3">
-                        <Monitor className="w-5 h-5 text-muted-foreground" />
-                        <div>
-                          <p className="font-medium text-foreground">Chrome su Linux</p>
-                          <p className="text-sm text-muted-foreground">Attiva ora</p>
-                        </div>
-                      </div>
-                      <Badge className="bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300">Corrente</Badge>
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              {/* Activity Log */}
-              <div className="border-t border-border pt-6">
-                <h4 className="font-medium text-foreground mb-4">Log Attività</h4>
-                <div className="space-y-2">
-                  {[
-                    { action: 'Login effettuato', time: 'Oggi, 10:30', device: 'Chrome - Linux' },
-                    { action: 'Password modificata', time: '3 giorni fa', device: 'Safari - iPhone' },
-                    { action: 'Integrazione PayPal connessa', time: '1 settimana fa', device: 'Chrome - Linux' },
-                  ].map((log, i) => (
-                    <div key={i} className="flex items-center justify-between py-2 text-sm">
-                      <span className="text-foreground">{log.action}</span>
-                      <div className="text-right">
-                        <p className="text-muted-foreground">{log.time}</p>
-                        <p className="text-xs text-muted-foreground">{log.device}</p>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            </div>
-          </Card>
-        </motion.div>
-      )}
+      {activeTab === 'security' && <SecurityTab />}
 
       {/* ================================================================= */}
       {/* Data Tab */}

--- a/apps/web/src/components/settings/SecurityTab.tsx
+++ b/apps/web/src/components/settings/SecurityTab.tsx
@@ -1,0 +1,355 @@
+/**
+ * SecurityTab — Settings > Sicurezza tab
+ *
+ * Owns the password change flow. Uses `securityClient.changePassword` which
+ * re-verifies the current password before applying the new one.
+ *
+ * 2FA, active sessions, and activity log sections remain as "In arrivo"
+ * placeholders (out of scope for Sprint 1.2 — wired in later sprints when
+ * the respective backends land).
+ *
+ * @module components/settings/SecurityTab
+ */
+
+'use client';
+
+import { useState } from 'react';
+import { motion } from 'framer-motion';
+import {
+  AlertCircle,
+  Check,
+  Key,
+  Loader2,
+  Mail,
+  Monitor,
+  Smartphone,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useAuthStore } from '@/store/auth.store';
+import {
+  securityClient,
+  SecurityApiError,
+} from '@/services/security.client';
+import {
+  passwordChangeSchema,
+  type PasswordChangeInput,
+} from '@/types/security';
+
+const TOGGLE_CLASS =
+  'w-10 h-6 appearance-none bg-muted rounded-full relative cursor-pointer checked:bg-primary transition-colors before:content-[""] before:absolute before:top-0.5 before:left-0.5 before:w-5 before:h-5 before:bg-white before:rounded-full before:transition-transform checked:before:translate-x-4';
+
+// =============================================================================
+// Password form
+// =============================================================================
+
+type FormState = {
+  currentPassword: string;
+  newPassword: string;
+  confirmPassword: string;
+};
+
+const EMPTY_FORM: FormState = {
+  currentPassword: '',
+  newPassword: '',
+  confirmPassword: '',
+};
+
+type FieldErrors = Partial<Record<keyof PasswordChangeInput, string>>;
+
+function PasswordChangeForm() {
+  const user = useAuthStore((s) => s.user);
+
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  const [errors, setErrors] = useState<FieldErrors>({});
+  const [serverError, setServerError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const setField = <K extends keyof FormState>(key: K, value: string) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+    if (errors[key]) setErrors((prev) => ({ ...prev, [key]: undefined }));
+    if (serverError) setServerError(null);
+    if (success) setSuccess(null);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (submitting) return;
+
+    setServerError(null);
+    setSuccess(null);
+
+    const parsed = passwordChangeSchema.safeParse(form);
+    if (!parsed.success) {
+      const next: FieldErrors = {};
+      for (const issue of parsed.error.issues) {
+        const k = issue.path[0] as keyof PasswordChangeInput | undefined;
+        if (k && !next[k]) next[k] = issue.message;
+      }
+      setErrors(next);
+      return;
+    }
+
+    if (!user?.email) {
+      setServerError('Sessione non valida. Rifai login e riprova.');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await securityClient.changePassword({
+        email: user.email,
+        currentPassword: parsed.data.currentPassword,
+        newPassword: parsed.data.newPassword,
+      });
+      setForm(EMPTY_FORM);
+      setSuccess('Password aggiornata con successo.');
+    } catch (err) {
+      if (err instanceof SecurityApiError) {
+        if (err.code === 'current_password_mismatch') {
+          setErrors({ currentPassword: err.message });
+        } else {
+          setServerError(err.message);
+        }
+      } else {
+        setServerError(
+          'Errore imprevisto durante il cambio password. Riprova.'
+        );
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 max-w-md" noValidate>
+      <div className="space-y-2">
+        <Label htmlFor="currentPassword">Password Attuale</Label>
+        <Input
+          id="currentPassword"
+          type="password"
+          autoComplete="current-password"
+          value={form.currentPassword}
+          onChange={(e) => setField('currentPassword', e.target.value)}
+          aria-invalid={!!errors.currentPassword}
+          aria-describedby={
+            errors.currentPassword ? 'currentPassword-error' : undefined
+          }
+          disabled={submitting}
+        />
+        {errors.currentPassword && (
+          <p
+            id="currentPassword-error"
+            className="text-sm text-destructive"
+          >
+            {errors.currentPassword}
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="newPassword">Nuova Password</Label>
+        <Input
+          id="newPassword"
+          type="password"
+          autoComplete="new-password"
+          value={form.newPassword}
+          onChange={(e) => setField('newPassword', e.target.value)}
+          aria-invalid={!!errors.newPassword}
+          aria-describedby={
+            errors.newPassword ? 'newPassword-error' : undefined
+          }
+          disabled={submitting}
+        />
+        {errors.newPassword && (
+          <p id="newPassword-error" className="text-sm text-destructive">
+            {errors.newPassword}
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="confirmPassword">Conferma Password</Label>
+        <Input
+          id="confirmPassword"
+          type="password"
+          autoComplete="new-password"
+          value={form.confirmPassword}
+          onChange={(e) => setField('confirmPassword', e.target.value)}
+          aria-invalid={!!errors.confirmPassword}
+          aria-describedby={
+            errors.confirmPassword ? 'confirmPassword-error' : undefined
+          }
+          disabled={submitting}
+        />
+        {errors.confirmPassword && (
+          <p
+            id="confirmPassword-error"
+            className="text-sm text-destructive"
+          >
+            {errors.confirmPassword}
+          </p>
+        )}
+      </div>
+
+      {serverError && (
+        <div
+          role="alert"
+          className="flex items-center gap-2 p-3 bg-red-500/10 rounded-xl"
+        >
+          <AlertCircle className="w-4 h-4 text-red-600" />
+          <span className="text-[13px] text-red-600">{serverError}</span>
+        </div>
+      )}
+
+      {success ? (
+        <span className="flex items-center gap-2 text-[13px] text-emerald-600">
+          <Check className="w-4 h-4" /> {success}
+        </span>
+      ) : (
+        <Button
+          type="submit"
+          disabled={submitting}
+          className="bg-gradient-to-r from-emerald-500 to-teal-500 hover:from-emerald-600 hover:to-teal-600 text-white border-0"
+        >
+          {submitting ? (
+            <>
+              <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+              Aggiornamento...
+            </>
+          ) : (
+            'Aggiorna Password'
+          )}
+        </Button>
+      )}
+    </form>
+  );
+}
+
+// =============================================================================
+// Placeholder sections (functional in later sprints)
+// =============================================================================
+
+const TWO_FA_ITEMS = [
+  { icon: Smartphone, title: '2FA con SMS', desc: 'Codice via SMS al tuo telefono' },
+  { icon: Key, title: 'Authenticator App', desc: 'Google Authenticator o simili' },
+  { icon: Mail, title: '2FA via Email', desc: 'Codice di verifica via email' },
+];
+
+function TwoFactorPlaceholder() {
+  return (
+    <div className="border-t border-border pt-6">
+      <div className="flex items-center gap-2 mb-4">
+        <h4 className="font-medium text-foreground">Autenticazione a Due Fattori</h4>
+        <span className="text-[11px] px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
+          In arrivo
+        </span>
+      </div>
+      <div className="space-y-3">
+        {TWO_FA_ITEMS.map((item) => (
+          <div
+            key={item.title}
+            className="flex items-center justify-between p-4 bg-muted/50 rounded-xl opacity-70"
+          >
+            <div className="flex items-center gap-3">
+              <item.icon className="w-5 h-5 text-muted-foreground" />
+              <div>
+                <p className="font-medium text-foreground">{item.title}</p>
+                <p className="text-sm text-muted-foreground">{item.desc}</p>
+              </div>
+            </div>
+            <input
+              type="checkbox"
+              className={TOGGLE_CLASS}
+              disabled
+              aria-label={`${item.title} — non ancora disponibile`}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function CurrentSessionRow() {
+  // We intentionally show only the current session — full session enumeration
+  // needs an admin-side API that isn't wired yet.
+  return (
+    <div className="p-4 bg-muted/50 rounded-xl">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <Monitor className="w-5 h-5 text-muted-foreground" />
+          <div>
+            <p className="font-medium text-foreground">Sessione corrente</p>
+            <p className="text-sm text-muted-foreground">Attiva ora</p>
+          </div>
+        </div>
+        <span className="inline-flex items-center gap-1 rounded-full bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300 text-xs px-2 py-1">
+          <Check className="w-3 h-3" /> Verificata
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function SessionsPlaceholder() {
+  return (
+    <div className="border-t border-border pt-6">
+      <div className="flex items-center gap-2 mb-4">
+        <h4 className="font-medium text-foreground">Sessioni Attive</h4>
+        <span className="text-[11px] px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
+          Elenco completo in arrivo
+        </span>
+      </div>
+      <div className="space-y-3">
+        <CurrentSessionRow />
+      </div>
+    </div>
+  );
+}
+
+function ActivityLogPlaceholder() {
+  return (
+    <div className="border-t border-border pt-6">
+      <div className="flex items-center gap-2 mb-4">
+        <h4 className="font-medium text-foreground">Log Attività</h4>
+        <span className="text-[11px] px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
+          In arrivo
+        </span>
+      </div>
+      <p className="text-sm text-muted-foreground">
+        Quando sarà disponibile, qui troverai la cronologia di accessi e modifiche rilevanti al tuo account.
+      </p>
+    </div>
+  );
+}
+
+// =============================================================================
+// Main component
+// =============================================================================
+
+export function SecurityTab() {
+  return (
+    <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }}>
+      <Card className="p-6 rounded-2xl border-0 shadow-sm">
+        <h3 className="text-lg font-semibold text-foreground mb-6">
+          Sicurezza Account
+        </h3>
+        <div className="space-y-6">
+          <div>
+            <h4 className="font-medium text-foreground mb-4">Cambia Password</h4>
+            <PasswordChangeForm />
+          </div>
+          <TwoFactorPlaceholder />
+          <SessionsPlaceholder />
+          <ActivityLogPlaceholder />
+        </div>
+      </Card>
+    </motion.div>
+  );
+}
+
+export default SecurityTab;

--- a/apps/web/src/services/security.client.ts
+++ b/apps/web/src/services/security.client.ts
@@ -1,0 +1,111 @@
+/**
+ * Security Client — password change via Supabase Auth.
+ *
+ * Two-step flow for defense-in-depth against session hijack:
+ *   1. Re-verify the current password via `signInWithPassword` (if wrong → abort)
+ *   2. `updateUser({ password })` to apply the new one
+ *
+ * Supabase enforces server-side password rules as well; any rejection
+ * bubbles up as `SecurityApiError`.
+ *
+ * @module services/security.client
+ */
+
+import { createClient } from '@/utils/supabase/client';
+
+// =============================================================================
+// Error class
+// =============================================================================
+
+export type SecurityErrorCode =
+  | 'missing_email'
+  | 'current_password_mismatch'
+  | 'update_failed'
+  | 'unknown';
+
+export class SecurityApiError extends Error {
+  constructor(
+    message: string,
+    public statusCode: number,
+    public code: SecurityErrorCode = 'unknown',
+    public details?: unknown
+  ) {
+    super(message);
+    this.name = 'SecurityApiError';
+  }
+}
+
+// =============================================================================
+// Client
+// =============================================================================
+
+type SupabaseLike = {
+  auth: {
+    signInWithPassword: (creds: {
+      email: string;
+      password: string;
+    }) => Promise<{ error: { message: string } | null }>;
+    updateUser: (attrs: {
+      password: string;
+    }) => Promise<{ error: { message: string } | null }>;
+  };
+};
+
+export const securityClient = {
+  /**
+   * Change the current user's password.
+   *
+   * @throws {SecurityApiError} with `code='current_password_mismatch'` if the
+   *  current password re-verification fails, or `code='update_failed'` if the
+   *  new password is rejected by Supabase Auth.
+   */
+  async changePassword(params: {
+    email: string;
+    currentPassword: string;
+    newPassword: string;
+  }): Promise<{ changedAt: string }> {
+    const { email, currentPassword, newPassword } = params;
+
+    if (!email) {
+      throw new SecurityApiError(
+        'Email mancante nella sessione — rifai login e riprova',
+        400,
+        'missing_email'
+      );
+    }
+
+    const supabase = createClient() as unknown as SupabaseLike;
+
+    // Step 1: re-verify current password. signInWithPassword does not invalidate
+    // the existing session on success — it just returns a fresh one; on failure
+    // the existing session is untouched, so this is safe as a guard.
+    const reverify = await supabase.auth.signInWithPassword({
+      email,
+      password: currentPassword,
+    });
+    if (reverify.error) {
+      throw new SecurityApiError(
+        'La password attuale non è corretta',
+        401,
+        'current_password_mismatch',
+        reverify.error
+      );
+    }
+
+    // Step 2: update to the new password.
+    const update = await supabase.auth.updateUser({ password: newPassword });
+    if (update.error) {
+      throw new SecurityApiError(
+        update.error.message ||
+          'Impossibile aggiornare la password. Riprova più tardi.',
+        500,
+        'update_failed',
+        update.error
+      );
+    }
+
+    return { changedAt: new Date().toISOString() };
+  },
+};
+
+export default securityClient;

--- a/apps/web/src/types/security.ts
+++ b/apps/web/src/types/security.ts
@@ -1,0 +1,51 @@
+/**
+ * Security — shared types for the Settings > Sicurezza flow.
+ *
+ * Schema for password change requests. Mirrors the register flow's `min(8)`
+ * policy (see `app/auth/register/page.tsx`) and adds:
+ *   - confirmPassword match
+ *   - newPassword must differ from currentPassword
+ *
+ * Supabase Auth enforces its own server-side rules; this client schema is
+ * for UX feedback and defensive pre-submit validation.
+ *
+ * @module types/security
+ */
+
+import { z } from 'zod';
+
+// =============================================================================
+// Password policy
+// =============================================================================
+
+/** Minimum length — aligned with register flow. */
+export const PASSWORD_MIN_LENGTH = 8;
+
+export const passwordChangeSchema = z
+  .object({
+    currentPassword: z
+      .string()
+      .min(1, 'La password attuale è obbligatoria'),
+    newPassword: z
+      .string()
+      .min(PASSWORD_MIN_LENGTH, `La password deve avere almeno ${PASSWORD_MIN_LENGTH} caratteri`),
+    confirmPassword: z.string(),
+  })
+  .refine((d) => d.newPassword === d.confirmPassword, {
+    message: 'Le password non coincidono',
+    path: ['confirmPassword'],
+  })
+  .refine((d) => d.newPassword !== d.currentPassword, {
+    message: 'La nuova password deve essere diversa da quella attuale',
+    path: ['newPassword'],
+  });
+
+export type PasswordChangeInput = z.infer<typeof passwordChangeSchema>;
+
+// =============================================================================
+// Result shape
+// =============================================================================
+
+export interface PasswordChangeResult {
+  changedAt: string;
+}


### PR DESCRIPTION
## Summary

Sprint 1.2 — extracts the Settings > Sicurezza tab into a dedicated `<SecurityTab />` component (mirroring the PR #438 pattern for Notifiche) and wires the "Cambia Password" form to a real Supabase Auth flow.

- New `types/security.ts`: Zod schema (min 8 chars aligned with register flow, confirmPassword match, new != current)
- New `services/security.client.ts`: two-step flow — re-verify current password via `signInWithPassword`, then `updateUser({ password })`. Error codes: `missing_email`, `current_password_mismatch`, `update_failed`
- New `components/settings/SecurityTab.tsx`: password form + three "In arrivo" placeholders (2FA, active sessions, activity log)
- `page.tsx`: monolithic Security block (~100 lines) replaced with `<SecurityTab />`, dead state + unused icons removed
- 24 new unit tests (types: 7, service: 7, component: 10), full suite 1479 pass / 2 skip

## Design notes

- **Password policy**: `min(8)` matches the existing register flow (`app/auth/register/page.tsx`). Server-side rules via Supabase Auth remain the authoritative enforcement; this client schema is for UX feedback + defensive pre-submit validation.
- **Re-verification rationale**: `signInWithPassword` does not invalidate the existing session on success and is untouched on failure — safe guard that catches session-hijack scenarios where an attacker has cookies but not the password.
- **Error routing**: `current_password_mismatch` routes to the inline `currentPassword` field error; everything else renders as a top-level `role="alert"` banner. Generic network failures fall into the latter with an Italian-localized fallback.
- **Out of scope** (placeholders, tracked for later sprints): 2FA wiring (needs provider decision), active sessions enumeration (needs admin API), activity log (needs `audit_logs` query wiring).

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 errors, only pre-existing warnings
- [x] `pnpm --filter @money-wise/web test` — 1479 pass / 2 skip / 0 fail
- [ ] **Manual browser verification (human at wake-up)**:
  - [ ] Wrong current password → field-level error, no session change
  - [ ] Weak new password (<8) → inline error, no network call
  - [ ] Valid change → success message, existing session still valid
  - [ ] Network error mid-submit → top-level alert, form preserved for retry

## Notes

- Carries the \`auto-merge\` label (dogfooding of PR #442 workflow). Will auto-merge when all required checks pass and no blocking labels are present. Touches no \`supabase/migrations/**\` so the schema guard is not triggered.
- Unblocks Sprint 1.4 (Piano placeholders) which needed 1.2 merged first to avoid \`page.tsx\` contention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)