### PR TITLE
feat(settings): GDPR Dati tab with real account deletion flow

### DIFF
--- a/apps/web/__tests__/components/settings/DataTab.test.tsx
+++ b/apps/web/__tests__/components/settings/DataTab.test.tsx
@@ -1,0 +1,208 @@
+/**
+ * Tests for DataTab — delete-account happy/error paths + confirm phrase gate.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const mocks = vi.hoisted(() => ({
+  deleteAccount: vi.fn(),
+  logout: vi.fn(),
+  routerReplace: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: mocks.routerReplace, push: vi.fn() }),
+}));
+
+vi.mock('../../../src/store/auth.store', () => ({
+  useAuthStore: <T,>(selector: (s: { logout: typeof mocks.logout }) => T) =>
+    selector({ logout: mocks.logout }),
+}));
+
+vi.mock('../../../src/services/gdpr.client', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../../src/services/gdpr.client')
+  >('../../../src/services/gdpr.client');
+  return {
+    ...actual,
+    gdprClient: { deleteAccount: mocks.deleteAccount },
+  };
+});
+
+import { DataTab } from '../../../src/components/settings/DataTab';
+import { GdprApiError } from '../../../src/services/gdpr.client';
+
+describe('DataTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.logout.mockResolvedValue(undefined);
+  });
+
+  it('renders export placeholder + danger zone initially', () => {
+    render(<DataTab />);
+    expect(screen.getByText('Esportazione Dati')).toBeInTheDocument();
+    expect(screen.getByText('Zona Pericolosa')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /^Elimina$/i })
+    ).toBeInTheDocument();
+  });
+
+  it('shows the delete form after clicking "Elimina"', async () => {
+    render(<DataTab />);
+    await userEvent.click(screen.getByRole('button', { name: /^Elimina$/i }));
+    expect(screen.getByLabelText(/Conferma con la tua password/i)).toBeInTheDocument();
+    expect(screen.getByText(/Digita/i)).toBeInTheDocument();
+  });
+
+  it('blocks submit when confirm phrase is wrong', async () => {
+    render(<DataTab />);
+    await userEvent.click(screen.getByRole('button', { name: /^Elimina$/i }));
+
+    await userEvent.type(
+      screen.getByLabelText(/Conferma con la tua password/i),
+      'p'
+    );
+    await userEvent.type(screen.getByLabelText(/Digita/i), 'WRONG');
+    await userEvent.click(
+      screen.getByRole('button', { name: /Conferma Eliminazione Definitiva/i })
+    );
+
+    expect(await screen.findByText(/Digita ELIMINA/i)).toBeInTheDocument();
+    expect(mocks.deleteAccount).not.toHaveBeenCalled();
+  });
+
+  it('blocks submit when password is empty', async () => {
+    render(<DataTab />);
+    await userEvent.click(screen.getByRole('button', { name: /^Elimina$/i }));
+
+    await userEvent.type(screen.getByLabelText(/Digita/i), 'ELIMINA');
+    await userEvent.click(
+      screen.getByRole('button', { name: /Conferma Eliminazione Definitiva/i })
+    );
+
+    expect(await screen.findByText(/password è obbligatoria/i)).toBeInTheDocument();
+    expect(mocks.deleteAccount).not.toHaveBeenCalled();
+  });
+
+  it('calls the service with password + exportDataFirst=false on happy path', async () => {
+    mocks.deleteAccount.mockResolvedValueOnce({
+      success: true,
+      deletedAt: '2026-04-17T20:00:00.000Z',
+      familyDeleted: false,
+    });
+    render(<DataTab />);
+    await userEvent.click(screen.getByRole('button', { name: /^Elimina$/i }));
+
+    await userEvent.type(
+      screen.getByLabelText(/Conferma con la tua password/i),
+      'hunter2'
+    );
+    await userEvent.type(screen.getByLabelText(/Digita/i), 'ELIMINA');
+    await userEvent.click(
+      screen.getByRole('button', { name: /Conferma Eliminazione Definitiva/i })
+    );
+
+    await waitFor(() => {
+      expect(mocks.deleteAccount).toHaveBeenCalledWith({
+        password: 'hunter2',
+        exportDataFirst: false,
+      });
+    });
+
+    await waitFor(() => {
+      expect(mocks.logout).toHaveBeenCalled();
+      expect(mocks.routerReplace).toHaveBeenCalledWith('/auth/login?deleted=1');
+    });
+  });
+
+  it('forwards exportDataFirst=true when checkbox is checked', async () => {
+    mocks.deleteAccount.mockResolvedValueOnce({
+      success: true,
+      deletedAt: '2026-04-17T20:00:00.000Z',
+      familyDeleted: false,
+      exportData: { profile: { id: 'u' } },
+    });
+    render(<DataTab />);
+    await userEvent.click(screen.getByRole('button', { name: /^Elimina$/i }));
+
+    await userEvent.type(
+      screen.getByLabelText(/Conferma con la tua password/i),
+      'hunter2'
+    );
+    // Check the export checkbox (first within the danger zone form)
+    const checkbox = screen
+      .getAllByRole('checkbox')
+      .find((c) => !(c as HTMLInputElement).disabled);
+    if (checkbox) await userEvent.click(checkbox);
+
+    await userEvent.type(screen.getByLabelText(/Digita/i), 'ELIMINA');
+    await userEvent.click(
+      screen.getByRole('button', { name: /Conferma Eliminazione Definitiva/i })
+    );
+
+    await waitFor(() => {
+      expect(mocks.deleteAccount).toHaveBeenCalledWith({
+        password: 'hunter2',
+        exportDataFirst: true,
+      });
+    });
+  });
+
+  it('routes password_mismatch to the password field, not the top-level alert', async () => {
+    mocks.deleteAccount.mockRejectedValueOnce(
+      new GdprApiError('La password non è corretta', 401, 'password_mismatch')
+    );
+    render(<DataTab />);
+    await userEvent.click(screen.getByRole('button', { name: /^Elimina$/i }));
+
+    await userEvent.type(
+      screen.getByLabelText(/Conferma con la tua password/i),
+      'wrong'
+    );
+    await userEvent.type(screen.getByLabelText(/Digita/i), 'ELIMINA');
+    await userEvent.click(
+      screen.getByRole('button', { name: /Conferma Eliminazione Definitiva/i })
+    );
+
+    expect(
+      await screen.findByText(/password non è corretta/i)
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(mocks.routerReplace).not.toHaveBeenCalled();
+  });
+
+  it('shows top-level alert for non-password errors', async () => {
+    mocks.deleteAccount.mockRejectedValueOnce(
+      new GdprApiError('Eliminazione fallita. Riprova.', 500, 'delete_failed')
+    );
+    render(<DataTab />);
+    await userEvent.click(screen.getByRole('button', { name: /^Elimina$/i }));
+
+    await userEvent.type(
+      screen.getByLabelText(/Conferma con la tua password/i),
+      'hunter2'
+    );
+    await userEvent.type(screen.getByLabelText(/Digita/i), 'ELIMINA');
+    await userEvent.click(
+      screen.getByRole('button', { name: /Conferma Eliminazione Definitiva/i })
+    );
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/Eliminazione fallita/i);
+    expect(mocks.routerReplace).not.toHaveBeenCalled();
+  });
+
+  it('cancel button returns to the initial state', async () => {
+    render(<DataTab />);
+    await userEvent.click(screen.getByRole('button', { name: /^Elimina$/i }));
+    expect(screen.getByLabelText(/Conferma con la tua password/i)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /Annulla/i }));
+    expect(
+      screen.queryByLabelText(/Conferma con la tua password/i)
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^Elimina$/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/__tests__/services/gdpr.client.test.ts
+++ b/apps/web/__tests__/services/gdpr.client.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests for services/gdpr.client — account-delete edge function wrapper.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock('../../src/utils/supabase/client', () => ({
+  createClient: vi.fn(() => ({
+    functions: { invoke: mocks.invoke },
+  })),
+}));
+
+import { gdprClient, GdprApiError } from '../../src/services/gdpr.client';
+
+describe('gdprClient.deleteAccount', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.invoke.mockReset();
+  });
+
+  it('returns the server result on happy path', async () => {
+    mocks.invoke.mockResolvedValueOnce({
+      data: {
+        success: true,
+        deletedAt: '2026-04-17T20:00:00.000Z',
+        familyDeleted: true,
+      },
+      error: null,
+    });
+
+    const r = await gdprClient.deleteAccount({
+      password: 'p',
+      exportDataFirst: false,
+    });
+    expect(r.success).toBe(true);
+    expect(r.deletedAt).toBe('2026-04-17T20:00:00.000Z');
+    expect(r.familyDeleted).toBe(true);
+
+    expect(mocks.invoke).toHaveBeenCalledWith('account-delete', {
+      body: { password: 'p', exportDataFirst: false },
+    });
+  });
+
+  it('passes exportData through when server returns it', async () => {
+    mocks.invoke.mockResolvedValueOnce({
+      data: {
+        success: true,
+        deletedAt: '2026-04-17T20:00:00.000Z',
+        familyDeleted: false,
+        exportData: { profile: { id: 'u' } },
+      },
+      error: null,
+    });
+
+    const r = await gdprClient.deleteAccount({
+      password: 'p',
+      exportDataFirst: true,
+    });
+    expect(r.exportData).toEqual({ profile: { id: 'u' } });
+  });
+
+  it('maps password_mismatch to code=password_mismatch (401)', async () => {
+    mocks.invoke.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'password_mismatch', context: { status: 401 } },
+    });
+
+    await expect(
+      gdprClient.deleteAccount({ password: 'p', exportDataFirst: false })
+    ).rejects.toMatchObject({
+      name: 'GdprApiError',
+      code: 'password_mismatch',
+      statusCode: 401,
+    });
+  });
+
+  it('maps profile_not_found to code=profile_not_found (404)', async () => {
+    mocks.invoke.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'profile_not_found', context: { status: 404 } },
+    });
+
+    await expect(
+      gdprClient.deleteAccount({ password: 'p', exportDataFirst: false })
+    ).rejects.toMatchObject({ code: 'profile_not_found', statusCode: 404 });
+  });
+
+  it('maps export_failed prefix to code=export_failed', async () => {
+    mocks.invoke.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'export_failed: something broke', context: { status: 500 } },
+    });
+
+    await expect(
+      gdprClient.deleteAccount({ password: 'p', exportDataFirst: true })
+    ).rejects.toMatchObject({ code: 'export_failed', statusCode: 500 });
+  });
+
+  it('maps family_delete_failed / user_delete_failed to code=delete_failed', async () => {
+    for (const msg of ['family_delete_failed: x', 'user_delete_failed: y']) {
+      mocks.invoke.mockResolvedValueOnce({
+        data: null,
+        error: { message: msg, context: { status: 500 } },
+      });
+      await expect(
+        gdprClient.deleteAccount({ password: 'p', exportDataFirst: false })
+      ).rejects.toMatchObject({ code: 'delete_failed' });
+    }
+  });
+
+  it('maps generic 500 to code=delete_failed', async () => {
+    mocks.invoke.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'internal_error: unknown', context: { status: 500 } },
+    });
+    await expect(
+      gdprClient.deleteAccount({ password: 'p', exportDataFirst: false })
+    ).rejects.toMatchObject({ code: 'delete_failed' });
+  });
+
+  it('throws network error when invoke itself rejects', async () => {
+    mocks.invoke.mockRejectedValueOnce(new Error('fetch failed'));
+    await expect(
+      gdprClient.deleteAccount({ password: 'p', exportDataFirst: false })
+    ).rejects.toMatchObject({
+      code: 'network',
+      statusCode: 0,
+      message: expect.stringContaining('Connessione'),
+    });
+  });
+
+  it('throws unknown error when data is missing / success!=true', async () => {
+    mocks.invoke.mockResolvedValueOnce({ data: null, error: null });
+    await expect(
+      gdprClient.deleteAccount({ password: 'p', exportDataFirst: false })
+    ).rejects.toMatchObject({ code: 'unknown' });
+
+    mocks.invoke.mockResolvedValueOnce({
+      data: { success: false } as unknown,
+      error: null,
+    });
+    await expect(
+      gdprClient.deleteAccount({ password: 'p', exportDataFirst: false })
+    ).rejects.toMatchObject({ code: 'unknown' });
+  });
+});
+
+describe('GdprApiError', () => {
+  it('carries code + statusCode + details', () => {
+    const err = new GdprApiError('msg', 418, 'unknown', { x: 1 });
+    expect(err.message).toBe('msg');
+    expect(err.statusCode).toBe(418);
+    expect(err.code).toBe('unknown');
+    expect(err.details).toEqual({ x: 1 });
+    expect(err.name).toBe('GdprApiError');
+  });
+
+  it('defaults code to unknown', () => {
+    const err = new GdprApiError('x', 500);
+    expect(err.code).toBe('unknown');
+  });
+});

--- a/apps/web/__tests__/types/gdpr.test.ts
+++ b/apps/web/__tests__/types/gdpr.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Tests for types/gdpr — deleteAccountSchema validation.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  deleteAccountSchema,
+  DELETE_CONFIRM_PHRASE,
+} from '../../src/types/gdpr';
+
+const VALID = {
+  password: 'hunter2',
+  exportDataFirst: false,
+  confirmPhrase: 'ELIMINA',
+};
+
+describe('deleteAccountSchema', () => {
+  it('accepts valid input with exportDataFirst=false', () => {
+    const r = deleteAccountSchema.safeParse(VALID);
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts valid input with exportDataFirst=true', () => {
+    const r = deleteAccountSchema.safeParse({ ...VALID, exportDataFirst: true });
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects empty password', () => {
+    const r = deleteAccountSchema.safeParse({ ...VALID, password: '' });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues.some((i) => i.path[0] === 'password')).toBe(true);
+    }
+  });
+
+  it('rejects wrong confirm phrase', () => {
+    const r = deleteAccountSchema.safeParse({ ...VALID, confirmPhrase: 'DELETE' });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(
+        r.error.issues.some((i) => i.path[0] === 'confirmPhrase')
+      ).toBe(true);
+    }
+  });
+
+  it('accepts case-insensitive / trimmed confirm phrase', () => {
+    for (const phrase of ['elimina', ' ELIMINA ', 'Elimina']) {
+      expect(
+        deleteAccountSchema.safeParse({ ...VALID, confirmPhrase: phrase }).success
+      ).toBe(true);
+    }
+  });
+
+  it('rejects missing exportDataFirst (must be boolean)', () => {
+    const r = deleteAccountSchema.safeParse({
+      password: 'p',
+      confirmPhrase: 'ELIMINA',
+    });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe('DELETE_CONFIRM_PHRASE', () => {
+  it('is the expected literal', () => {
+    expect(DELETE_CONFIRM_PHRASE).toBe('ELIMINA');
+  });
+});

--- a/apps/web/app/dashboard/settings/page.tsx
+++ b/apps/web/app/dashboard/settings/page.tsx
@@ -15,6 +15,7 @@ import { createClient } from '@/utils/supabase/client';
 import { CategoryManager } from '@/components/categories/CategoryManager';
 import { NotificationsTab } from '@/components/settings/NotificationsTab';
 import { SecurityTab } from '@/components/settings/SecurityTab';
+import { DataTab } from '@/components/settings/DataTab';
 import {
   User,
   CreditCard,
@@ -30,11 +31,9 @@ import {
   Building2,
   CheckCircle2,
   X as XIcon,
-  Download,
   FileSpreadsheet,
   Zap,
   RefreshCw,
-  Trash2,
   Key,
   Monitor,
   TrendingUp,
@@ -218,8 +217,6 @@ export default function SettingsPage() {
   const [apiKeys, setApiKeys] = useState({ openai: '', anthropic: '', gemini: '', coinbase: '', plaid: '' });
   const [apiKeyFeedback, setApiKeyFeedback] = useState<string | null>(null);
 
-  // Data state
-  const [dataFeedback, setDataFeedback] = useState<string | null>(null);
 
   // Initialize form with user data
   useEffect(() => {
@@ -985,78 +982,7 @@ export default function SettingsPage() {
       {/* ================================================================= */}
       {/* Data Tab */}
       {/* ================================================================= */}
-      {activeTab === 'data' && (
-        <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} className="space-y-6">
-          <Card className="p-6 rounded-2xl border-0 shadow-sm">
-            <h3 className="text-lg font-semibold text-foreground mb-6">Gestione Dati</h3>
-            {dataFeedback && (
-              <div className="mb-4 flex items-center gap-2 p-3 bg-emerald-500/10 rounded-xl">
-                <Check className="w-4 h-4 text-emerald-600" />
-                <span className="text-[13px] text-emerald-600">{dataFeedback}</span>
-              </div>
-            )}
-            <div className="space-y-4">
-              <div className="flex items-center justify-between p-4 bg-muted/30 rounded-xl">
-                <div className="flex items-center gap-3">
-                  <Download className="w-5 h-5 text-blue-600" />
-                  <div>
-                    <p className="font-medium text-foreground">Esporta Tutti i Dati</p>
-                    <p className="text-sm text-muted-foreground">Scarica un backup completo in JSON</p>
-                  </div>
-                </div>
-                <Button
-                  variant="outline"
-                  onClick={() => showFeedback(setDataFeedback, 'Export completato! File scaricato.')}
-                >
-                  <Download className="w-4 h-4 mr-2" /> Esporta
-                </Button>
-              </div>
-              <div className="flex items-center justify-between p-4 bg-muted/30 rounded-xl">
-                <div className="flex items-center gap-3">
-                  <FileSpreadsheet className="w-5 h-5 text-green-600" />
-                  <div>
-                    <p className="font-medium text-foreground">Export Mensile Automatico</p>
-                    <p className="text-sm text-muted-foreground">Ricevi un report CSV ogni primo del mese</p>
-                  </div>
-                </div>
-                <input type="checkbox" className={TOGGLE_CLASS} />
-              </div>
-            </div>
-          </Card>
-
-          <Card className="p-6 rounded-2xl border-red-200 dark:border-red-800">
-            <h3 className="text-lg font-semibold text-red-600 mb-4">Zona Pericolosa</h3>
-            <div className="space-y-4">
-              <div className="flex items-center justify-between p-4 bg-red-50 dark:bg-red-950/20 rounded-xl">
-                <div>
-                  <p className="font-medium text-foreground">Reset Dati Demo</p>
-                  <p className="text-sm text-muted-foreground">Ripristina tutti i dati ai valori iniziali</p>
-                </div>
-                <Button
-                  variant="outline"
-                  className="text-red-600 border-red-300 hover:bg-red-50"
-                  onClick={() => showFeedback(setDataFeedback, 'Dati resettati ai valori demo')}
-                >
-                  <RefreshCw className="w-4 h-4 mr-2" /> Reset
-                </Button>
-              </div>
-              <div className="flex items-center justify-between p-4 bg-red-50 dark:bg-red-950/20 rounded-xl">
-                <div>
-                  <p className="font-medium text-foreground">Elimina Account</p>
-                  <p className="text-sm text-muted-foreground">Cancella permanentemente tutti i dati</p>
-                </div>
-                <Button
-                  variant="outline"
-                  className="text-red-600 border-red-300 hover:bg-red-50"
-                  onClick={() => showFeedback(setDataFeedback, 'Funzione disabilitata nella demo')}
-                >
-                  <Trash2 className="w-4 h-4 mr-2" /> Elimina
-                </Button>
-              </div>
-            </div>
-          </Card>
-        </motion.div>
-      )}
+      {activeTab === 'data' && <DataTab />}
     </div>
   );
 }

--- a/apps/web/src/components/settings/DataTab.tsx
+++ b/apps/web/src/components/settings/DataTab.tsx
@@ -1,0 +1,366 @@
+/**
+ * DataTab — Settings > Dati tab
+ *
+ * Two sections:
+ *   - Esportazione Dati: placeholder "In arrivo" (standalone export needs
+ *     a dedicated edge function — out of scope for Sprint 1.3)
+ *   - Zona Pericolosa: "Elimina Account" wired to the `account-delete` edge
+ *     function (PR #441). Defense-in-depth UX:
+ *       1. Primary button reveals a confirmation form
+ *       2. User types their password + the literal word "ELIMINA"
+ *       3. Optional "Esporta prima" checkbox → JSON download before deletion
+ *       4. On server success: trigger export download (if any), then logout
+ *          and redirect to /auth/login (session is dead server-side)
+ *
+ * @module components/settings/DataTab
+ */
+
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { motion } from 'framer-motion';
+import {
+  AlertCircle,
+  AlertTriangle,
+  Download,
+  FileSpreadsheet,
+  Loader2,
+  Trash2,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useAuthStore } from '@/store/auth.store';
+import { gdprClient, GdprApiError } from '@/services/gdpr.client';
+import {
+  deleteAccountSchema,
+  DELETE_CONFIRM_PHRASE,
+  type DeleteAccountInput,
+} from '@/types/gdpr';
+
+// =============================================================================
+// Export download helper (client-side blob)
+// =============================================================================
+
+function triggerExportDownload(data: Record<string, unknown>) {
+  try {
+    const json = JSON.stringify(data, null, 2);
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `moneywise-export-${new Date().toISOString().slice(0, 10)}.json`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  } catch {
+    // Non-fatal: the account was deleted regardless; user can request again
+    // from their email if needed. We don't block the redirect.
+  }
+}
+
+// =============================================================================
+// Export section (placeholder)
+// =============================================================================
+
+function ExportSection() {
+  return (
+    <Card className="p-6 rounded-2xl border-0 shadow-sm">
+      <div className="flex items-center gap-2 mb-6">
+        <h3 className="text-lg font-semibold text-foreground">Esportazione Dati</h3>
+        <span className="text-[11px] px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
+          In arrivo
+        </span>
+      </div>
+      <div className="space-y-4">
+        <div className="flex items-center justify-between p-4 bg-muted/30 rounded-xl opacity-70">
+          <div className="flex items-center gap-3">
+            <Download className="w-5 h-5 text-blue-600" />
+            <div>
+              <p className="font-medium text-foreground">Esporta Tutti i Dati</p>
+              <p className="text-sm text-muted-foreground">
+                Scarica un backup completo in JSON. Per ora disponibile solo
+                insieme all&apos;eliminazione account qui sotto.
+              </p>
+            </div>
+          </div>
+          <Button variant="outline" disabled>
+            <Download className="w-4 h-4 mr-2" /> Esporta
+          </Button>
+        </div>
+        <div className="flex items-center justify-between p-4 bg-muted/30 rounded-xl opacity-70">
+          <div className="flex items-center gap-3">
+            <FileSpreadsheet className="w-5 h-5 text-green-600" />
+            <div>
+              <p className="font-medium text-foreground">Export Mensile Automatico</p>
+              <p className="text-sm text-muted-foreground">
+                Ricevi un report CSV ogni primo del mese
+              </p>
+            </div>
+          </div>
+          <input
+            type="checkbox"
+            disabled
+            className="w-10 h-6 appearance-none bg-muted rounded-full relative cursor-not-allowed"
+            aria-label="Export mensile automatico — non ancora disponibile"
+          />
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+// =============================================================================
+// Delete account form
+// =============================================================================
+
+type FormState = Partial<DeleteAccountInput>;
+
+type FieldErrors = Partial<Record<keyof DeleteAccountInput, string>>;
+
+function DeleteAccountForm({ onCancel }: { onCancel: () => void }) {
+  const router = useRouter();
+  const logout = useAuthStore((s) => s.logout);
+
+  const [form, setForm] = useState<FormState>({
+    password: '',
+    exportDataFirst: false,
+    confirmPhrase: '',
+  });
+  const [errors, setErrors] = useState<FieldErrors>({});
+  const [serverError, setServerError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const setField = <K extends keyof DeleteAccountInput>(
+    key: K,
+    value: DeleteAccountInput[K]
+  ) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+    if (errors[key]) setErrors((prev) => ({ ...prev, [key]: undefined }));
+    if (serverError) setServerError(null);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (submitting) return;
+
+    setServerError(null);
+    const parsed = deleteAccountSchema.safeParse(form);
+    if (!parsed.success) {
+      const next: FieldErrors = {};
+      for (const issue of parsed.error.issues) {
+        const k = issue.path[0] as keyof DeleteAccountInput | undefined;
+        if (k && !next[k]) next[k] = issue.message;
+      }
+      setErrors(next);
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const result = await gdprClient.deleteAccount({
+        password: parsed.data.password,
+        exportDataFirst: parsed.data.exportDataFirst,
+      });
+      if (result.exportData) {
+        triggerExportDownload(result.exportData);
+      }
+      // Session is dead server-side. Invalidate local store + redirect.
+      try {
+        await logout();
+      } catch {
+        // Already invalid; the redirect is what matters.
+      }
+      router.replace('/auth/login?deleted=1');
+    } catch (err) {
+      if (err instanceof GdprApiError) {
+        if (err.code === 'password_mismatch') {
+          setErrors({ password: err.message });
+        } else {
+          setServerError(err.message);
+        }
+      } else {
+        setServerError(
+          'Errore imprevisto durante l\'eliminazione. Riprova.'
+        );
+      }
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="space-y-4 p-4 bg-red-50 dark:bg-red-950/20 rounded-xl border border-red-200 dark:border-red-900"
+      noValidate
+    >
+      <div className="flex items-start gap-2">
+        <AlertTriangle
+          className="w-5 h-5 text-red-600 flex-shrink-0 mt-0.5"
+          aria-hidden="true"
+        />
+        <div className="text-sm text-red-900 dark:text-red-200 space-y-1">
+          <p className="font-medium">Questa azione è irreversibile.</p>
+          <p>
+            Tutti i tuoi dati (profilo, transazioni, categorie, budget, notifiche)
+            saranno eliminati permanentemente dal nostro server.
+          </p>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="delete-password">Conferma con la tua password</Label>
+        <Input
+          id="delete-password"
+          type="password"
+          autoComplete="current-password"
+          value={form.password ?? ''}
+          onChange={(e) => setField('password', e.target.value)}
+          aria-invalid={!!errors.password}
+          aria-describedby={errors.password ? 'delete-password-error' : undefined}
+          disabled={submitting}
+        />
+        {errors.password && (
+          <p id="delete-password-error" className="text-sm text-destructive">
+            {errors.password}
+          </p>
+        )}
+      </div>
+
+      <label className="flex items-start gap-3 cursor-pointer">
+        <input
+          type="checkbox"
+          className="mt-1"
+          checked={form.exportDataFirst ?? false}
+          onChange={(e) => setField('exportDataFirst', e.target.checked)}
+          disabled={submitting}
+        />
+        <span className="text-sm text-foreground">
+          Esporta i miei dati in JSON prima di eliminare. Il download partirà
+          automaticamente.
+        </span>
+      </label>
+
+      <div className="space-y-2">
+        <Label htmlFor="delete-confirm">
+          Digita <span className="font-mono font-semibold">{DELETE_CONFIRM_PHRASE}</span>{' '}
+          per confermare
+        </Label>
+        <Input
+          id="delete-confirm"
+          type="text"
+          autoComplete="off"
+          value={form.confirmPhrase ?? ''}
+          onChange={(e) => setField('confirmPhrase', e.target.value)}
+          aria-invalid={!!errors.confirmPhrase}
+          aria-describedby={
+            errors.confirmPhrase ? 'delete-confirm-error' : undefined
+          }
+          disabled={submitting}
+        />
+        {errors.confirmPhrase && (
+          <p id="delete-confirm-error" className="text-sm text-destructive">
+            {errors.confirmPhrase}
+          </p>
+        )}
+      </div>
+
+      {serverError && (
+        <div
+          role="alert"
+          className="flex items-center gap-2 p-3 bg-red-500/10 rounded-xl"
+        >
+          <AlertCircle className="w-4 h-4 text-red-600 flex-shrink-0" />
+          <span className="text-[13px] text-red-600">{serverError}</span>
+        </div>
+      )}
+
+      <div className="flex items-center gap-2 pt-2">
+        <Button
+          type="submit"
+          disabled={submitting}
+          className="bg-red-600 hover:bg-red-700 text-white border-0"
+        >
+          {submitting ? (
+            <>
+              <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+              Eliminazione in corso...
+            </>
+          ) : (
+            <>
+              <Trash2 className="w-4 h-4 mr-2" /> Conferma Eliminazione Definitiva
+            </>
+          )}
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onCancel}
+          disabled={submitting}
+        >
+          Annulla
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+// =============================================================================
+// Danger zone card
+// =============================================================================
+
+function DangerZone() {
+  const [showDelete, setShowDelete] = useState(false);
+
+  return (
+    <Card className="p-6 rounded-2xl border-red-200 dark:border-red-800">
+      <h3 className="text-lg font-semibold text-red-600 mb-4">Zona Pericolosa</h3>
+      <div className="space-y-4">
+        {!showDelete ? (
+          <div className="flex items-center justify-between p-4 bg-red-50 dark:bg-red-950/20 rounded-xl">
+            <div>
+              <p className="font-medium text-foreground">Elimina Account</p>
+              <p className="text-sm text-muted-foreground">
+                Cancella permanentemente tutti i dati. GDPR Art. 17 (diritto all&apos;oblio).
+              </p>
+            </div>
+            <Button
+              variant="outline"
+              className="text-red-600 border-red-300 hover:bg-red-50"
+              onClick={() => setShowDelete(true)}
+            >
+              <Trash2 className="w-4 h-4 mr-2" /> Elimina
+            </Button>
+          </div>
+        ) : (
+          <DeleteAccountForm onCancel={() => setShowDelete(false)} />
+        )}
+      </div>
+    </Card>
+  );
+}
+
+// =============================================================================
+// Main component
+// =============================================================================
+
+export function DataTab() {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      className="space-y-6"
+    >
+      <ExportSection />
+      <DangerZone />
+    </motion.div>
+  );
+}
+
+export default DataTab;
+
+// Re-export for tests that want to drive the inner form directly
+export { DeleteAccountForm as __DeleteAccountForm };

--- a/apps/web/src/components/settings/DataTab.tsx
+++ b/apps/web/src/components/settings/DataTab.tsx
@@ -17,7 +17,7 @@
 
 'use client';
 
-import { useState } from 'react';
+import { useState, type FormEvent } from 'react';
 import { useRouter } from 'next/navigation';
 import { motion } from 'framer-motion';
 import {
@@ -143,7 +143,7 @@ function DeleteAccountForm({ onCancel }: { onCancel: () => void }) {
     if (serverError) setServerError(null);
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     if (submitting) return;
 

--- a/apps/web/src/services/gdpr.client.ts
+++ b/apps/web/src/services/gdpr.client.ts
@@ -8,6 +8,7 @@
  * @module services/gdpr.client
  */
 
+import { FunctionsHttpError } from '@supabase/supabase-js';
 import { createClient } from '@/utils/supabase/client';
 import type { DeleteAccountResult } from '@/types/gdpr';
 
@@ -32,6 +33,9 @@ export class GdprApiError extends Error {
   ) {
     super(message);
     this.name = 'GdprApiError';
+    // Preserve `instanceof` across transpilation targets — aligned with
+    // other error classes in this repo (e.g. BankingApiError).
+    Object.setPrototypeOf(this, GdprApiError.prototype);
   }
 }
 
@@ -44,12 +48,7 @@ type SupabaseLike = {
     invoke: <T = unknown>(
       name: string,
       opts: { body: unknown }
-    ) => Promise<{
-      data: T | null;
-      error:
-        | { message?: string; context?: { status?: number } }
-        | null;
-    }>;
+    ) => Promise<{ data: T | null; error: unknown }>;
   };
 };
 
@@ -66,6 +65,42 @@ function mapErrorCode(
   }
   if (httpStatus && httpStatus >= 500) return 'delete_failed';
   return 'unknown';
+}
+
+/**
+ * Parse a supabase.functions.invoke() error into (message, httpStatus).
+ *
+ * `FunctionsHttpError` carries the real response body in `error.context`.
+ * Edge functions in this repo return `{ error: "<message>" }` on non-2xx,
+ * so we must read the body to recover the server-side error message —
+ * otherwise `error.message` is a generic HTTP description.
+ *
+ * Non-HTTP errors (network, relay) fall through to the `.message` field.
+ */
+async function parseInvokeError(error: unknown): Promise<{
+  serverMsg: string;
+  httpStatus: number | undefined;
+}> {
+  if (error instanceof FunctionsHttpError) {
+    const status = error.context?.status;
+    try {
+      const body = (await error.context.json()) as
+        | { error?: string; message?: string }
+        | null;
+      const serverMsg =
+        body?.error || body?.message || error.message || '';
+      return { serverMsg, httpStatus: status };
+    } catch {
+      return { serverMsg: error.message || '', httpStatus: status };
+    }
+  }
+  if (error && typeof error === 'object') {
+    const e = error as { message?: unknown; context?: { status?: number } };
+    const m = typeof e.message === 'string' ? e.message : '';
+    const status = typeof e.context?.status === 'number' ? e.context.status : undefined;
+    return { serverMsg: m, httpStatus: status };
+  }
+  return { serverMsg: '', httpStatus: undefined };
 }
 
 // =============================================================================
@@ -96,9 +131,7 @@ export const gdprClient = {
 
     type InvokeResponse = {
       data: DeleteAccountResult | null;
-      error:
-        | { message?: string; context?: { status?: number } }
-        | null;
+      error: unknown;
     };
     let response: InvokeResponse;
     try {
@@ -117,10 +150,8 @@ export const gdprClient = {
 
     const { data, error } = response;
     if (error) {
-      const status = error.context?.status;
-      // Edge function returns { error: "<code_or_message>" } on non-2xx
-      const serverMsg = error.message || '';
-      const code = mapErrorCode(serverMsg, status);
+      const { serverMsg, httpStatus } = await parseInvokeError(error);
+      const code = mapErrorCode(serverMsg, httpStatus);
       const humanMessage =
         code === 'password_mismatch'
           ? 'La password non è corretta'
@@ -131,7 +162,7 @@ export const gdprClient = {
               : code === 'delete_failed'
                 ? 'Eliminazione fallita. Riprova più tardi.'
                 : serverMsg || 'Errore imprevisto durante l\'eliminazione.';
-      throw new GdprApiError(humanMessage, status || 500, code, error);
+      throw new GdprApiError(humanMessage, httpStatus || 500, code, error);
     }
 
     if (!data || data.success !== true) {

--- a/apps/web/src/services/gdpr.client.ts
+++ b/apps/web/src/services/gdpr.client.ts
@@ -1,0 +1,150 @@
+/**
+ * GDPR Client — account deletion via the `account-delete` edge function.
+ *
+ * The edge function (PR #441) re-verifies the password, optionally exports
+ * all user data as JSON, then cascade-deletes via Postgres ON DELETE
+ * CASCADE triggered by `auth.admin.deleteUser`.
+ *
+ * @module services/gdpr.client
+ */
+
+import { createClient } from '@/utils/supabase/client';
+import type { DeleteAccountResult } from '@/types/gdpr';
+
+// =============================================================================
+// Error class
+// =============================================================================
+
+export type GdprErrorCode =
+  | 'password_mismatch'
+  | 'profile_not_found'
+  | 'export_failed'
+  | 'delete_failed'
+  | 'network'
+  | 'unknown';
+
+export class GdprApiError extends Error {
+  constructor(
+    message: string,
+    public statusCode: number,
+    public code: GdprErrorCode = 'unknown',
+    public details?: unknown
+  ) {
+    super(message);
+    this.name = 'GdprApiError';
+  }
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+type SupabaseLike = {
+  functions: {
+    invoke: <T = unknown>(
+      name: string,
+      opts: { body: unknown }
+    ) => Promise<{
+      data: T | null;
+      error:
+        | { message?: string; context?: { status?: number } }
+        | null;
+    }>;
+  };
+};
+
+function mapErrorCode(
+  serverError: string | undefined,
+  httpStatus: number | undefined
+): GdprErrorCode {
+  const msg = (serverError || '').toLowerCase();
+  if (msg.includes('password_mismatch')) return 'password_mismatch';
+  if (msg.includes('profile_not_found')) return 'profile_not_found';
+  if (msg.startsWith('export_failed')) return 'export_failed';
+  if (msg.includes('family_delete_failed') || msg.includes('user_delete_failed')) {
+    return 'delete_failed';
+  }
+  if (httpStatus && httpStatus >= 500) return 'delete_failed';
+  return 'unknown';
+}
+
+// =============================================================================
+// Client
+// =============================================================================
+
+export const gdprClient = {
+  /**
+   * Delete the current user's account. The server re-verifies the password
+   * and optionally returns a JSON export of all personal data.
+   *
+   * After a successful call the session is dead — the caller MUST redirect
+   * to a public route (usually /auth/login) and invalidate the local store.
+   *
+   * @throws {GdprApiError} with a typed `code` routed to the UI:
+   *   - `password_mismatch` (401) → FIELD error on the password input
+   *   - `profile_not_found` (404) → TOP-LEVEL alert; likely corrupted state
+   *   - `export_failed` (500) → TOP-LEVEL alert; retry without export
+   *   - `delete_failed` (500) → TOP-LEVEL alert; retry
+   *   - `network` (0) → TOP-LEVEL alert; check connectivity
+   *   - `unknown` (varies) → TOP-LEVEL alert; generic fallback
+   */
+  async deleteAccount(params: {
+    password: string;
+    exportDataFirst: boolean;
+  }): Promise<DeleteAccountResult> {
+    const supabase = createClient() as unknown as SupabaseLike;
+
+    type InvokeResponse = {
+      data: DeleteAccountResult | null;
+      error:
+        | { message?: string; context?: { status?: number } }
+        | null;
+    };
+    let response: InvokeResponse;
+    try {
+      response = (await supabase.functions.invoke<DeleteAccountResult>(
+        'account-delete',
+        { body: params }
+      )) as InvokeResponse;
+    } catch (err) {
+      throw new GdprApiError(
+        'Connessione persa mentre eliminavamo il tuo account. Riprova.',
+        0,
+        'network',
+        err
+      );
+    }
+
+    const { data, error } = response;
+    if (error) {
+      const status = error.context?.status;
+      // Edge function returns { error: "<code_or_message>" } on non-2xx
+      const serverMsg = error.message || '';
+      const code = mapErrorCode(serverMsg, status);
+      const humanMessage =
+        code === 'password_mismatch'
+          ? 'La password non è corretta'
+          : code === 'profile_not_found'
+            ? 'Profilo non trovato. Contatta il supporto.'
+            : code === 'export_failed'
+              ? 'Non è stato possibile esportare i tuoi dati. Riprova senza export.'
+              : code === 'delete_failed'
+                ? 'Eliminazione fallita. Riprova più tardi.'
+                : serverMsg || 'Errore imprevisto durante l\'eliminazione.';
+      throw new GdprApiError(humanMessage, status || 500, code, error);
+    }
+
+    if (!data || data.success !== true) {
+      throw new GdprApiError(
+        'Risposta inattesa dal server',
+        500,
+        'unknown',
+        data
+      );
+    }
+
+    return data;
+  },
+};
+
+export default gdprClient;

--- a/apps/web/src/types/gdpr.ts
+++ b/apps/web/src/types/gdpr.ts
@@ -1,9 +1,11 @@
 /**
  * GDPR — shared types for the Settings > Dati flow.
  *
- * Mirrors the contract of the `account-delete` Supabase Edge Function
- * (`supabase/functions/account-delete/index.ts`). Keep in sync if the
- * edge function's request/response shape changes.
+ * The request sent to the `account-delete` edge function is
+ * `{ password, exportDataFirst? }`; `confirmPhrase` is a UI-only field
+ * that guards the submit button and is NOT forwarded to the server.
+ * `DeleteAccountResult` mirrors the edge function's response shape
+ * (`supabase/functions/account-delete/index.ts`) — keep in sync if it changes.
  *
  * @module types/gdpr
  */
@@ -11,17 +13,28 @@
 import { z } from 'zod';
 
 // =============================================================================
-// Delete-my-account request
+// Confirmation phrase — single source of truth
+// =============================================================================
+
+/** Literal word the user must type to confirm account deletion. */
+export const DELETE_CONFIRM_PHRASE = 'ELIMINA';
+
+// =============================================================================
+// Delete-my-account request (UI form)
 // =============================================================================
 
 export const deleteAccountSchema = z.object({
   password: z.string().min(1, 'La password è obbligatoria per conferma'),
   exportDataFirst: z.boolean(),
-  /** Must be typed literally to confirm intent — Italian UX copy. */
+  /**
+   * UI-only: must be typed literally to confirm intent. NOT forwarded to
+   * the edge function — callers destructure `{password, exportDataFirst}`
+   * before invoking the server.
+   */
   confirmPhrase: z
     .string()
-    .refine((v) => v.trim().toUpperCase() === 'ELIMINA', {
-      message: 'Digita ELIMINA per confermare',
+    .refine((v) => v.trim().toUpperCase() === DELETE_CONFIRM_PHRASE, {
+      message: `Digita ${DELETE_CONFIRM_PHRASE} per confermare`,
     }),
 });
 
@@ -39,5 +52,3 @@ export interface DeleteAccountResult {
   exportData?: Record<string, unknown>;
 }
 
-/** Confirmation phrase expected in the "type to confirm" input. */
-export const DELETE_CONFIRM_PHRASE = 'ELIMINA';

--- a/apps/web/src/types/gdpr.ts
+++ b/apps/web/src/types/gdpr.ts
@@ -1,0 +1,43 @@
+/**
+ * GDPR — shared types for the Settings > Dati flow.
+ *
+ * Mirrors the contract of the `account-delete` Supabase Edge Function
+ * (`supabase/functions/account-delete/index.ts`). Keep in sync if the
+ * edge function's request/response shape changes.
+ *
+ * @module types/gdpr
+ */
+
+import { z } from 'zod';
+
+// =============================================================================
+// Delete-my-account request
+// =============================================================================
+
+export const deleteAccountSchema = z.object({
+  password: z.string().min(1, 'La password è obbligatoria per conferma'),
+  exportDataFirst: z.boolean(),
+  /** Must be typed literally to confirm intent — Italian UX copy. */
+  confirmPhrase: z
+    .string()
+    .refine((v) => v.trim().toUpperCase() === 'ELIMINA', {
+      message: 'Digita ELIMINA per confermare',
+    }),
+});
+
+export type DeleteAccountInput = z.infer<typeof deleteAccountSchema>;
+
+/**
+ * Successful response from `account-delete` edge function.
+ * Matches the return of `handleDelete` in supabase/functions/account-delete/index.ts.
+ */
+export interface DeleteAccountResult {
+  success: true;
+  deletedAt: string;
+  familyDeleted: boolean;
+  /** Present when request had `exportDataFirst: true`. */
+  exportData?: Record<string, unknown>;
+}
+
+/** Confirmation phrase expected in the "type to confirm" input. */
+export const DELETE_CONFIRM_PHRASE = 'ELIMINA';


### PR DESCRIPTION
## Summary

Sprint 1.3 — extracts Settings > Dati into a dedicated \`<DataTab />\` (same pattern as NotificationsTab / SecurityTab) and wires "Elimina Account" to the \`account-delete\` Supabase Edge Function merged in PR #441.

- New \`types/gdpr.ts\`: Zod schema for delete confirmation (password + literal "ELIMINA" phrase + exportDataFirst checkbox). \`DeleteAccountResult\` mirrors edge function response.
- New \`services/gdpr.client.ts\`: typed wrapper over \`supabase.functions.invoke('account-delete')\`. Error codes routed to UI: \`password_mismatch\` → field, others → top-level alert.
- New \`components/settings/DataTab.tsx\`: inline confirm form with password + phrase + optional exportDataFirst. On success: download JSON (if exported), logout, redirect to \`/auth/login?deleted=1\`. "Reset Dati Demo" button removed (was demo-only).
- \`page.tsx\`: ~80 inline lines replaced with \`<DataTab />\`, dead state + unused icons cleaned.
- 27 new unit tests (types: 7, service: 11, component: 9), full suite 1511 pass / 2 skip.

## Design notes

- **Defense-in-depth UX**: three distinct gates before a delete fires — password, literal "ELIMINA" phrase, explicit confirm button. The phrase confirms *intent* (not just auth), important for an irreversible action.
- **Export before delete**: optional checkbox; the edge function returns the JSON inline in the response, we trigger browser download via blob + anchor click before logout.
- **Session invalidation**: after server 200, we call \`logout()\` locally as best-effort and \`router.replace('/auth/login?deleted=1')\`. The \`?deleted=1\` param lets the login page show a "tuo account è stato eliminato" message (out of scope here; the query param is the hook).
- **Standalone export**: deliberately left as "In arrivo" placeholder — a dedicated export-only edge function is outside Sprint 1.3 scope.

## Test plan

- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm lint\` — 0 errors (3 pre-existing warnings)
- [x] \`pnpm --filter @money-wise/web test\` — 1511 pass / 2 skip / 0 fail
- [ ] **Manual browser verification (human)**:
  - [ ] Wrong password → field-level error, account intact
  - [ ] Wrong confirm phrase (e.g. "DELETE") → inline error, no network call
  - [ ] Valid delete without export → session logout, redirect to login
  - [ ] Valid delete WITH export → JSON file downloaded, then redirect
  - [ ] Network error mid-submit → top-level alert, form preserved

## Notes

- PR opened **without** \`auto-merge\` label on purpose — the MANDATORY PR lifecycle loop (memoria \`feedback_pr_lifecycle_loop_workflow\`) will add it after Copilot review is clean + CI is green.
- Touches no \`supabase/migrations/**\`; auto-merge schema guard not triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)