### PR TITLE
feat(settings): Piano / Integrazioni / API Keys placeholders "In arrivo"

### DIFF
--- a/apps/web/__tests__/components/settings/ComingSoonTab.test.tsx
+++ b/apps/web/__tests__/components/settings/ComingSoonTab.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * Tests for ComingSoonTab — placeholder for unfinished Settings tabs.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Crown, Key } from 'lucide-react';
+
+import { ComingSoonTab } from '../../../src/components/settings/ComingSoonTab';
+
+describe('ComingSoonTab', () => {
+  it('renders title, default eta label, and description', () => {
+    render(
+      <ComingSoonTab
+        icon={Crown}
+        title="Gestione Piano"
+        description="Passa a Pro o Premium per sbloccare altre feature."
+      />
+    );
+    expect(screen.getByText('Gestione Piano')).toBeInTheDocument();
+    expect(screen.getByText(/In arrivo — Beta Q3 2026/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Passa a Pro o Premium/)
+    ).toBeInTheDocument();
+  });
+
+  it('honors a custom eta label', () => {
+    render(
+      <ComingSoonTab
+        icon={Key}
+        title="Chiavi API"
+        description="x"
+        eta="Q4 2026"
+      />
+    );
+    expect(screen.getByText(/In arrivo — Q4 2026/)).toBeInTheDocument();
+  });
+
+  it('renders preview features when provided', () => {
+    render(
+      <ComingSoonTab
+        title="X"
+        description="y"
+        previewFeatures={['Feature uno', 'Feature due', 'Feature tre']}
+      />
+    );
+    expect(screen.getByText('Cosa potrai fare')).toBeInTheDocument();
+    expect(screen.getByText('Feature uno')).toBeInTheDocument();
+    expect(screen.getByText('Feature due')).toBeInTheDocument();
+    expect(screen.getByText('Feature tre')).toBeInTheDocument();
+  });
+
+  it('does not render the preview section when no features passed', () => {
+    render(<ComingSoonTab title="X" description="y" />);
+    expect(screen.queryByText('Cosa potrai fare')).not.toBeInTheDocument();
+  });
+
+  it('does not render the preview section for an empty array', () => {
+    render(<ComingSoonTab title="X" description="y" previewFeatures={[]} />);
+    expect(screen.queryByText('Cosa potrai fare')).not.toBeInTheDocument();
+  });
+
+  it('applies a custom icon gradient class', () => {
+    const { container } = render(
+      <ComingSoonTab
+        title="X"
+        description="y"
+        iconGradient="from-red-500 to-pink-500"
+      />
+    );
+    const icon = container.querySelector('[class*="from-red-500"]');
+    expect(icon).not.toBeNull();
+  });
+});

--- a/apps/web/app/dashboard/settings/page.tsx
+++ b/apps/web/app/dashboard/settings/page.tsx
@@ -16,39 +16,21 @@ import { CategoryManager } from '@/components/categories/CategoryManager';
 import { NotificationsTab } from '@/components/settings/NotificationsTab';
 import { SecurityTab } from '@/components/settings/SecurityTab';
 import { DataTab } from '@/components/settings/DataTab';
+import { ComingSoonTab } from '@/components/settings/ComingSoonTab';
 import {
-  User,
-  CreditCard,
-  Shield,
-  Globe,
   Link as LinkIcon,
   Check,
   AlertCircle,
   Sun,
   Palette,
   Crown,
-  Users,
-  Building2,
-  CheckCircle2,
-  X as XIcon,
-  FileSpreadsheet,
-  Zap,
-  RefreshCw,
   Key,
   Monitor,
-  TrendingUp,
-  Wallet,
-  Sparkles,
-  Eye,
-  EyeOff,
-  Copy,
-  Brain,
   Loader2,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Badge } from '@/components/ui/badge';
 import { Card } from '@/components/ui/card';
 import { useAuthStore } from '@/store/auth.store';
 import { useTheme, type Theme } from '@/hooks/useTheme';
@@ -99,80 +81,10 @@ const TABS: { key: TabKey; label: string }[] = [
   { key: 'data', label: 'Dati' },
 ];
 
-const plans = [
-  {
-    id: 'single',
-    name: 'Single User',
-    price: 'Gratis',
-    icon: User,
-    color: 'border-blue-200 bg-blue-50 dark:bg-blue-950/30',
-    features: [
-      { name: 'Dashboard base', included: true },
-      { name: '2 Conti', included: true },
-      { name: 'Spese e Budget', included: true },
-      { name: 'Analisi AI base', included: true },
-      { name: '50 transazioni/mese', included: true },
-      { name: 'Conti illimitati', included: false },
-      { name: 'AskAI illimitato', included: false },
-      { name: 'Integrazioni PayPal/Plaid', included: false },
-      { name: 'Report mensili avanzati', included: false },
-      { name: 'Import/Export avanzato', included: false },
-      { name: 'Multi-utente', included: false },
-    ],
-  },
-  {
-    id: 'family',
-    name: 'Family',
-    price: '€9,99/mese',
-    icon: Users,
-    color: 'border-purple-200 bg-purple-50 dark:bg-purple-950/30',
-    popular: true,
-    features: [
-      { name: 'Dashboard avanzata', included: true },
-      { name: 'Conti illimitati', included: true },
-      { name: 'Spese e Budget', included: true },
-      { name: 'Analisi AI avanzata', included: true },
-      { name: 'Transazioni illimitate', included: true },
-      { name: 'AskAI illimitato', included: true },
-      { name: 'Integrazioni PayPal/Plaid', included: true },
-      { name: 'Report mensili avanzati', included: true },
-      { name: 'Import/Export completo', included: true },
-      { name: 'Fino a 5 utenti', included: true },
-      { name: 'API access', included: false },
-    ],
-  },
-  {
-    id: 'business',
-    name: 'Business',
-    price: '€24,99/mese',
-    icon: Building2,
-    color: 'border-yellow-200 bg-yellow-50 dark:bg-yellow-950/30',
-    features: [
-      { name: 'Dashboard avanzata', included: true },
-      { name: 'Conti illimitati', included: true },
-      { name: 'Spese e Budget', included: true },
-      { name: 'Analisi AI premium', included: true },
-      { name: 'Transazioni illimitate', included: true },
-      { name: 'AskAI illimitato', included: true },
-      { name: 'Tutte le integrazioni', included: true },
-      { name: 'Report personalizzati', included: true },
-      { name: 'Import/Export completo', included: true },
-      { name: 'Utenti illimitati', included: true },
-      { name: 'API access + Webhook', included: true },
-    ],
-  },
-];
-
-const integrations = [
-  { id: 'paypal', name: 'PayPal', desc: 'Gestione pagamenti e transazioni', icon: CreditCard, color: 'bg-blue-600', category: 'pagamenti' },
-  { id: 'plaid', name: 'Plaid Banking', desc: 'Sincronizza conti bancari automaticamente', icon: LinkIcon, color: 'bg-green-600', category: 'banca' },
-  { id: 'revolut', name: 'Revolut', desc: 'Conto e carta multi-valuta', icon: RefreshCw, color: 'bg-indigo-600', category: 'banca' },
-  { id: 'wise', name: 'Wise (TransferWise)', desc: 'Trasferimenti internazionali economici', icon: Globe, color: 'bg-cyan-600', category: 'pagamenti' },
-  { id: 'coinbase', name: 'Coinbase', desc: 'Portafoglio crypto e trading', icon: TrendingUp, color: 'bg-blue-500', category: 'crypto' },
-  { id: 'binance', name: 'Binance', desc: 'Exchange crypto avanzato', icon: TrendingUp, color: 'bg-yellow-500', category: 'crypto' },
-  { id: 'gsheets', name: 'Google Sheets', desc: 'Esporta dati su fogli di calcolo', icon: FileSpreadsheet, color: 'bg-green-500', category: 'produttività' },
-  { id: 'zapier', name: 'Zapier', desc: 'Automatizzazioni e workflow', icon: Zap, color: 'bg-orange-500', category: 'automazione' },
-];
+// `plans` and `integrations` catalogs removed in Sprint 1.4 — their tabs
+// render <ComingSoonTab /> until the real feature ships. When restoring,
+// consider moving them into dedicated config files (plans.config.ts,
+// integrations.config.ts) rather than inlining here.
 
 const TOGGLE_CLASS =
   'appearance-none w-10 h-5 bg-muted rounded-full relative cursor-pointer checked:bg-emerald-500 after:content-[\'\'] after:absolute after:top-0.5 after:left-0.5 after:w-4 after:h-4 after:bg-white after:rounded-full after:transition-transform checked:after:translate-x-5';
@@ -204,18 +116,8 @@ export default function SettingsPage() {
     },
   });
 
-  // Plan state
-  const [currentPlan, setCurrentPlan] = useState('single');
-  const [planFeedback, setPlanFeedback] = useState<string | null>(null);
-
-  // Integrations state
-  const [connectedIntegrations, setConnectedIntegrations] = useState<string[]>([]);
-  const [integrationFeedback, setIntegrationFeedback] = useState<string | null>(null);
-
-  // API Keys state
-  const [showApiKeys, setShowApiKeys] = useState<Record<string, boolean>>({});
-  const [apiKeys, setApiKeys] = useState({ openai: '', anthropic: '', gemini: '', coinbase: '', plaid: '' });
-  const [apiKeyFeedback, setApiKeyFeedback] = useState<string | null>(null);
+  // Piano / Integrazioni / API Keys tabs are "In arrivo" placeholders (Sprint 1.4),
+  // so their state is gone. When these tabs go live, restore here.
 
 
   // Initialize form with user data
@@ -242,11 +144,6 @@ export default function SettingsPage() {
   const initials = user
     ? `${(user.firstName || '')[0] || ''}${(user.lastName || '')[0] || ''}`.toUpperCase() || 'U'
     : 'U';
-
-  const showFeedback = (setter: (v: string | null) => void, msg: string) => {
-    setter(msg);
-    setTimeout(() => setter(null), 2500);
-  };
 
   // Profile save (real Supabase)
   const handleSaveProfile = async () => {
@@ -299,16 +196,6 @@ export default function SettingsPage() {
       setError(err instanceof Error ? err.message : 'Impossibile salvare le modifiche');
     } finally {
       setIsSaving(false);
-    }
-  };
-
-  const toggleIntegration = (id: string) => {
-    if (connectedIntegrations.includes(id)) {
-      setConnectedIntegrations((prev) => prev.filter((i) => i !== id));
-      showFeedback(setIntegrationFeedback, 'Integrazione disconnessa');
-    } else {
-      setConnectedIntegrations((prev) => [...prev, id]);
-      showFeedback(setIntegrationFeedback, 'Integrazione connessa!');
     }
   };
 
@@ -585,290 +472,36 @@ export default function SettingsPage() {
       {/* API Keys Tab */}
       {/* ================================================================= */}
       {activeTab === 'apikeys' && (
-        <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} className="space-y-4">
-          {/* Header Card */}
-          <Card className="p-6 rounded-2xl border-0 shadow-sm bg-gradient-to-r from-purple-500/5 via-indigo-500/5 to-blue-500/5">
-            <div className="flex items-start gap-4">
-              <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-purple-500 to-indigo-500 flex items-center justify-center shadow-lg flex-shrink-0">
-                <Key className="w-6 h-6 text-white" />
-              </div>
-              <div className="flex-1">
-                <h3 className="text-[18px] font-medium text-foreground">Chiavi API</h3>
-                <p className="text-[13px] text-muted-foreground mt-1">
-                  Configura le tue API keys per abilitare l&apos;integrazione con servizi AI e finanziari
-                </p>
-              </div>
-            </div>
-          </Card>
-
-          {/* Feedback */}
-          {apiKeyFeedback && (
-            <div className="flex items-center gap-2 p-3 bg-emerald-500/10 rounded-xl">
-              <Check className="w-4 h-4 text-emerald-600" />
-              <span className="text-[13px] text-emerald-600">{apiKeyFeedback}</span>
-            </div>
-          )}
-
-          {/* AI Services */}
-          <Card className="p-6 rounded-2xl border-0 shadow-sm">
-            <h4 className="text-[16px] font-medium text-foreground mb-5 flex items-center gap-2">
-              <Brain className="w-5 h-5 text-purple-500" />
-              Intelligenza Artificiale
-            </h4>
-            <div className="space-y-4">
-              {[
-                { id: 'openai', name: 'OpenAI', desc: 'GPT-4, GPT-3.5 Turbo', icon: '🤖', gradient: 'from-emerald-500 to-teal-500' },
-                { id: 'anthropic', name: 'Anthropic Claude', desc: 'Claude 3 Opus, Sonnet, Haiku', icon: '🧠', gradient: 'from-orange-500 to-amber-500' },
-                { id: 'gemini', name: 'Google Gemini', desc: 'Gemini Pro, Ultra', icon: '✨', gradient: 'from-blue-500 to-indigo-500' },
-              ].map((service) => {
-                const keyValue = apiKeys[service.id as keyof typeof apiKeys];
-                const isConfigured = keyValue.length > 0;
-                return (
-                  <div key={service.id} className="p-4 rounded-xl bg-muted/30 hover:bg-muted/50 transition-all border border-border/50">
-                    <div className="flex items-center gap-3 mb-3">
-                      <div className={`w-10 h-10 rounded-lg bg-gradient-to-br ${service.gradient} flex items-center justify-center text-[20px] shadow-sm flex-shrink-0`}>
-                        {service.icon}
-                      </div>
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-2">
-                          <p className="text-[14px] font-medium text-foreground">{service.name}</p>
-                          {isConfigured && (
-                            <span className="flex items-center gap-1 text-[10px] font-medium px-2 py-0.5 rounded-md bg-emerald-500/10 text-emerald-600 dark:text-emerald-400">
-                              <Check className="w-3 h-3" />Attiva
-                            </span>
-                          )}
-                        </div>
-                        <p className="text-[11px] text-muted-foreground mt-0.5">{service.desc}</p>
-                      </div>
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <div className="relative flex-1">
-                        <Input
-                          type={showApiKeys[service.id] ? 'text' : 'password'}
-                          placeholder="sk-••••••••••••••••••••••••"
-                          value={keyValue}
-                          onChange={(e) => setApiKeys({ ...apiKeys, [service.id]: e.target.value })}
-                          className="h-9 pr-16 font-mono text-[11px] bg-background border-border/50"
-                        />
-                        <div className="absolute right-1 top-1/2 -translate-y-1/2 flex items-center gap-0.5">
-                          <button
-                            type="button"
-                            onClick={() => setShowApiKeys({ ...showApiKeys, [service.id]: !showApiKeys[service.id] })}
-                            className="p-1.5 hover:bg-muted rounded-md transition-colors"
-                          >
-                            {showApiKeys[service.id] ? (
-                              <EyeOff className="w-3.5 h-3.5 text-muted-foreground" />
-                            ) : (
-                              <Eye className="w-3.5 h-3.5 text-muted-foreground" />
-                            )}
-                          </button>
-                          {keyValue && (
-                            <button
-                              type="button"
-                              onClick={() => {
-                                window.navigator.clipboard.writeText(keyValue);
-                                showFeedback(setApiKeyFeedback, 'API key copiata!');
-                              }}
-                              className="p-1.5 hover:bg-muted rounded-md transition-colors"
-                            >
-                              <Copy className="w-3.5 h-3.5 text-muted-foreground" />
-                            </button>
-                          )}
-                        </div>
-                      </div>
-                      <Button
-                        size="sm"
-                        className={`h-9 px-4 rounded-lg ${
-                          isConfigured
-                            ? 'bg-muted text-foreground hover:bg-muted/80'
-                            : `bg-gradient-to-r ${service.gradient} text-white hover:opacity-90`
-                        }`}
-                        onClick={() =>
-                          showFeedback(setApiKeyFeedback, `API key ${service.name} ${isConfigured ? 'aggiornata' : 'salvata'}!`)
-                        }
-                      >
-                        {isConfigured ? 'Aggiorna' : 'Salva'}
-                      </Button>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          </Card>
-
-          {/* Financial Services */}
-          <Card className="p-6 rounded-2xl border-0 shadow-sm">
-            <h4 className="text-[16px] font-medium text-foreground mb-5 flex items-center gap-2">
-              <Wallet className="w-5 h-5 text-blue-500" />
-              Servizi Finanziari
-            </h4>
-            <div className="space-y-4">
-              {[
-                { id: 'plaid', name: 'Plaid Banking', desc: 'Sincronizzazione bancaria automatica', icon: '🏦', gradient: 'from-blue-500 to-cyan-500' },
-                { id: 'coinbase', name: 'Coinbase API', desc: 'Trading e portfolio crypto', icon: '₿', gradient: 'from-orange-500 to-yellow-500' },
-              ].map((service) => {
-                const keyValue = apiKeys[service.id as keyof typeof apiKeys];
-                const isConfigured = keyValue.length > 0;
-                return (
-                  <div key={service.id} className="p-4 rounded-xl bg-muted/30 hover:bg-muted/50 transition-all border border-border/50">
-                    <div className="flex items-center gap-3 mb-3">
-                      <div className={`w-10 h-10 rounded-lg bg-gradient-to-br ${service.gradient} flex items-center justify-center text-[20px] shadow-sm flex-shrink-0`}>
-                        {service.icon}
-                      </div>
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-2">
-                          <p className="text-[14px] font-medium text-foreground">{service.name}</p>
-                          {isConfigured && (
-                            <span className="flex items-center gap-1 text-[10px] font-medium px-2 py-0.5 rounded-md bg-emerald-500/10 text-emerald-600 dark:text-emerald-400">
-                              <Check className="w-3 h-3" />Attiva
-                            </span>
-                          )}
-                        </div>
-                        <p className="text-[11px] text-muted-foreground mt-0.5">{service.desc}</p>
-                      </div>
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <div className="relative flex-1">
-                        <Input
-                          type={showApiKeys[service.id] ? 'text' : 'password'}
-                          placeholder="••••••••••••••••••••••••"
-                          value={keyValue}
-                          onChange={(e) => setApiKeys({ ...apiKeys, [service.id]: e.target.value })}
-                          className="h-9 pr-16 font-mono text-[11px] bg-background border-border/50"
-                        />
-                        <div className="absolute right-1 top-1/2 -translate-y-1/2 flex items-center gap-0.5">
-                          <button
-                            type="button"
-                            onClick={() => setShowApiKeys({ ...showApiKeys, [service.id]: !showApiKeys[service.id] })}
-                            className="p-1.5 hover:bg-muted rounded-md transition-colors"
-                          >
-                            {showApiKeys[service.id] ? (
-                              <EyeOff className="w-3.5 h-3.5 text-muted-foreground" />
-                            ) : (
-                              <Eye className="w-3.5 h-3.5 text-muted-foreground" />
-                            )}
-                          </button>
-                          {keyValue && (
-                            <button
-                              type="button"
-                              onClick={() => {
-                                window.navigator.clipboard.writeText(keyValue);
-                                showFeedback(setApiKeyFeedback, 'API key copiata!');
-                              }}
-                              className="p-1.5 hover:bg-muted rounded-md transition-colors"
-                            >
-                              <Copy className="w-3.5 h-3.5 text-muted-foreground" />
-                            </button>
-                          )}
-                        </div>
-                      </div>
-                      <Button
-                        size="sm"
-                        className={`h-9 px-4 rounded-lg ${
-                          isConfigured
-                            ? 'bg-muted text-foreground hover:bg-muted/80'
-                            : `bg-gradient-to-r ${service.gradient} text-white hover:opacity-90`
-                        }`}
-                        onClick={() =>
-                          showFeedback(setApiKeyFeedback, `API key ${service.name} ${isConfigured ? 'aggiornata' : 'salvata'}!`)
-                        }
-                      >
-                        {isConfigured ? 'Aggiorna' : 'Salva'}
-                      </Button>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          </Card>
-
-          {/* Security Note */}
-          <Card className="p-5 rounded-2xl border-0 bg-amber-500/5 border-l-4 border-l-amber-500">
-            <div className="flex items-start gap-3">
-              <Shield className="w-5 h-5 text-amber-600 dark:text-amber-400 mt-0.5 flex-shrink-0" />
-              <div>
-                <p className="text-[13px] font-medium text-foreground">Sicurezza e Privacy</p>
-                <p className="text-[12px] text-muted-foreground mt-1.5 leading-relaxed">
-                  Le API keys vengono criptate end-to-end e archiviate in modo sicuro. Non vengono mai condivise con terze parti.
-                </p>
-              </div>
-            </div>
-          </Card>
-        </motion.div>
+        <ComingSoonTab
+          icon={Key}
+          iconGradient="from-purple-500 to-indigo-500"
+          title="Chiavi API"
+          description="Configura le tue API keys per abilitare l'integrazione con servizi AI e finanziari (OpenAI, Anthropic, Gemini, Plaid, Coinbase)."
+          eta="Beta Q3 2026"
+          previewFeatures={[
+            'Chiavi cifrate end-to-end lato server',
+            'Rotazione automatica e audit delle chiamate',
+            'Quota e rate-limit per servizio',
+          ]}
+        />
       )}
 
       {/* ================================================================= */}
       {/* Plan Tab */}
       {/* ================================================================= */}
       {activeTab === 'plan' && (
-        <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }}>
-          <div className="mb-6">
-            <h3 className="text-lg font-semibold text-foreground mb-1">Gestione Piano</h3>
-            <p className="text-sm text-muted-foreground">
-              Piano attuale: <Badge className="ml-1">{plans.find((p) => p.id === currentPlan)?.name}</Badge>
-            </p>
-            {planFeedback && (
-              <div className="mt-3 flex items-center gap-2 text-[13px] text-emerald-600">
-                <Check className="w-4 h-4" /> {planFeedback}
-              </div>
-            )}
-          </div>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            {plans.map((plan) => {
-              const active = currentPlan === plan.id;
-              return (
-                <motion.div key={plan.id} initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }}>
-                  <Card className={`p-6 relative rounded-2xl border-0 shadow-sm ${active ? 'ring-2 ring-emerald-500' : ''} ${plan.color}`}>
-                    {plan.popular && (
-                      <div className="absolute -top-3 left-1/2 -translate-x-1/2">
-                        <Badge className="bg-purple-600 text-white">
-                          <Crown className="w-3 h-3 mr-1" /> Popolare
-                        </Badge>
-                      </div>
-                    )}
-                    <div className="flex items-center gap-3 mb-4">
-                      <div className="p-2 bg-card rounded-xl">
-                        <plan.icon className="w-6 h-6 text-foreground" />
-                      </div>
-                      <div>
-                        <h4 className="font-bold text-foreground">{plan.name}</h4>
-                        <p className="text-lg font-bold text-foreground">{plan.price}</p>
-                      </div>
-                    </div>
-                    <div className="space-y-2 mb-6">
-                      {plan.features.map((f) => (
-                        <div key={f.name} className="flex items-center gap-2 text-sm">
-                          {f.included ? (
-                            <CheckCircle2 className="w-4 h-4 text-green-600 flex-shrink-0" />
-                          ) : (
-                            <XIcon className="w-4 h-4 text-muted-foreground flex-shrink-0" />
-                          )}
-                          <span className={f.included ? 'text-foreground' : 'text-muted-foreground'}>{f.name}</span>
-                        </div>
-                      ))}
-                    </div>
-                    <Button
-                      className={`w-full ${
-                        active
-                          ? 'bg-muted text-muted-foreground cursor-default'
-                          : 'bg-gradient-to-r from-emerald-500 to-teal-500 hover:from-emerald-600 hover:to-teal-600 text-white'
-                      }`}
-                      onClick={() => {
-                        if (!active) {
-                          setCurrentPlan(plan.id);
-                          showFeedback(setPlanFeedback, `Piano ${plan.name} attivato!`);
-                        }
-                      }}
-                      disabled={active}
-                    >
-                      {active ? 'Piano Attuale' : 'Seleziona'}
-                    </Button>
-                  </Card>
-                </motion.div>
-              );
-            })}
-          </div>
-        </motion.div>
+        <ComingSoonTab
+          icon={Crown}
+          iconGradient="from-emerald-500 to-teal-500"
+          title="Gestione Piano"
+          description="Passa a Pro o Premium per sbloccare report AI avanzati, integrazioni bancarie e supporto prioritario."
+          eta="Beta Q3 2026"
+          previewFeatures={[
+            'Confronto Free / Pro / Premium',
+            'Fatturazione Stripe con ricevuta PDF',
+            'Cambio piano e cancellazione senza attrito',
+          ]}
+        />
       )}
 
       {/* ================================================================= */}
@@ -880,101 +513,18 @@ export default function SettingsPage() {
       {/* Integrations Tab */}
       {/* ================================================================= */}
       {activeTab === 'integrations' && (
-        <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} className="space-y-6">
-          {/* AI Suggestion */}
-          <Card className="p-4 rounded-2xl border-0 shadow-sm border-l-4 border-l-purple-500">
-            <div className="flex items-start gap-3">
-              <Sparkles className="w-5 h-5 text-purple-600 mt-0.5" />
-              <div>
-                <p className="text-sm font-semibold text-foreground">Suggerimento AI</p>
-                <p className="text-sm text-muted-foreground mt-1">
-                  Collegando Plaid Banking e PayPal, le tue transazioni verranno importate automaticamente.
-                  Risparmierai circa 15 minuti al giorno!
-                </p>
-              </div>
-            </div>
-          </Card>
-
-          {/* Feedback */}
-          {integrationFeedback && (
-            <div className="flex items-center gap-2 p-3 bg-emerald-500/10 rounded-xl">
-              <Check className="w-4 h-4 text-emerald-600" />
-              <span className="text-[13px] text-emerald-600">{integrationFeedback}</span>
-            </div>
-          )}
-
-          {/* Grouped */}
-          {(['banca', 'pagamenti', 'crypto', 'produttività', 'automazione'] as const).map((cat) => {
-            const items = integrations.filter((i) => i.category === cat);
-            if (items.length === 0) return null;
-            const catLabels: Record<string, string> = {
-              banca: 'Banking',
-              pagamenti: 'Pagamenti',
-              crypto: 'Crypto',
-              produttivita: 'Produttività',
-              automazione: 'Automazione',
-            };
-            return (
-              <div key={cat}>
-                <h4 className="text-sm font-semibold text-muted-foreground mb-3">{catLabels[cat]}</h4>
-                <div className="space-y-3">
-                  {items.map((integration) => {
-                    const connected = connectedIntegrations.includes(integration.id);
-                    return (
-                      <Card key={integration.id} className="p-4 rounded-2xl border-0 shadow-sm">
-                        <div className="flex items-center justify-between gap-4">
-                          <div className="flex items-center gap-4">
-                            <div className={`w-12 h-12 ${integration.color} rounded-xl flex items-center justify-center flex-shrink-0`}>
-                              <integration.icon className="w-6 h-6 text-white" />
-                            </div>
-                            <div>
-                              <h3 className="font-semibold text-foreground">{integration.name}</h3>
-                              <p className="text-sm text-muted-foreground">{integration.desc}</p>
-                            </div>
-                          </div>
-                          <div className="flex items-center gap-3 flex-shrink-0">
-                            {connected ? (
-                              <>
-                                <Badge className="bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300">
-                                  <Check className="w-3 h-3 mr-1" />Connesso
-                                </Badge>
-                                <Button variant="outline" size="sm" onClick={() => toggleIntegration(integration.id)}>
-                                  Disconnetti
-                                </Button>
-                              </>
-                            ) : (
-                              <Button
-                                size="sm"
-                                className="bg-gradient-to-r from-emerald-500 to-teal-500 hover:from-emerald-600 hover:to-teal-600 text-white border-0"
-                                onClick={() => toggleIntegration(integration.id)}
-                              >
-                                <LinkIcon className="w-4 h-4 mr-2" />Connetti
-                              </Button>
-                            )}
-                          </div>
-                        </div>
-                      </Card>
-                    );
-                  })}
-                </div>
-              </div>
-            );
-          })}
-
-          {/* Privacy Note */}
-          <Card className="p-6 rounded-2xl bg-blue-50 dark:bg-blue-950/30 border-blue-200 dark:border-blue-800">
-            <div className="flex items-start gap-3">
-              <AlertCircle className="w-5 h-5 text-blue-600 mt-0.5" />
-              <div>
-                <h4 className="font-semibold text-blue-900 dark:text-blue-100 mb-2">Nota sulla Privacy</h4>
-                <p className="text-sm text-blue-800 dark:text-blue-200">
-                  Questa è un&apos;applicazione demo. Le integrazioni sono simulate e non trasmettono dati reali.
-                  Non inserire credenziali finanziarie reali.
-                </p>
-              </div>
-            </div>
-          </Card>
-        </motion.div>
+        <ComingSoonTab
+          icon={LinkIcon}
+          iconGradient="from-cyan-500 to-blue-500"
+          title="Integrazioni"
+          description="Collega servizi esterni (PayPal, Revolut, Google Sheets, Notion) per centralizzare finanze e workflow."
+          eta="Beta Q3 2026"
+          previewFeatures={[
+            'Marketplace di integrazioni certificate',
+            'Sync bidirezionale dove supportato',
+            'Log delle sincronizzazioni con retry automatico',
+          ]}
+        />
       )}
 
       {activeTab === 'security' && <SecurityTab />}

--- a/apps/web/src/components/settings/ComingSoonTab.tsx
+++ b/apps/web/src/components/settings/ComingSoonTab.tsx
@@ -51,8 +51,9 @@ export function ComingSoonTab({
         <div className="flex items-start gap-4">
           <div
             className={`w-12 h-12 rounded-xl bg-gradient-to-br ${iconGradient} flex items-center justify-center shadow-lg flex-shrink-0`}
+            aria-hidden="true"
           >
-            <Icon className="w-6 h-6 text-white" />
+            <Icon className="w-6 h-6 text-white" aria-hidden="true" />
           </div>
           <div className="flex-1">
             <div className="flex items-center gap-2 flex-wrap">
@@ -74,9 +75,12 @@ export function ComingSoonTab({
             Cosa potrai fare
           </h4>
           <ul className="space-y-2">
-            {previewFeatures.map((feature) => (
+            {previewFeatures.map((feature, index) => (
               <li
-                key={feature}
+                // Index-based key — feature strings are not guaranteed unique
+                // (callers may pass duplicate labels) and the list is static
+                // per render so index is stable.
+                key={`${index}-${feature}`}
                 className="flex items-start gap-2 text-[13px] text-muted-foreground"
               >
                 <span

--- a/apps/web/src/components/settings/ComingSoonTab.tsx
+++ b/apps/web/src/components/settings/ComingSoonTab.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+/**
+ * ComingSoonTab — generic "In arrivo" placeholder for Settings tabs
+ * whose functionality is not yet wired (Piano, Integrazioni, API Keys).
+ *
+ * Replaces the previous mock UI that showed fake buttons/feedback. The
+ * real implementation for each tab will come in a later sprint — this
+ * placeholder sets expectations honestly without removing the tab entry
+ * from the nav (users still discover the feature area exists).
+ *
+ * @module components/settings/ComingSoonTab
+ */
+
+import type { ComponentType } from 'react';
+import { motion } from 'framer-motion';
+import type { LucideIcon } from 'lucide-react';
+import { Clock } from 'lucide-react';
+import { Card } from '@/components/ui/card';
+
+interface ComingSoonTabProps {
+  /** Optional hero icon (lucide). Defaults to Clock. */
+  icon?: LucideIcon | ComponentType<{ className?: string }>;
+  /** Title shown in the hero card. */
+  title: string;
+  /** One-sentence description of what this tab will do when live. */
+  description: string;
+  /** Expected availability label. Default: "Beta Q3 2026". */
+  eta?: string;
+  /** Gradient classes for the hero icon background. */
+  iconGradient?: string;
+  /** Optional bullet list of features the user can expect. */
+  previewFeatures?: string[];
+}
+
+export function ComingSoonTab({
+  icon: Icon = Clock,
+  title,
+  description,
+  eta = 'Beta Q3 2026',
+  iconGradient = 'from-indigo-500 to-violet-500',
+  previewFeatures,
+}: ComingSoonTabProps) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      className="space-y-4"
+    >
+      <Card className="p-6 rounded-2xl border-0 shadow-sm bg-gradient-to-r from-indigo-500/5 via-violet-500/5 to-blue-500/5">
+        <div className="flex items-start gap-4">
+          <div
+            className={`w-12 h-12 rounded-xl bg-gradient-to-br ${iconGradient} flex items-center justify-center shadow-lg flex-shrink-0`}
+          >
+            <Icon className="w-6 h-6 text-white" />
+          </div>
+          <div className="flex-1">
+            <div className="flex items-center gap-2 flex-wrap">
+              <h3 className="text-[18px] font-medium text-foreground">{title}</h3>
+              <span className="text-[11px] px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
+                In arrivo — {eta}
+              </span>
+            </div>
+            <p className="text-[13px] text-muted-foreground mt-1">
+              {description}
+            </p>
+          </div>
+        </div>
+      </Card>
+
+      {previewFeatures && previewFeatures.length > 0 && (
+        <Card className="p-6 rounded-2xl border-0 shadow-sm">
+          <h4 className="text-[14px] font-medium text-foreground mb-3">
+            Cosa potrai fare
+          </h4>
+          <ul className="space-y-2">
+            {previewFeatures.map((feature) => (
+              <li
+                key={feature}
+                className="flex items-start gap-2 text-[13px] text-muted-foreground"
+              >
+                <span
+                  className="mt-1.5 w-1 h-1 rounded-full bg-indigo-500/60 flex-shrink-0"
+                  aria-hidden="true"
+                />
+                <span>{feature}</span>
+              </li>
+            ))}
+          </ul>
+        </Card>
+      )}
+    </motion.div>
+  );
+}
+
+export default ComingSoonTab;


### PR DESCRIPTION
## Summary

Sprint 1.4 — three Settings tabs (Piano, Integrazioni, API Keys) rendered elaborate dummy UI with fake buttons/toggles that weren't wired to any backend. Replaced with a single \`<ComingSoonTab />\` component setting honest expectations: **"In arrivo — Beta Q3 2026"**.

- New \`components/settings/ComingSoonTab.tsx\` — generic parametrized placeholder
- \`page.tsx\`: ~380 lines of mock UI collapsed into 3 ~14-line wrappers
- Dead state / helpers / catalogs / unused icon imports removed (18 icons, 2 catalogs, 6 state hooks, 2 helpers)
- 6 new unit tests for ComingSoonTab

## Design notes

- **Why placeholders vs removing tabs**: users currently navigate via tab nav and the feature areas are product roadmap items. Hiding tabs = "we don't plan this" (wrong signal). Placeholders with ETA + preview features = "it's coming, with this scope" (honest).
- **Reusable helper**: \`ComingSoonTab\` is parametrized (icon, gradient, title, desc, eta, previewFeatures) so other future placeholders in the app can adopt it with one line.
- **Catalogs removal**: \`plans\` (with Single/Family/Business pricing features) and \`integrations\` (with PayPal/Plaid/Revolut/etc) were inlined in page.tsx. Removed now; when real implementations land, consider moving them into dedicated config files rather than inlining back.

## Test plan

- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm lint\` — 0 errors (3 pre-existing warnings)
- [x] \`pnpm --filter @money-wise/web test\` — ComingSoonTab: 6/6 pass locally
- [ ] **Manual browser verification (human)**: check each of the 3 tabs shows the placeholder with correct icon/gradient/ETA/preview list

## Notes

- PR opened **without** \`auto-merge\` label — loop MANDATORY gestirà l'applicazione post-review Copilot
- Touches no \`supabase/migrations/**\` so auto-merge schema guard not triggered
- Unblocks no other sprint (1.7 expense_class rimane indipendente)

🤖 Generated with [Claude Code](https://claude.com/claude-code)