### PR TITLE
feat(categories): wire AI Categorization to categorize-transaction edge fn

### DIFF
--- a/apps/web/__tests__/components/categories/AICategorization.test.tsx
+++ b/apps/web/__tests__/components/categories/AICategorization.test.tsx
@@ -1,0 +1,199 @@
+/**
+ * Tests for AICategorization — review flow with real service wired.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const mocks = vi.hoisted(() => ({
+  loadPendingWithSuggestions: vi.fn(),
+  applyCategory: vi.fn(),
+}));
+
+vi.mock('../../../src/services/categorization.client', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../../src/services/categorization.client')
+  >('../../../src/services/categorization.client');
+  return {
+    ...actual,
+    categorizationClient: {
+      loadPendingWithSuggestions: mocks.loadPendingWithSuggestions,
+      applyCategory: mocks.applyCategory,
+    },
+  };
+});
+
+import { AICategorization } from '../../../src/components/categories/AICategorization';
+import { CategorizationApiError } from '../../../src/services/categorization.client';
+
+const TX = {
+  id: 'tx-1',
+  description: 'Pagamento Esselunga',
+  amount: -67.3,
+  type: 'DEBIT' as const,
+  date: '2026-04-14',
+  suggestedCategoryId: 'cat-food',
+  suggestedCategoryName: 'Spesa Alimentare',
+  suggestedCategoryIcon: '🛒',
+  confidence: 97,
+  matchedBy: 'keyword' as const,
+};
+
+const TX2 = {
+  id: 'tx-2',
+  description: 'BOOTS 773',
+  amount: -3.24,
+  type: 'DEBIT' as const,
+  date: '2026-04-15',
+  suggestedCategoryId: null,
+  suggestedCategoryName: 'Da categorizzare',
+  suggestedCategoryIcon: '❓',
+  confidence: 0,
+  matchedBy: 'fallback' as const,
+};
+
+const CATEGORIES = [
+  { id: 'cat-food', name: 'Spesa Alimentare', icon: '🛒', type: 'EXPENSE' as const },
+  { id: 'cat-health', name: 'Salute', icon: '💊', type: 'EXPENSE' as const },
+];
+
+describe('AICategorization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows loading state initially', () => {
+    mocks.loadPendingWithSuggestions.mockReturnValueOnce(new Promise(() => {}));
+    render(<AICategorization />);
+    expect(
+      screen.getByText(/L'AI sta analizzando/i)
+    ).toBeInTheDocument();
+  });
+
+  it('shows load error with retry', async () => {
+    mocks.loadPendingWithSuggestions.mockRejectedValueOnce(
+      new CategorizationApiError('RLS denied', 500, 'fetch_failed')
+    );
+    render(<AICategorization />);
+    expect(await screen.findByText(/RLS denied/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Riprova/i })).toBeInTheDocument();
+  });
+
+  it('shows empty state when no pending', async () => {
+    mocks.loadPendingWithSuggestions.mockResolvedValueOnce({
+      items: [],
+      categories: CATEGORIES,
+    });
+    render(<AICategorization />);
+    expect(
+      await screen.findByText(/Tutto categorizzato/i)
+    ).toBeInTheDocument();
+  });
+
+  it('renders pending transactions with AI suggestions', async () => {
+    mocks.loadPendingWithSuggestions.mockResolvedValueOnce({
+      items: [TX],
+      categories: CATEGORIES,
+    });
+    render(<AICategorization />);
+    expect(
+      await screen.findByText('Pagamento Esselunga')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Spesa Alimentare')).toBeInTheDocument();
+    expect(screen.getByText('97%')).toBeInTheDocument();
+  });
+
+  it('applies suggested category on Accept and removes from list', async () => {
+    mocks.loadPendingWithSuggestions.mockResolvedValueOnce({
+      items: [TX, TX2],
+      categories: CATEGORIES,
+    });
+    mocks.applyCategory.mockResolvedValueOnce(undefined);
+
+    render(<AICategorization />);
+    await screen.findByText('Pagamento Esselunga');
+
+    const acceptButtons = screen.getAllByRole('button', { name: /Accetta/i });
+    await userEvent.click(acceptButtons[0]);
+
+    await waitFor(() => {
+      expect(mocks.applyCategory).toHaveBeenCalledWith('tx-1', 'cat-food');
+    });
+    await waitFor(() => {
+      expect(screen.queryByText('Pagamento Esselunga')).not.toBeInTheDocument();
+    });
+  });
+
+  it('disables Accept when no suggestion (fallback)', async () => {
+    mocks.loadPendingWithSuggestions.mockResolvedValueOnce({
+      items: [TX2],
+      categories: CATEGORIES,
+    });
+    render(<AICategorization />);
+    await screen.findByText('BOOTS 773');
+    const accept = screen.getByRole('button', { name: /Accetta/i });
+    expect(accept).toBeDisabled();
+  });
+
+  it('Cambia opens picker and choosing a category applies it', async () => {
+    mocks.loadPendingWithSuggestions.mockResolvedValueOnce({
+      items: [TX2],
+      categories: CATEGORIES,
+    });
+    mocks.applyCategory.mockResolvedValueOnce(undefined);
+
+    render(<AICategorization />);
+    await screen.findByText('BOOTS 773');
+    await userEvent.click(screen.getByRole('button', { name: /Cambia/i }));
+
+    // Picker buttons render — click the Salute one
+    const saluteButton = await screen.findByRole('button', { name: /Salute/i });
+    await userEvent.click(saluteButton);
+
+    await waitFor(() => {
+      expect(mocks.applyCategory).toHaveBeenCalledWith('tx-2', 'cat-health');
+    });
+  });
+
+  it('Skip removes tx without applying', async () => {
+    mocks.loadPendingWithSuggestions.mockResolvedValueOnce({
+      items: [TX],
+      categories: CATEGORIES,
+    });
+    render(<AICategorization />);
+    await screen.findByText('Pagamento Esselunga');
+
+    const skipButtons = screen.getAllByRole('button');
+    // Find the X-only skip button — it has aria-label or just X icon
+    // Here: last outline button in the row is the X reject
+    const xButton = skipButtons.find((b) =>
+      b.querySelector('svg.lucide-x, svg[class*="lucide-x"]')
+    );
+    if (xButton) {
+      await userEvent.click(xButton);
+      await waitFor(() => {
+        expect(screen.queryByText('Pagamento Esselunga')).not.toBeInTheDocument();
+      });
+      expect(mocks.applyCategory).not.toHaveBeenCalled();
+    }
+  });
+
+  it('shows row-level error when applyCategory fails', async () => {
+    mocks.loadPendingWithSuggestions.mockResolvedValueOnce({
+      items: [TX],
+      categories: CATEGORIES,
+    });
+    mocks.applyCategory.mockRejectedValueOnce(
+      new CategorizationApiError('RLS violation', 500, 'apply_failed')
+    );
+
+    render(<AICategorization />);
+    await screen.findByText('Pagamento Esselunga');
+    await userEvent.click(screen.getByRole('button', { name: /Accetta/i }));
+
+    expect(await screen.findByText(/RLS violation/i)).toBeInTheDocument();
+    // Tx remains in the list for retry
+    expect(screen.getByText('Pagamento Esselunga')).toBeInTheDocument();
+  });
+});

--- a/apps/web/__tests__/services/categorization.client.test.ts
+++ b/apps/web/__tests__/services/categorization.client.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Tests for services/categorization.client — fetch + suggest + apply flow.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock builder: the service chains .from().select().is().order().limit() for
+// pending; .from().select().order() for categories; .from().update().eq() for
+// applyCategory. We wire selective chains per test.
+const mocks = vi.hoisted(() => ({
+  fromSpy: vi.fn(),
+  invoke: vi.fn(),
+}));
+
+vi.mock('../../src/utils/supabase/client', () => ({
+  createClient: vi.fn(() => ({
+    from: mocks.fromSpy,
+    functions: { invoke: mocks.invoke },
+  })),
+}));
+
+import {
+  categorizationClient,
+  CategorizationApiError,
+} from '../../src/services/categorization.client';
+import type {
+  CategoryRow,
+  PendingTransactionRow,
+} from '../../src/types/categorization';
+
+function pendingChain(result: {
+  data: PendingTransactionRow[] | null;
+  error: { message: string } | null;
+}) {
+  return {
+    select: vi.fn().mockReturnValue({
+      is: vi.fn().mockReturnValue({
+        order: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue(result),
+        }),
+      }),
+      order: vi.fn(),
+    }),
+    update: vi.fn(),
+  };
+}
+
+function categoriesChain(result: {
+  data: CategoryRow[] | null;
+  error: { message: string } | null;
+}) {
+  return {
+    select: vi.fn().mockReturnValue({
+      order: vi.fn().mockResolvedValue(result),
+      is: vi.fn(),
+    }),
+    update: vi.fn(),
+  };
+}
+
+function updateChain(errorResult: { message: string } | null) {
+  return {
+    update: vi.fn().mockReturnValue({
+      eq: vi.fn().mockResolvedValue({ error: errorResult }),
+    }),
+    select: vi.fn(),
+  };
+}
+
+const TX: PendingTransactionRow = {
+  id: 'tx-1',
+  description: 'Pagamento Esselunga',
+  merchant_name: 'Esselunga',
+  amount: -67.3,
+  type: 'DEBIT',
+  date: '2026-04-14',
+  category_id: null,
+};
+
+const CAT: CategoryRow = {
+  id: 'cat-food',
+  name: 'Spesa Alimentare',
+  icon: '🛒',
+  type: 'EXPENSE',
+};
+
+describe('categorizationClient.fetchPendingTransactions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns data array on success', async () => {
+    mocks.fromSpy.mockReturnValueOnce(
+      pendingChain({ data: [TX], error: null })
+    );
+    const r = await categorizationClient.fetchPendingTransactions();
+    expect(r).toEqual([TX]);
+  });
+
+  it('throws fetch_failed on error', async () => {
+    mocks.fromSpy.mockReturnValueOnce(
+      pendingChain({ data: null, error: { message: 'RLS denied' } })
+    );
+    await expect(
+      categorizationClient.fetchPendingTransactions()
+    ).rejects.toMatchObject({
+      name: 'CategorizationApiError',
+      code: 'fetch_failed',
+      message: expect.stringContaining('RLS'),
+    });
+  });
+
+  it('returns empty array when data is null', async () => {
+    mocks.fromSpy.mockReturnValueOnce(
+      pendingChain({ data: null, error: null })
+    );
+    const r = await categorizationClient.fetchPendingTransactions();
+    expect(r).toEqual([]);
+  });
+});
+
+describe('categorizationClient.fetchCategories', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns data on success', async () => {
+    mocks.fromSpy.mockReturnValueOnce(
+      categoriesChain({ data: [CAT], error: null })
+    );
+    const r = await categorizationClient.fetchCategories();
+    expect(r).toEqual([CAT]);
+  });
+
+  it('throws fetch_failed on error', async () => {
+    mocks.fromSpy.mockReturnValueOnce(
+      categoriesChain({ data: null, error: { message: 'oops' } })
+    );
+    await expect(categorizationClient.fetchCategories()).rejects.toMatchObject(
+      { code: 'fetch_failed' }
+    );
+  });
+});
+
+describe('categorizationClient.suggestCategory', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('invokes edge fn with mapped body', async () => {
+    mocks.invoke.mockResolvedValueOnce({
+      data: { categoryId: 'cat-food', confidence: 97, matchedBy: 'keyword' },
+      error: null,
+    });
+    const r = await categorizationClient.suggestCategory(TX);
+    expect(mocks.invoke).toHaveBeenCalledWith('categorize-transaction', {
+      body: {
+        description: 'Pagamento Esselunga',
+        merchantName: 'Esselunga',
+        amount: -67.3,
+        type: 'DEBIT',
+      },
+    });
+    expect(r.categoryId).toBe('cat-food');
+    expect(r.confidence).toBe(97);
+  });
+
+  it('throws suggest_failed when invoke returns error', async () => {
+    mocks.invoke.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'edge down' },
+    });
+    await expect(
+      categorizationClient.suggestCategory(TX)
+    ).rejects.toMatchObject({ code: 'suggest_failed' });
+  });
+
+  it('throws suggest_failed when data is null (no error)', async () => {
+    mocks.invoke.mockResolvedValueOnce({ data: null, error: null });
+    await expect(
+      categorizationClient.suggestCategory(TX)
+    ).rejects.toMatchObject({ code: 'suggest_failed' });
+  });
+});
+
+describe('categorizationClient.applyCategory', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('sends UPDATE with category_id and txId', async () => {
+    const chain = updateChain(null);
+    mocks.fromSpy.mockReturnValueOnce(chain);
+    await categorizationClient.applyCategory('tx-1', 'cat-food');
+    expect(chain.update).toHaveBeenCalledWith({ category_id: 'cat-food' });
+  });
+
+  it('rejects empty txId / categoryId without touching DB', async () => {
+    await expect(
+      categorizationClient.applyCategory('', 'cat')
+    ).rejects.toMatchObject({ code: 'apply_failed' });
+    await expect(
+      categorizationClient.applyCategory('tx', '')
+    ).rejects.toMatchObject({ code: 'apply_failed' });
+    expect(mocks.fromSpy).not.toHaveBeenCalled();
+  });
+
+  it('throws apply_failed when UPDATE errors', async () => {
+    mocks.fromSpy.mockReturnValueOnce(
+      updateChain({ message: 'RLS violation' })
+    );
+    await expect(
+      categorizationClient.applyCategory('tx-1', 'cat-food')
+    ).rejects.toMatchObject({
+      code: 'apply_failed',
+      message: expect.stringContaining('RLS'),
+    });
+  });
+});
+
+describe('categorizationClient.loadPendingWithSuggestions', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns enriched items and categories', async () => {
+    mocks.fromSpy
+      .mockReturnValueOnce(pendingChain({ data: [TX], error: null }))
+      .mockReturnValueOnce(categoriesChain({ data: [CAT], error: null }));
+    mocks.invoke.mockResolvedValueOnce({
+      data: { categoryId: 'cat-food', confidence: 97, matchedBy: 'keyword' },
+      error: null,
+    });
+    const r = await categorizationClient.loadPendingWithSuggestions();
+    expect(r.categories).toEqual([CAT]);
+    expect(r.items).toHaveLength(1);
+    expect(r.items[0]).toMatchObject({
+      id: 'tx-1',
+      suggestedCategoryId: 'cat-food',
+      suggestedCategoryName: 'Spesa Alimentare',
+      suggestedCategoryIcon: '🛒',
+      confidence: 97,
+    });
+  });
+
+  it('falls back gracefully when suggestion throws (one tx)', async () => {
+    mocks.fromSpy
+      .mockReturnValueOnce(pendingChain({ data: [TX], error: null }))
+      .mockReturnValueOnce(categoriesChain({ data: [CAT], error: null }));
+    mocks.invoke.mockRejectedValueOnce(new Error('edge oops'));
+    const r = await categorizationClient.loadPendingWithSuggestions();
+    expect(r.items[0].suggestedCategoryId).toBeNull();
+    expect(r.items[0].confidence).toBe(0);
+    expect(r.items[0].matchedBy).toBe('fallback');
+    expect(r.items[0].suggestedCategoryName).toBe('Da categorizzare');
+  });
+});
+
+describe('CategorizationApiError', () => {
+  it('carries code + statusCode + details', () => {
+    const e = new CategorizationApiError('msg', 500, 'fetch_failed', {
+      x: 1,
+    });
+    expect(e.name).toBe('CategorizationApiError');
+    expect(e.code).toBe('fetch_failed');
+    expect(e.details).toEqual({ x: 1 });
+    expect(e instanceof CategorizationApiError).toBe(true);
+  });
+});

--- a/apps/web/__tests__/services/categorization.client.test.ts
+++ b/apps/web/__tests__/services/categorization.client.test.ts
@@ -49,9 +49,11 @@ function categoriesChain(result: {
   data: CategoryRow[] | null;
   error: { message: string } | null;
 }) {
+  const terminal = { order: vi.fn().mockResolvedValue(result) };
   return {
     select: vi.fn().mockReturnValue({
-      order: vi.fn().mockResolvedValue(result),
+      eq: vi.fn().mockReturnValue(terminal),
+      order: vi.fn(),
       is: vi.fn(),
     }),
     update: vi.fn(),

--- a/apps/web/src/components/categories/AICategorization.tsx
+++ b/apps/web/src/components/categories/AICategorization.tsx
@@ -55,6 +55,40 @@ function formatItDate(iso: string): string {
   return new Date(y, (m || 1) - 1, d || 1).toLocaleDateString('it-IT');
 }
 
+/**
+ * Locale-aware currency formatter — aligned with TransactionRow / other
+ * consumers in this codebase. Falls back to EUR on bad currency codes.
+ */
+function formatCurrency(amount: number, currency = 'EUR'): string {
+  try {
+    return new Intl.NumberFormat('it-IT', {
+      style: 'currency',
+      currency,
+    }).format(amount);
+  } catch {
+    return new Intl.NumberFormat('it-IT', {
+      style: 'currency',
+      currency: 'EUR',
+    }).format(amount);
+  }
+}
+
+/**
+ * Regex that heuristically detects whether a string starts with an emoji
+ * (symbol / pictograph / extended pictographic) as opposed to a lucide
+ * icon NAME like "ShoppingCart". We don't ship a Name→Component mapper
+ * in this module — rendering by name would display literal text
+ * "ShoppingCart". When the icon isn't an emoji, fall back to a neutral
+ * glyph so the UI stays consistent.
+ */
+const EMOJI_LEADING_RE = /^\p{Extended_Pictographic}/u;
+const FALLBACK_ICON_GLYPH = '❓';
+
+function renderCategoryIcon(icon: string | null | undefined): string {
+  if (!icon) return FALLBACK_ICON_GLYPH;
+  return EMOJI_LEADING_RE.test(icon) ? icon : FALLBACK_ICON_GLYPH;
+}
+
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
@@ -246,7 +280,8 @@ export function AICategorization() {
                         tx.amount < 0 ? 'text-rose-600' : 'text-emerald-600'
                       }`}
                     >
-                      {tx.amount < 0 ? '-' : '+'}€{Math.abs(tx.amount).toFixed(2)}
+                      {tx.amount >= 0 ? '+' : ''}
+                      {formatCurrency(tx.amount)}
                     </span>
                   </div>
                   <p className="text-[11px] text-muted-foreground">
@@ -258,8 +293,8 @@ export function AICategorization() {
                     <div
                       className={`flex items-center gap-2 px-3 py-1.5 rounded-xl ${getConfidenceBg(tx.confidence)}`}
                     >
-                      <span className="text-[16px]">
-                        {tx.suggestedCategoryIcon}
+                      <span className="text-[16px]" aria-hidden="true">
+                        {renderCategoryIcon(tx.suggestedCategoryIcon)}
                       </span>
                       <span className="text-[13px] font-medium text-foreground">
                         {tx.suggestedCategoryName}
@@ -300,7 +335,10 @@ export function AICategorization() {
                           disabled={busyTx === tx.id}
                           className="flex items-center gap-1 px-2 py-1 rounded-lg bg-muted/50 hover:bg-muted text-[11px] text-foreground transition-colors disabled:opacity-50"
                         >
-                          <span>{cat.icon || '❓'}</span> {cat.name}
+                          <span aria-hidden="true">
+                            {renderCategoryIcon(cat.icon)}
+                          </span>{' '}
+                          {cat.name}
                         </button>
                       ))}
                       <button
@@ -349,9 +387,10 @@ export function AICategorization() {
                         className="rounded-xl text-[12px] text-rose-500 border-rose-200 dark:border-rose-800 hover:bg-rose-50 dark:hover:bg-rose-500/10"
                         onClick={() => handleSkip(tx)}
                         disabled={busyTx === tx.id}
+                        aria-label="Salta — nessuna categoria applicata"
                         title="Salta — nessuna categoria applicata"
                       >
-                        <X className="w-3 h-3" />
+                        <X className="w-3 h-3" aria-hidden="true" />
                       </Button>
                     </>
                   )}

--- a/apps/web/src/components/categories/AICategorization.tsx
+++ b/apps/web/src/components/categories/AICategorization.tsx
@@ -1,6 +1,17 @@
 'use client';
 
-import { useState } from 'react';
+/**
+ * AICategorization — review flow for AI-suggested categories.
+ *
+ * Fetches uncategorized transactions + all categories, asks the
+ * `categorize-transaction` edge function for each one, and lets the user
+ * accept / change / skip the suggestion. Accept and change persist via
+ * UPDATE on `transactions.category_id`.
+ *
+ * @module components/categories/AICategorization
+ */
+
+import { useCallback, useEffect, useState } from 'react';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -12,46 +23,19 @@ import {
   ChevronRight,
   Sparkles,
   AlertCircle,
+  Loader2,
 } from 'lucide-react';
+import {
+  categorizationClient,
+  CategorizationApiError,
+} from '@/services/categorization.client';
+import type {
+  CategoryRow,
+  PendingTransactionWithSuggestion,
+} from '@/types/categorization';
 
 // ---------------------------------------------------------------------------
-// Demo data
-// ---------------------------------------------------------------------------
-
-interface Transaction {
-  id: string;
-  description: string;
-  amount: number;
-  type: 'expense' | 'income';
-  date: string;
-  aiSuggestedCategory: string;
-  aiSuggestedIcon: string;
-  aiConfidence: number;
-}
-
-const PENDING_TRANSACTIONS: Transaction[] = [
-  { id: '1', description: 'CARD PAYMENT TO JOHN LEWIS', amount: -19.95, type: 'expense', date: '2026-04-15', aiSuggestedCategory: 'Shopping', aiSuggestedIcon: '🛍️', aiConfidence: 92 },
-  { id: '2', description: 'Pagamento Esselunga', amount: -67.30, type: 'expense', date: '2026-04-14', aiSuggestedCategory: 'Spesa Alimentare', aiSuggestedIcon: '🛒', aiConfidence: 97 },
-  { id: '3', description: 'Netflix Monthly', amount: -15.99, type: 'expense', date: '2026-04-13', aiSuggestedCategory: 'Abbonamenti', aiSuggestedIcon: '📺', aiConfidence: 99 },
-  { id: '4', description: 'BOOTS 773 LONDON', amount: -3.24, type: 'expense', date: '2026-04-15', aiSuggestedCategory: 'Salute', aiSuggestedIcon: '💊', aiConfidence: 78 },
-  { id: '5', description: 'Bonifico DA Mario Rossi', amount: 500, type: 'income', date: '2026-04-12', aiSuggestedCategory: 'Trasferimenti', aiSuggestedIcon: '↔️', aiConfidence: 65 },
-];
-
-const ALL_CATEGORIES = [
-  { name: 'Spesa Alimentare', icon: '🛒' },
-  { name: 'Shopping', icon: '🛍️' },
-  { name: 'Abbonamenti', icon: '📺' },
-  { name: 'Salute', icon: '💊' },
-  { name: 'Trasporti', icon: '🚗' },
-  { name: 'Ristorazione', icon: '🍽️' },
-  { name: 'Bollette', icon: '⚡' },
-  { name: 'Trasferimenti', icon: '↔️' },
-  { name: 'Stipendio', icon: '💼' },
-  { name: 'Intrattenimento', icon: '🎬' },
-];
-
-// ---------------------------------------------------------------------------
-// Component
+// Helpers
 // ---------------------------------------------------------------------------
 
 function getConfidenceColor(confidence: number) {
@@ -66,31 +50,154 @@ function getConfidenceBg(confidence: number) {
   return 'bg-red-500/10';
 }
 
+function formatItDate(iso: string): string {
+  const [y, m, d] = iso.slice(0, 10).split('-').map(Number);
+  return new Date(y, (m || 1) - 1, d || 1).toLocaleDateString('it-IT');
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
 export function AICategorization() {
-  const [pending, setPending] = useState(PENDING_TRANSACTIONS);
+  const [pending, setPending] = useState<PendingTransactionWithSuggestion[]>([]);
+  const [categories, setCategories] = useState<CategoryRow[]>([]);
   const [reviewedCount, setReviewedCount] = useState(0);
+  const [totalToReview, setTotalToReview] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [busyTx, setBusyTx] = useState<string | null>(null);
   const [changingCategory, setChangingCategory] = useState<string | null>(null);
+  const [rowError, setRowError] = useState<Record<string, string>>({});
 
-  const totalToReview = PENDING_TRANSACTIONS.length;
-  const progress = totalToReview > 0 ? (reviewedCount / totalToReview) * 100 : 0;
+  const load = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const { items, categories: cats } =
+        await categorizationClient.loadPendingWithSuggestions();
+      setPending(items);
+      setCategories(cats);
+      setTotalToReview(items.length);
+      setReviewedCount(0);
+    } catch (err) {
+      setLoadError(
+        err instanceof CategorizationApiError
+          ? err.message
+          : 'Impossibile caricare le transazioni da categorizzare'
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, []);
 
-  const handleAccept = (id: string) => {
-    setPending(prev => prev.filter(t => t.id !== id));
-    setReviewedCount(prev => prev + 1);
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const markReviewed = (txId: string) => {
+    setPending((prev) => prev.filter((t) => t.id !== txId));
+    setReviewedCount((c) => c + 1);
+    setRowError((prev) => {
+      const { [txId]: _drop, ...rest } = prev;
+      return rest;
+    });
   };
 
-  const handleReject = (id: string) => {
-    setPending(prev => prev.filter(t => t.id !== id));
-    setReviewedCount(prev => prev + 1);
+  const applyCategoryAndAccept = async (
+    txId: string,
+    categoryId: string | null
+  ) => {
+    if (!categoryId) {
+      setRowError((prev) => ({
+        ...prev,
+        [txId]: 'Nessuna categoria da applicare',
+      }));
+      return;
+    }
+    setBusyTx(txId);
+    try {
+      await categorizationClient.applyCategory(txId, categoryId);
+      markReviewed(txId);
+      setChangingCategory(null);
+    } catch (err) {
+      setRowError((prev) => ({
+        ...prev,
+        [txId]:
+          err instanceof CategorizationApiError
+            ? err.message
+            : 'Impossibile applicare la categoria',
+      }));
+    } finally {
+      setBusyTx(null);
+    }
+  };
+
+  const handleAccept = (tx: PendingTransactionWithSuggestion) =>
+    applyCategoryAndAccept(tx.id, tx.suggestedCategoryId);
+
+  const handleChoose = (tx: PendingTransactionWithSuggestion, cat: CategoryRow) =>
+    applyCategoryAndAccept(tx.id, cat.id);
+
+  const handleSkip = (tx: PendingTransactionWithSuggestion) => {
+    // User-initiated skip: remove from the review queue without persisting.
+    // Category remains NULL on the transaction.
+    markReviewed(tx.id);
     setChangingCategory(null);
   };
+
+  const progress =
+    totalToReview > 0 ? (reviewedCount / totalToReview) * 100 : 0;
+
+  // -----------------------------------------------------------------------
+  // Render
+  // -----------------------------------------------------------------------
+
+  if (loading) {
+    return (
+      <Card className="p-12 rounded-2xl border-0 shadow-sm text-center">
+        <Loader2 className="w-8 h-8 text-muted-foreground animate-spin mx-auto mb-3" />
+        <p className="text-[13px] text-muted-foreground">
+          L&apos;AI sta analizzando le tue transazioni...
+        </p>
+      </Card>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <Card className="p-8 rounded-2xl border-0 shadow-sm">
+        <div
+          role="alert"
+          className="flex items-start gap-3 p-4 bg-red-500/10 rounded-xl"
+        >
+          <AlertCircle className="w-5 h-5 text-red-600 flex-shrink-0 mt-0.5" />
+          <div className="flex-1">
+            <p className="text-[14px] font-medium text-red-700 dark:text-red-300">
+              {loadError}
+            </p>
+            <Button
+              size="sm"
+              variant="outline"
+              className="mt-3 rounded-xl"
+              onClick={load}
+            >
+              Riprova
+            </Button>
+          </div>
+        </div>
+      </Card>
+    );
+  }
 
   return (
     <div className="space-y-6">
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-[20px] font-semibold text-foreground">Categorizzazione AI</h2>
+          <h2 className="text-[20px] font-semibold text-foreground">
+            Categorizzazione AI
+          </h2>
           <p className="text-[13px] text-muted-foreground mt-1">
             {pending.length > 0
               ? `${pending.length} transazioni da revisionare`
@@ -106,74 +213,103 @@ export function AICategorization() {
       </div>
 
       {/* Progress */}
-      <Card className="p-5 rounded-2xl border-0 shadow-sm">
-        <div className="flex items-center justify-between mb-3">
-          <p className="text-sm text-muted-foreground">Progresso revisione</p>
-          <span className="text-sm font-semibold text-foreground">{reviewedCount}/{totalToReview}</span>
-        </div>
-        <Progress value={progress} className="h-2" />
-      </Card>
+      {totalToReview > 0 && (
+        <Card className="p-5 rounded-2xl border-0 shadow-sm">
+          <div className="flex items-center justify-between mb-3">
+            <p className="text-sm text-muted-foreground">Progresso revisione</p>
+            <span className="text-sm font-semibold text-foreground">
+              {reviewedCount}/{totalToReview}
+            </span>
+          </div>
+          <Progress value={progress} className="h-2" />
+        </Card>
+      )}
 
-      {/* Pending list */}
+      {/* Pending list or empty state */}
       {pending.length > 0 ? (
         <div className="space-y-3">
           {pending.map((tx) => (
-            <Card key={tx.id} className="p-5 rounded-2xl border-0 shadow-sm">
+            <Card
+              key={tx.id}
+              className="p-5 rounded-2xl border-0 shadow-sm"
+              data-testid={`tx-card-${tx.id}`}
+            >
               <div className="flex items-start gap-4">
                 {/* Transaction info */}
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2 mb-1">
-                    <p className="text-[14px] font-medium text-foreground truncate">{tx.description}</p>
-                    <span className={`text-[13px] font-semibold tabular-nums ${tx.amount < 0 ? 'text-rose-600' : 'text-emerald-600'}`}>
+                    <p className="text-[14px] font-medium text-foreground truncate">
+                      {tx.description}
+                    </p>
+                    <span
+                      className={`text-[13px] font-semibold tabular-nums ${
+                        tx.amount < 0 ? 'text-rose-600' : 'text-emerald-600'
+                      }`}
+                    >
                       {tx.amount < 0 ? '-' : '+'}€{Math.abs(tx.amount).toFixed(2)}
                     </span>
                   </div>
-                  <p className="text-[11px] text-muted-foreground">{(() => {
-                    // Parse YYYY-MM-DD as local-midnight to avoid timezone drift
-                    const [y, m, d] = tx.date.slice(0, 10).split('-').map(Number);
-                    return new Date(y, (m || 1) - 1, d || 1).toLocaleDateString('it-IT');
-                  })()}</p>
+                  <p className="text-[11px] text-muted-foreground">
+                    {formatItDate(tx.date)}
+                  </p>
 
                   {/* AI suggestion */}
                   <div className="mt-3 flex items-center gap-3">
-                    <div className={`flex items-center gap-2 px-3 py-1.5 rounded-xl ${getConfidenceBg(tx.aiConfidence)}`}>
-                      <span className="text-[16px]">{tx.aiSuggestedIcon}</span>
-                      <span className="text-[13px] font-medium text-foreground">{tx.aiSuggestedCategory}</span>
-                      <span className={`text-[11px] font-semibold ${getConfidenceColor(tx.aiConfidence)}`}>
-                        {tx.aiConfidence}%
+                    <div
+                      className={`flex items-center gap-2 px-3 py-1.5 rounded-xl ${getConfidenceBg(tx.confidence)}`}
+                    >
+                      <span className="text-[16px]">
+                        {tx.suggestedCategoryIcon}
+                      </span>
+                      <span className="text-[13px] font-medium text-foreground">
+                        {tx.suggestedCategoryName}
+                      </span>
+                      <span
+                        className={`text-[11px] font-semibold ${getConfidenceColor(tx.confidence)}`}
+                      >
+                        {Math.round(tx.confidence)}%
                       </span>
                     </div>
-                    {tx.aiConfidence < 80 && (
+                    {tx.confidence < 80 && (
                       <div className="flex items-center gap-1 text-amber-500">
                         <AlertCircle className="w-3.5 h-3.5" />
                         <span className="text-[11px]">Bassa confidenza</span>
                       </div>
                     )}
                   </div>
+
+                  {rowError[tx.id] && (
+                    <p
+                      className="mt-2 text-[11px] text-red-600"
+                      role="alert"
+                    >
+                      {rowError[tx.id]}
+                    </p>
+                  )}
                 </div>
 
                 {/* Actions */}
                 <div className="flex items-center gap-2 flex-shrink-0">
                   {changingCategory === tx.id ? (
-                    <div className="flex flex-wrap gap-1.5 max-w-[200px]">
-                      {ALL_CATEGORIES.map(cat => (
+                    <div className="flex flex-wrap gap-1.5 max-w-[240px]">
+                      {categories.map((cat) => (
                         <button
-                          key={cat.name}
-                          onClick={() => {
-                            // Apply the chosen category to the transaction, then accept
-                            setPending(prev => prev.map(t =>
-                              t.id === tx.id
-                                ? { ...t, aiSuggestedCategory: cat.name, aiSuggestedIcon: cat.icon, aiConfidence: 100 }
-                                : t
-                            ));
-                            handleAccept(tx.id);
-                            setChangingCategory(null);
-                          }}
-                          className="flex items-center gap-1 px-2 py-1 rounded-lg bg-muted/50 hover:bg-muted text-[11px] text-foreground transition-colors"
+                          key={cat.id}
+                          type="button"
+                          onClick={() => handleChoose(tx, cat)}
+                          disabled={busyTx === tx.id}
+                          className="flex items-center gap-1 px-2 py-1 rounded-lg bg-muted/50 hover:bg-muted text-[11px] text-foreground transition-colors disabled:opacity-50"
                         >
-                          <span>{cat.icon}</span> {cat.name}
+                          <span>{cat.icon || '❓'}</span> {cat.name}
                         </button>
                       ))}
+                      <button
+                        type="button"
+                        onClick={() => setChangingCategory(null)}
+                        className="flex items-center gap-1 px-2 py-1 rounded-lg bg-muted/50 hover:bg-muted text-[11px] text-muted-foreground transition-colors"
+                      >
+                        Annulla
+                      </button>
                     </div>
                   ) : (
                     <>
@@ -182,23 +318,38 @@ export function AICategorization() {
                         variant="outline"
                         className="rounded-xl text-[12px] border-border/50"
                         onClick={() => setChangingCategory(tx.id)}
+                        disabled={busyTx === tx.id}
                       >
                         <ChevronRight className="w-3 h-3 mr-1" />
                         Cambia
                       </Button>
                       <Button
                         size="sm"
-                        className="rounded-xl text-[12px] bg-emerald-500 hover:bg-emerald-600 text-white"
-                        onClick={() => handleAccept(tx.id)}
+                        className="rounded-xl text-[12px] bg-emerald-500 hover:bg-emerald-600 text-white disabled:opacity-60"
+                        onClick={() => handleAccept(tx)}
+                        disabled={
+                          busyTx === tx.id || !tx.suggestedCategoryId
+                        }
+                        title={
+                          !tx.suggestedCategoryId
+                            ? 'Nessun suggerimento AI — usa "Cambia"'
+                            : undefined
+                        }
                       >
-                        <Check className="w-3 h-3 mr-1" />
+                        {busyTx === tx.id ? (
+                          <Loader2 className="w-3 h-3 mr-1 animate-spin" />
+                        ) : (
+                          <Check className="w-3 h-3 mr-1" />
+                        )}
                         Accetta
                       </Button>
                       <Button
                         size="sm"
                         variant="outline"
                         className="rounded-xl text-[12px] text-rose-500 border-rose-200 dark:border-rose-800 hover:bg-rose-50 dark:hover:bg-rose-500/10"
-                        onClick={() => handleReject(tx.id)}
+                        onClick={() => handleSkip(tx)}
+                        disabled={busyTx === tx.id}
+                        title="Salta — nessuna categoria applicata"
                       >
                         <X className="w-3 h-3" />
                       </Button>
@@ -212,9 +363,13 @@ export function AICategorization() {
       ) : (
         <Card className="p-12 rounded-2xl border-0 shadow-sm text-center">
           <Sparkles className="w-12 h-12 text-emerald-500 mx-auto mb-4" />
-          <h3 className="text-lg font-semibold text-foreground mb-2">Tutto categorizzato!</h3>
+          <h3 className="text-lg font-semibold text-foreground mb-2">
+            Tutto categorizzato!
+          </h3>
           <p className="text-[13px] text-muted-foreground">
-            Hai revisionato {reviewedCount} transazioni. L'AI imparerà dalle tue scelte per migliorare le prossime classificazioni.
+            {totalToReview > 0
+              ? `Hai revisionato ${reviewedCount} transazioni. L'AI imparerà dalle tue scelte.`
+              : 'Nessuna transazione da categorizzare al momento.'}
           </p>
         </Card>
       )}

--- a/apps/web/src/services/categorization.client.ts
+++ b/apps/web/src/services/categorization.client.ts
@@ -11,6 +11,7 @@
  * @module services/categorization.client
  */
 
+import { FunctionsHttpError } from '@supabase/supabase-js';
 import { createClient } from '@/utils/supabase/client';
 import type {
   CategorizeResult,
@@ -18,6 +19,38 @@ import type {
   PendingTransactionRow,
   PendingTransactionWithSuggestion,
 } from '@/types/categorization';
+
+/**
+ * Parse a supabase.functions.invoke() error into (message, status).
+ * FunctionsHttpError carries the real body in `context`; read it to recover
+ * the server-side `{error: "..."}` message. Aligned with gdpr.client /
+ * banking.client pattern in this repo.
+ */
+async function parseInvokeError(error: unknown): Promise<{
+  serverMsg: string;
+  httpStatus: number | undefined;
+}> {
+  if (error instanceof FunctionsHttpError) {
+    const status = error.context?.status;
+    try {
+      const body = (await error.context.json()) as
+        | { error?: string; message?: string }
+        | null;
+      const serverMsg = body?.error || body?.message || error.message || '';
+      return { serverMsg, httpStatus: status };
+    } catch {
+      return { serverMsg: error.message || '', httpStatus: status };
+    }
+  }
+  if (error && typeof error === 'object') {
+    const e = error as { message?: unknown; context?: { status?: number } };
+    const m = typeof e.message === 'string' ? e.message : '';
+    const status =
+      typeof e.context?.status === 'number' ? e.context.status : undefined;
+    return { serverMsg: m, httpStatus: status };
+  }
+  return { serverMsg: '', httpStatus: undefined };
+}
 
 // =============================================================================
 // Error class
@@ -61,6 +94,12 @@ type SupabaseLike = {
           }>;
         };
       };
+      eq: (col: string, val: string) => {
+        order: (col: string, opts: { ascending: boolean }) => Promise<{
+          data: CategoryRow[] | null;
+          error: { message: string } | null;
+        }>;
+      };
       order: (col: string, opts: { ascending: boolean }) => Promise<{
         data: CategoryRow[] | null;
         error: { message: string } | null;
@@ -70,7 +109,10 @@ type SupabaseLike = {
       eq: (
         col: string,
         val: string
-      ) => Promise<{ error: { message: string } | null }>;
+      ) => Promise<{
+        error: { message: string } | null;
+        count?: number | null;
+      }>;
     };
   };
   functions: {
@@ -119,13 +161,16 @@ export const categorizationClient = {
   },
 
   /**
-   * Fetch all active categories in the user's family (RLS-scoped).
+   * Fetch all ACTIVE categories in the user's family (RLS-scoped).
+   * Inactive/archived categories are filtered out — they'd confuse the
+   * suggestion display and picker.
    */
   async fetchCategories(): Promise<CategoryRow[]> {
     const supabase = createClient() as unknown as SupabaseLike;
     const { data, error } = await supabase
       .from('categories')
       .select('id, name, icon, type')
+      .eq('status', 'ACTIVE')
       .order('sort_order', { ascending: true });
     if (error) {
       throw new CategorizationApiError(
@@ -155,9 +200,10 @@ export const categorizationClient = {
       }
     );
     if (error) {
+      const { serverMsg, httpStatus } = await parseInvokeError(error);
       throw new CategorizationApiError(
-        'Impossibile ottenere suggerimento AI',
-        500,
+        serverMsg || 'Impossibile ottenere suggerimento AI',
+        httpStatus || 500,
         'suggest_failed',
         error
       );
@@ -223,6 +269,12 @@ export const categorizationClient = {
 
   /**
    * Persist a category choice on a transaction.
+   *
+   * Returns the count of affected rows if the driver exposes it: 0 means
+   * the tx either no longer exists, was already categorized, or is hidden
+   * by RLS. Without this check a no-op UPDATE returns `error: null` and
+   * the UI would drop the transaction as "reviewed" even though nothing
+   * was persisted.
    */
   async applyCategory(txId: string, categoryId: string): Promise<void> {
     if (!txId || !categoryId) {
@@ -233,7 +285,7 @@ export const categorizationClient = {
       );
     }
     const supabase = createClient() as unknown as SupabaseLike;
-    const { error } = await supabase
+    const { error, count } = await supabase
       .from('transactions')
       .update({ category_id: categoryId })
       .eq('id', txId);
@@ -243,6 +295,15 @@ export const categorizationClient = {
         500,
         'apply_failed',
         error
+      );
+    }
+    // When the driver provides a row count, a 0 means the filter matched
+    // nothing — surface as a not-found so the UI can retry / refresh.
+    if (typeof count === 'number' && count === 0) {
+      throw new CategorizationApiError(
+        'Transazione non trovata (potrebbe essere già categorizzata o rimossa)',
+        404,
+        'apply_failed'
       );
     }
   },

--- a/apps/web/src/services/categorization.client.ts
+++ b/apps/web/src/services/categorization.client.ts
@@ -1,0 +1,251 @@
+/**
+ * Categorization Client — AI suggestions via the `categorize-transaction`
+ * edge function + direct Supabase queries for transactions/categories.
+ *
+ * Flow consumed by AICategorization component:
+ *   1. fetchPendingTransactions() — uncategorized tx (category_id IS NULL)
+ *   2. fetchCategories() — all user categories (for suggestion display + picker)
+ *   3. suggestCategory(tx) — invoke edge fn for one tx
+ *   4. applyCategory(txId, categoryId) — UPDATE transactions.category_id
+ *
+ * @module services/categorization.client
+ */
+
+import { createClient } from '@/utils/supabase/client';
+import type {
+  CategorizeResult,
+  CategoryRow,
+  PendingTransactionRow,
+  PendingTransactionWithSuggestion,
+} from '@/types/categorization';
+
+// =============================================================================
+// Error class
+// =============================================================================
+
+export type CategorizationErrorCode =
+  | 'fetch_failed'
+  | 'suggest_failed'
+  | 'apply_failed'
+  | 'unknown';
+
+export class CategorizationApiError extends Error {
+  constructor(
+    message: string,
+    public statusCode: number,
+    public code: CategorizationErrorCode = 'unknown',
+    public details?: unknown
+  ) {
+    super(message);
+    this.name = 'CategorizationApiError';
+    Object.setPrototypeOf(this, CategorizationApiError.prototype);
+  }
+}
+
+// =============================================================================
+// Client
+// =============================================================================
+
+const DEFAULT_PENDING_LIMIT = 20;
+const FALLBACK_ICON = '❓';
+const FALLBACK_NAME = 'Da categorizzare';
+
+type SupabaseLike = {
+  from: (table: string) => {
+    select: (cols: string) => {
+      is: (col: string, val: null) => {
+        order: (col: string, opts: { ascending: boolean }) => {
+          limit: (n: number) => Promise<{
+            data: PendingTransactionRow[] | null;
+            error: { message: string } | null;
+          }>;
+        };
+      };
+      order: (col: string, opts: { ascending: boolean }) => Promise<{
+        data: CategoryRow[] | null;
+        error: { message: string } | null;
+      }>;
+    };
+    update: (payload: Record<string, unknown>) => {
+      eq: (
+        col: string,
+        val: string
+      ) => Promise<{ error: { message: string } | null }>;
+    };
+  };
+  functions: {
+    invoke: <T = unknown>(
+      name: string,
+      opts: { body: unknown }
+    ) => Promise<{ data: T | null; error: unknown }>;
+  };
+};
+
+function lookupCategory(
+  id: string | null,
+  categories: CategoryRow[]
+): { name: string; icon: string } {
+  if (!id) return { name: FALLBACK_NAME, icon: FALLBACK_ICON };
+  const c = categories.find((x) => x.id === id);
+  return c
+    ? { name: c.name, icon: c.icon || FALLBACK_ICON }
+    : { name: FALLBACK_NAME, icon: FALLBACK_ICON };
+}
+
+export const categorizationClient = {
+  /**
+   * Fetch uncategorized transactions (category_id IS NULL) for the current
+   * user's family. RLS handles scoping. Defaults to 20 most recent.
+   */
+  async fetchPendingTransactions(
+    limit = DEFAULT_PENDING_LIMIT
+  ): Promise<PendingTransactionRow[]> {
+    const supabase = createClient() as unknown as SupabaseLike;
+    const { data, error } = await supabase
+      .from('transactions')
+      .select('id, description, merchant_name, amount, type, date, category_id')
+      .is('category_id', null)
+      .order('date', { ascending: false })
+      .limit(limit);
+    if (error) {
+      throw new CategorizationApiError(
+        error.message || 'Impossibile caricare le transazioni',
+        500,
+        'fetch_failed',
+        error
+      );
+    }
+    return data ?? [];
+  },
+
+  /**
+   * Fetch all active categories in the user's family (RLS-scoped).
+   */
+  async fetchCategories(): Promise<CategoryRow[]> {
+    const supabase = createClient() as unknown as SupabaseLike;
+    const { data, error } = await supabase
+      .from('categories')
+      .select('id, name, icon, type')
+      .order('sort_order', { ascending: true });
+    if (error) {
+      throw new CategorizationApiError(
+        error.message || 'Impossibile caricare le categorie',
+        500,
+        'fetch_failed',
+        error
+      );
+    }
+    return data ?? [];
+  },
+
+  /**
+   * Ask the `categorize-transaction` edge function for one transaction.
+   */
+  async suggestCategory(tx: PendingTransactionRow): Promise<CategorizeResult> {
+    const supabase = createClient() as unknown as SupabaseLike;
+    const { data, error } = await supabase.functions.invoke<CategorizeResult>(
+      'categorize-transaction',
+      {
+        body: {
+          description: tx.description,
+          merchantName: tx.merchant_name,
+          amount: Number(tx.amount),
+          type: tx.type,
+        },
+      }
+    );
+    if (error) {
+      throw new CategorizationApiError(
+        'Impossibile ottenere suggerimento AI',
+        500,
+        'suggest_failed',
+        error
+      );
+    }
+    if (!data) {
+      throw new CategorizationApiError(
+        'Risposta AI vuota',
+        500,
+        'suggest_failed'
+      );
+    }
+    return data;
+  },
+
+  /**
+   * Convenience: fetch pending + categories + all AI suggestions in parallel,
+   * returning enriched view models ready for the component.
+   */
+  async loadPendingWithSuggestions(
+    limit = DEFAULT_PENDING_LIMIT
+  ): Promise<{
+    items: PendingTransactionWithSuggestion[];
+    categories: CategoryRow[];
+  }> {
+    const [pending, categories] = await Promise.all([
+      this.fetchPendingTransactions(limit),
+      this.fetchCategories(),
+    ]);
+
+    const suggestions = await Promise.all(
+      pending.map((tx) =>
+        this.suggestCategory(tx).catch(
+          (): CategorizeResult => ({
+            categoryId: null,
+            confidence: 0,
+            matchedBy: 'fallback',
+          })
+        )
+      )
+    );
+
+    const items: PendingTransactionWithSuggestion[] = pending.map(
+      (tx, i) => {
+        const sug = suggestions[i];
+        const { name, icon } = lookupCategory(sug.categoryId, categories);
+        return {
+          id: tx.id,
+          description: tx.description,
+          amount: Number(tx.amount),
+          type: tx.type,
+          date: tx.date,
+          suggestedCategoryId: sug.categoryId,
+          suggestedCategoryName: name,
+          suggestedCategoryIcon: icon,
+          confidence: sug.confidence,
+          matchedBy: sug.matchedBy,
+        };
+      }
+    );
+
+    return { items, categories };
+  },
+
+  /**
+   * Persist a category choice on a transaction.
+   */
+  async applyCategory(txId: string, categoryId: string): Promise<void> {
+    if (!txId || !categoryId) {
+      throw new CategorizationApiError(
+        'txId e categoryId sono obbligatori',
+        400,
+        'apply_failed'
+      );
+    }
+    const supabase = createClient() as unknown as SupabaseLike;
+    const { error } = await supabase
+      .from('transactions')
+      .update({ category_id: categoryId })
+      .eq('id', txId);
+    if (error) {
+      throw new CategorizationApiError(
+        error.message || 'Impossibile applicare la categoria',
+        500,
+        'apply_failed',
+        error
+      );
+    }
+  },
+};
+
+export default categorizationClient;

--- a/apps/web/src/types/categorization.ts
+++ b/apps/web/src/types/categorization.ts
@@ -1,0 +1,71 @@
+/**
+ * Categorization — shared types for the AI Categorization review flow.
+ *
+ * Mirrors the `categorize-transaction` edge function contract
+ * (`supabase/functions/categorize-transaction/index.ts`) plus UI-level
+ * view models for the AICategorization component.
+ *
+ * @module types/categorization
+ */
+
+// =============================================================================
+// Edge function contract
+// =============================================================================
+
+export interface CategorizeInput {
+  description: string;
+  merchantName?: string | null;
+  amount?: number;
+  type?: 'DEBIT' | 'CREDIT';
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface CategorizeResult {
+  categoryId: string | null;
+  confidence: number;
+  matchedBy:
+    | 'enrichment'
+    | 'merchant_exact'
+    | 'merchant_partial'
+    | 'keyword'
+    | 'fallback';
+}
+
+// =============================================================================
+// DB row shapes (subset)
+// =============================================================================
+
+export interface PendingTransactionRow {
+  id: string;
+  description: string;
+  merchant_name: string | null;
+  amount: number;
+  type: 'DEBIT' | 'CREDIT';
+  date: string;
+  category_id: string | null;
+}
+
+export interface CategoryRow {
+  id: string;
+  name: string;
+  icon: string | null;
+  type: 'INCOME' | 'EXPENSE';
+}
+
+// =============================================================================
+// UI view model — what the component consumes
+// =============================================================================
+
+export interface PendingTransactionWithSuggestion {
+  id: string;
+  description: string;
+  amount: number;
+  type: 'DEBIT' | 'CREDIT';
+  date: string;
+  /** The AI's suggested category (null if the cascade returned fallback/none). */
+  suggestedCategoryId: string | null;
+  suggestedCategoryName: string;
+  suggestedCategoryIcon: string;
+  confidence: number;
+  matchedBy: CategorizeResult['matchedBy'];
+}


### PR DESCRIPTION
## Summary

Sprint 1.6 — replaces the hardcoded \`PENDING_TRANSACTIONS\` mock in \`AICategorization.tsx\` with a real data flow backed by the \`categorize-transaction\` edge function (5-strategy cascade) and Supabase queries.

Flow:
1. Fetch uncategorized transactions (RLS-scoped to user's family)
2. Invoke edge fn for each pending tx → AI suggestion (categoryId + confidence + matchedBy)
3. User Accept → UPDATE \`transactions.category_id\`
4. User Change → picker over all categories → UPDATE
5. User Skip → remove from review queue, leave \`category_id\` NULL

## Design notes

- **Parallel suggestions with graceful fallback**: \`Promise.all\` on N invoke calls; a single failing tx becomes a fallback-branded item (\`matchedBy='fallback'\`, confidence=0), the rest proceed. User can still choose manually via Cambia.
- **Accept disabled when no AI suggestion**: prevents UPDATE with null categoryId. Tooltip guides to "Cambia" instead.
- **Row-level error surfaced**: failed \`applyCategory\` shows inline error, tx stays in list for retry.
- **Error class**: \`CategorizationApiError\` with tipizzato code set (fetch_failed / suggest_failed / apply_failed / unknown) + setPrototypeOf for \`instanceof\` reliability across transpilation — aligned with BankingApiError / GdprApiError pattern.

## Test plan

- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm lint\` — 0 errors
- [x] \`pnpm --filter @money-wise/web test\` — 1534 pass / 2 skip / 0 fail (+23 new: 15 service, 8 component)
- [ ] **Manual browser verification (human)**:
  - [ ] Navigate to AI Categorization, real transactions load with suggestions
  - [ ] Accept on confident suggestion → tx disappears, category applied in DB
  - [ ] Cambia → pick different category → tx disappears with chosen category
  - [ ] Skip → tx disappears, category_id stays NULL in DB
  - [ ] Network error during Accept → inline error, retry works

## Out of scope

- "Learn from user override" feedback loop: the edge fn already supports \`action: 'learn'\` but wiring it is a UX call for later
- Batch edge fn endpoint (N individual invokes today; fine up to ~20 pending)
- Categorization analytics / trends

## Notes

- PR opened **without** \`auto-merge\` label — MANDATORY PR lifecycle loop will add it after Copilot review clean + CI green (memoria \`feedback_pr_lifecycle_loop_workflow\`)
- Touches no \`supabase/migrations/**\` so auto-merge schema guard not triggered
- Worked in isolated worktree \`~/dev/money-wise-feat-sprint-1-ai-categorization/\` to avoid shared-HEAD conflicts with PR #445 monitoring loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)