### PR TITLE
fix(settings): address Copilot review feedback on PR #443

### DIFF
--- a/apps/web/__tests__/components/settings/SecurityTab.test.tsx
+++ b/apps/web/__tests__/components/settings/SecurityTab.test.tsx
@@ -160,6 +160,29 @@ describe('SecurityTab', () => {
     expect(alert).toHaveTextContent(/server rejected policy/i);
   });
 
+  it('shows a top-level alert for reverify_failed (rate limit / network) — NOT a field error', async () => {
+    mocks.changePassword.mockRejectedValueOnce(
+      new SecurityApiError(
+        'For security purposes, you can only request this after 60 seconds.',
+        429,
+        'reverify_failed'
+      )
+    );
+    render(<SecurityTab />);
+
+    await userEvent.type(screen.getByLabelText('Password Attuale'), 'OldSecure1');
+    await userEvent.type(screen.getByLabelText('Nuova Password'), 'NewSecure22');
+    await userEvent.type(screen.getByLabelText('Conferma Password'), 'NewSecure22');
+    await userEvent.click(screen.getByRole('button', { name: /Aggiorna Password/i }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/60 seconds/i);
+    // Must NOT be routed to the currentPassword field
+    expect(
+      screen.queryByText('La password attuale non è corretta')
+    ).not.toBeInTheDocument();
+  });
+
   it('shows generic error message for non-SecurityApiError failures', async () => {
     mocks.changePassword.mockRejectedValueOnce(new Error('network down'));
     render(<SecurityTab />);

--- a/apps/web/__tests__/services/security.client.test.ts
+++ b/apps/web/__tests__/services/security.client.test.ts
@@ -69,9 +69,9 @@ describe('securityClient.changePassword', () => {
     expect(new Date(result.changedAt).toString()).not.toBe('Invalid Date');
   });
 
-  it('throws current_password_mismatch when re-verification fails', async () => {
+  it('throws current_password_mismatch when reverify returns invalid_credentials code', async () => {
     mocks.signInWithPassword.mockResolvedValueOnce({
-      error: { message: 'invalid login' },
+      error: { message: 'whatever', code: 'invalid_credentials', status: 400 },
     });
 
     await expect(
@@ -86,6 +86,84 @@ describe('securityClient.changePassword', () => {
       code: 'current_password_mismatch',
     });
     expect(mocks.updateUser).not.toHaveBeenCalled();
+  });
+
+  it('throws current_password_mismatch on legacy "Invalid login credentials" message without code', async () => {
+    mocks.signInWithPassword.mockResolvedValueOnce({
+      error: { message: 'Invalid login credentials' },
+    });
+
+    await expect(
+      securityClient.changePassword({
+        email: EMAIL,
+        currentPassword: CURR,
+        newPassword: NEW,
+      })
+    ).rejects.toMatchObject({
+      code: 'current_password_mismatch',
+    });
+  });
+
+  it('throws reverify_failed (NOT mismatch) on rate-limit errors', async () => {
+    mocks.signInWithPassword.mockResolvedValueOnce({
+      error: {
+        message: 'For security purposes, you can only request this after 60 seconds.',
+        status: 429,
+      },
+    });
+
+    await expect(
+      securityClient.changePassword({
+        email: EMAIL,
+        currentPassword: CURR,
+        newPassword: NEW,
+      })
+    ).rejects.toMatchObject({
+      name: 'SecurityApiError',
+      statusCode: 429,
+      code: 'reverify_failed',
+      message: expect.stringContaining('60 seconds'),
+    });
+    expect(mocks.updateUser).not.toHaveBeenCalled();
+  });
+
+  it('throws reverify_failed on email-not-confirmed error', async () => {
+    mocks.signInWithPassword.mockResolvedValueOnce({
+      error: {
+        message: 'Email not confirmed',
+        code: 'email_not_confirmed',
+        status: 400,
+      },
+    });
+
+    await expect(
+      securityClient.changePassword({
+        email: EMAIL,
+        currentPassword: CURR,
+        newPassword: NEW,
+      })
+    ).rejects.toMatchObject({
+      code: 'reverify_failed',
+      statusCode: 400,
+    });
+  });
+
+  it('throws reverify_failed with fallback message when reverify error has no message', async () => {
+    mocks.signInWithPassword.mockResolvedValueOnce({
+      error: { message: '' } as { message: string },
+    });
+
+    await expect(
+      securityClient.changePassword({
+        email: EMAIL,
+        currentPassword: CURR,
+        newPassword: NEW,
+      })
+    ).rejects.toMatchObject({
+      code: 'reverify_failed',
+      statusCode: 500,
+      message: expect.stringContaining('Impossibile verificare'),
+    });
   });
 
   it('throws update_failed when updateUser rejects', async () => {

--- a/apps/web/src/services/security.client.ts
+++ b/apps/web/src/services/security.client.ts
@@ -79,9 +79,19 @@ export const securityClient = {
   /**
    * Change the current user's password.
    *
-   * @throws {SecurityApiError} with `code='current_password_mismatch'` if the
-   *  current password re-verification fails, or `code='update_failed'` if the
-   *  new password is rejected by Supabase Auth.
+   * Error routing guidance for callers:
+   * - `missing_email` (400) → session is unusable; prompt re-login.
+   * - `current_password_mismatch` (401) → FIELD-LEVEL error on
+   *   `currentPassword`. The user typed the wrong current password.
+   * - `reverify_failed` (typically 429 / 400 / 500) → TOP-LEVEL alert.
+   *   Supabase returned an auth error that is NOT wrong-password
+   *   (rate limit, email not confirmed, network/server hiccup). Misrouting
+   *   these to the currentPassword field misleads the user.
+   * - `update_failed` (typically 500) → TOP-LEVEL alert. The current
+   *   password was accepted but the new one was rejected server-side
+   *   (e.g. breach-list match, weak policy).
+   *
+   * @throws {SecurityApiError} with one of the codes above.
    */
   async changePassword(params: {
     email: string;

--- a/apps/web/src/services/security.client.ts
+++ b/apps/web/src/services/security.client.ts
@@ -12,6 +12,7 @@
  */
 
 import { createClient } from '@/utils/supabase/client';
+import type { PasswordChangeResult } from '@/types/security';
 
 // =============================================================================
 // Error class
@@ -20,6 +21,7 @@ import { createClient } from '@/utils/supabase/client';
 export type SecurityErrorCode =
   | 'missing_email'
   | 'current_password_mismatch'
+  | 'reverify_failed'
   | 'update_failed'
   | 'unknown';
 
@@ -39,17 +41,39 @@ export class SecurityApiError extends Error {
 // Client
 // =============================================================================
 
+type SupabaseAuthError = {
+  message: string;
+  status?: number;
+  code?: string;
+  name?: string;
+};
+
 type SupabaseLike = {
   auth: {
     signInWithPassword: (creds: {
       email: string;
       password: string;
-    }) => Promise<{ error: { message: string } | null }>;
+    }) => Promise<{ error: SupabaseAuthError | null }>;
     updateUser: (attrs: {
       password: string;
-    }) => Promise<{ error: { message: string } | null }>;
+    }) => Promise<{ error: SupabaseAuthError | null }>;
   };
 };
+
+/**
+ * Distinguish a genuine wrong-password from other Supabase auth failures
+ * (rate limit, email not confirmed, network, server error). Only the first
+ * should be routed to the currentPassword field as a validation error;
+ * everything else belongs in the top-level alert.
+ *
+ * Supabase >= 2.43 returns `error.code = 'invalid_credentials'` on wrong
+ * password. Older versions only expose `message: "Invalid login credentials"`.
+ * We accept both.
+ */
+function isWrongPassword(err: SupabaseAuthError): boolean {
+  if (err.code === 'invalid_credentials') return true;
+  return /invalid\s*(login|credentials)/i.test(err.message || '');
+}
 
 export const securityClient = {
   /**
@@ -63,7 +87,7 @@ export const securityClient = {
     email: string;
     currentPassword: string;
     newPassword: string;
-  }): Promise<{ changedAt: string }> {
+  }): Promise<PasswordChangeResult> {
     const { email, currentPassword, newPassword } = params;
 
     if (!email) {
@@ -84,11 +108,23 @@ export const securityClient = {
       password: currentPassword,
     });
     if (reverify.error) {
+      const err = reverify.error;
+      if (isWrongPassword(err)) {
+        throw new SecurityApiError(
+          'La password attuale non è corretta',
+          401,
+          'current_password_mismatch',
+          err
+        );
+      }
+      // Rate limit, email not confirmed, network, server error: surface
+      // as a top-level banner, not a field error.
       throw new SecurityApiError(
-        'La password attuale non è corretta',
-        401,
-        'current_password_mismatch',
-        reverify.error
+        err.message ||
+          'Impossibile verificare la password attuale. Riprova più tardi.',
+        err.status || 500,
+        'reverify_failed',
+        err
       );
     }
 
@@ -98,7 +134,7 @@ export const securityClient = {
       throw new SecurityApiError(
         update.error.message ||
           'Impossibile aggiornare la password. Riprova più tardi.',
-        500,
+        update.error.status || 500,
         'update_failed',
         update.error
       );

--- a/apps/web/src/types/security.ts
+++ b/apps/web/src/types/security.ts
@@ -52,6 +52,11 @@ export type PasswordChangeInput = z.infer<typeof passwordChangeSchema>;
  * definition.
  */
 export interface PasswordChangeResult {
-  /** ISO-8601 timestamp of when the server confirmed the update. */
+  /**
+   * ISO-8601 timestamp of when the client confirmed the password change
+   * succeeded (i.e. Supabase `updateUser` returned without error).
+   * Client-generated; Supabase does not expose a dedicated server timestamp
+   * for password updates.
+   */
   changedAt: string;
 }

--- a/apps/web/src/types/security.ts
+++ b/apps/web/src/types/security.ts
@@ -46,6 +46,12 @@ export type PasswordChangeInput = z.infer<typeof passwordChangeSchema>;
 // Result shape
 // =============================================================================
 
+/**
+ * Returned by `securityClient.changePassword` on success.
+ * Used as the public return type so callers + tests share a single
+ * definition.
+ */
 export interface PasswordChangeResult {
+  /** ISO-8601 timestamp of when the server confirmed the update. */
   changedAt: string;
 }


### PR DESCRIPTION
## Summary

Post-merge follow-up applying two Copilot review comments missed on PR #443 due to premature auto-merge labelling (flagged immediately at PR creation instead of after Copilot's asynchronous review).

### Fixes

1. **\`PasswordChangeResult\` now the service return type** — was exported but unused; service returned inline \`{changedAt: string}\` creating drift risk. Aligned.

2. **Reverify errors no longer all become \`current_password_mismatch\`** — previously rate-limit / email-not-confirmed / network errors were misrouted to the \`currentPassword\` field as "password errata". New \`isWrongPassword(err)\` helper distinguishes genuine invalid-credentials (via \`code === 'invalid_credentials'\` OR legacy message match) from other failures. The latter throw with new code \`reverify_failed\` and propagate the original HTTP status → surfaced as top-level alert banner, not field error.

### Tests

+5 tests, suite now 1484 pass / 2 skip / 0 fail. New coverage:
- \`invalid_credentials\` code path (current Supabase ≥ 2.43)
- Legacy "Invalid login credentials" message path (older Supabase)
- Rate-limit (status 429) → \`reverify_failed\`
- Email-not-confirmed (code \`email_not_confirmed\`, status 400) → \`reverify_failed\`
- Empty error message → fallback i18n-friendly message
- Component test: reverify_failed renders top-level alert, explicitly NOT the \`currentPassword\` field error

## Process note

This PR is being opened **without** the \`auto-merge\` label on purpose. I want Copilot to review first, then manually apply the label if clean. Lesson learned from #443: applying \`auto-merge\` at PR open time bypasses Copilot review (which takes ~2 min to spawn, while CI + label-gate can merge within 1 min). See forthcoming \`feedback_auto_merge_label_timing.md\` memo.

## Test plan

- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm lint\` — 0 errors (3 pre-existing warnings)
- [x] \`pnpm --filter @money-wise/web test\` — 1484 / 2 skip
- [ ] **After Copilot review**, if no new blocking issues → add \`auto-merge\` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)