### PR TITLE
feat(expenses): reorganize tabs around expense_class (Fisse/Variabili)

### DIFF
--- a/apps/web/__tests__/pages/dashboard/transactions.test.tsx
+++ b/apps/web/__tests__/pages/dashboard/transactions.test.tsx
@@ -177,11 +177,13 @@ describe('TransactionsPage (ExpensesPage)', () => {
     it('renders tab filter buttons', async () => {
       render(<TransactionsPage />);
 
-      // Tab labels include counts, e.g. "Tutte (0)", "Uscite (0)"
+      // Tab labels include counts, e.g. "Tutte (0)", "Fisse (0)"
+      // Sprint 1.7: tabs reorganized around expense_class (Fisse/Variabili)
+      // instead of transaction type (Uscite/Entrate).
       await waitFor(() => {
         expect(screen.getByText(/Tutte \(/)).toBeInTheDocument();
-        expect(screen.getByText(/Uscite \(/)).toBeInTheDocument();
-        expect(screen.getByText(/Entrate \(/)).toBeInTheDocument();
+        expect(screen.getByText(/Fisse \(/)).toBeInTheDocument();
+        expect(screen.getByText(/Variabili \(/)).toBeInTheDocument();
         expect(screen.getByText(/Ricorrenti \(/)).toBeInTheDocument();
       });
     });

--- a/apps/web/__tests__/pages/dashboard/transactions.test.tsx
+++ b/apps/web/__tests__/pages/dashboard/transactions.test.tsx
@@ -187,6 +187,39 @@ describe('TransactionsPage (ExpensesPage)', () => {
         expect(screen.getByText(/Ricorrenti \(/)).toBeInTheDocument();
       });
     });
+
+    // Sprint 1.7 semantic check: the page is "Spese" so CREDIT rows should
+    // never be counted in any tab — all tabs partition the DEBIT universe.
+    it('excludes CREDIT (income) transactions from all tab counts', async () => {
+      const mixed = [
+        // 3 DEBIT expenses, 2 CREDIT income
+        { id: 't1', type: 'DEBIT', amount: -10, categoryId: 'cat-fixed', isRecurring: false, date: '2026-04-01', description: 'x', merchantName: null, accountId: 'a', status: 'POSTED' },
+        { id: 't2', type: 'DEBIT', amount: -20, categoryId: 'cat-var', isRecurring: true, date: '2026-04-02', description: 'y', merchantName: null, accountId: 'a', status: 'POSTED' },
+        { id: 't3', type: 'DEBIT', amount: -30, categoryId: null, isRecurring: false, date: '2026-04-03', description: 'z', merchantName: null, accountId: 'a', status: 'POSTED' },
+        { id: 't4', type: 'CREDIT', amount: 500, categoryId: 'cat-income', isRecurring: false, date: '2026-04-04', description: 'salary', merchantName: null, accountId: 'a', status: 'POSTED' },
+        { id: 't5', type: 'CREDIT', amount: 100, categoryId: 'cat-income', isRecurring: true, date: '2026-04-05', description: 'dividend', merchantName: null, accountId: 'a', status: 'POSTED' },
+      ];
+      mockTransactionsClient.getTransactions.mockResolvedValue(
+        mixed as unknown as Awaited<ReturnType<typeof mockTransactionsClient.getTransactions>>
+      );
+      mockCategoriesClient.getOptions.mockResolvedValue([
+        { id: 'cat-fixed', name: 'Rent', slug: 'rent', type: 'EXPENSE', expenseClass: 'FIXED' },
+        { id: 'cat-var', name: 'Food', slug: 'food', type: 'EXPENSE', expenseClass: 'VARIABLE' },
+        { id: 'cat-income', name: 'Salary', slug: 'salary', type: 'INCOME', expenseClass: null },
+        // deno-lint-ignore no-explicit-any
+      ] as unknown as any);
+
+      render(<TransactionsPage />);
+
+      // Tutte = 3 (DEBITs only, CREDITs excluded)
+      await waitFor(() => {
+        expect(screen.getByText(/Tutte \(3\)/)).toBeInTheDocument();
+      });
+      // Fisse = 1 (t1), Variabili = 1 (t2), Ricorrenti = 1 (t2 only; t5 is CREDIT)
+      expect(screen.getByText(/Fisse \(1\)/)).toBeInTheDocument();
+      expect(screen.getByText(/Variabili \(1\)/)).toBeInTheDocument();
+      expect(screen.getByText(/Ricorrenti \(1\)/)).toBeInTheDocument();
+    });
   });
 
   describe('Transaction List', () => {

--- a/apps/web/app/dashboard/transactions/page.tsx
+++ b/apps/web/app/dashboard/transactions/page.tsx
@@ -176,50 +176,46 @@ export default function ExpensesPage() {
     [categorySpending]
   );
 
-  // Filter transactions by tab — "Spese" view is expense-class oriented:
-  // Fisse / Variabili partition the DEBIT universe, with Ricorrenti as an
-  // orthogonal slice. Income transactions are not shown under these tabs;
-  // use /dashboard/transactions for full list with Entrate view.
+  // This page is "Spese" — income (CREDIT) is out of scope here. We pre-filter
+  // to the expense universe so every tab (incluso 'all' and 'recurring')
+  // shows only DEBIT tx, consistent with the page title and the summary
+  // cards (Costi Fissi / Costi Variabili) that already compute on DEBIT.
+  const expenseTransactions = useMemo(
+    () => transactions.filter((t) => t.type === 'DEBIT'),
+    [transactions]
+  );
+
+  // Tab filters partition `expenseTransactions`: Fisse / Variabili split by
+  // category.expense_class; Ricorrenti is an orthogonal slice.
   const filteredTransactions = useMemo(() => {
     switch (activeTab) {
       case 'fixed':
-        return transactions.filter(
-          (t) =>
-            t.type === 'DEBIT' &&
-            t.categoryId &&
-            expenseClassMap.get(t.categoryId) === 'FIXED'
+        return expenseTransactions.filter(
+          (t) => t.categoryId && expenseClassMap.get(t.categoryId) === 'FIXED'
         );
       case 'variable':
-        return transactions.filter(
-          (t) =>
-            t.type === 'DEBIT' &&
-            t.categoryId &&
-            expenseClassMap.get(t.categoryId) === 'VARIABLE'
+        return expenseTransactions.filter(
+          (t) => t.categoryId && expenseClassMap.get(t.categoryId) === 'VARIABLE'
         );
       case 'recurring':
-        return transactions.filter((t) => t.isRecurring);
+        return expenseTransactions.filter((t) => t.isRecurring);
       default:
-        return transactions;
+        return expenseTransactions;
     }
-  }, [transactions, activeTab, expenseClassMap]);
+  }, [expenseTransactions, activeTab, expenseClassMap]);
 
-  // Tab counts
+  // Tab counts — aligned with filteredTransactions so the badges match the
+  // list below 1:1.
   const tabCounts: Record<TabKey, number> = useMemo(() => ({
-    all: transactions.length,
-    fixed: transactions.filter(
-      (t) =>
-        t.type === 'DEBIT' &&
-        t.categoryId &&
-        expenseClassMap.get(t.categoryId) === 'FIXED'
+    all: expenseTransactions.length,
+    fixed: expenseTransactions.filter(
+      (t) => t.categoryId && expenseClassMap.get(t.categoryId) === 'FIXED'
     ).length,
-    variable: transactions.filter(
-      (t) =>
-        t.type === 'DEBIT' &&
-        t.categoryId &&
-        expenseClassMap.get(t.categoryId) === 'VARIABLE'
+    variable: expenseTransactions.filter(
+      (t) => t.categoryId && expenseClassMap.get(t.categoryId) === 'VARIABLE'
     ).length,
-    recurring: transactions.filter((t) => t.isRecurring).length,
-  }), [transactions, expenseClassMap]);
+    recurring: expenseTransactions.filter((t) => t.isRecurring).length,
+  }), [expenseTransactions, expenseClassMap]);
 
   if (isLoading) {
     return (

--- a/apps/web/app/dashboard/transactions/page.tsx
+++ b/apps/web/app/dashboard/transactions/page.tsx
@@ -47,12 +47,12 @@ function CustomTooltip({ active, payload, label }: { active?: boolean; payload?:
 // Tab types
 // ---------------------------------------------------------------------------
 
-type TabKey = 'all' | 'expenses' | 'income' | 'recurring';
+type TabKey = 'all' | 'fixed' | 'variable' | 'recurring';
 
 const TABS: { key: TabKey; label: string }[] = [
   { key: 'all', label: 'Tutte' },
-  { key: 'expenses', label: 'Uscite' },
-  { key: 'income', label: 'Entrate' },
+  { key: 'fixed', label: 'Fisse' },
+  { key: 'variable', label: 'Variabili' },
   { key: 'recurring', label: 'Ricorrenti' },
 ];
 
@@ -176,23 +176,50 @@ export default function ExpensesPage() {
     [categorySpending]
   );
 
-  // Filter transactions by tab
+  // Filter transactions by tab — "Spese" view is expense-class oriented:
+  // Fisse / Variabili partition the DEBIT universe, with Ricorrenti as an
+  // orthogonal slice. Income transactions are not shown under these tabs;
+  // use /dashboard/transactions for full list with Entrate view.
   const filteredTransactions = useMemo(() => {
     switch (activeTab) {
-      case 'expenses': return transactions.filter(t => t.type === 'DEBIT');
-      case 'income': return transactions.filter(t => t.type === 'CREDIT');
-      case 'recurring': return transactions.filter(t => t.isRecurring);
-      default: return transactions;
+      case 'fixed':
+        return transactions.filter(
+          (t) =>
+            t.type === 'DEBIT' &&
+            t.categoryId &&
+            expenseClassMap.get(t.categoryId) === 'FIXED'
+        );
+      case 'variable':
+        return transactions.filter(
+          (t) =>
+            t.type === 'DEBIT' &&
+            t.categoryId &&
+            expenseClassMap.get(t.categoryId) === 'VARIABLE'
+        );
+      case 'recurring':
+        return transactions.filter((t) => t.isRecurring);
+      default:
+        return transactions;
     }
-  }, [transactions, activeTab]);
+  }, [transactions, activeTab, expenseClassMap]);
 
   // Tab counts
   const tabCounts: Record<TabKey, number> = useMemo(() => ({
     all: transactions.length,
-    expenses: transactions.filter(t => t.type === 'DEBIT').length,
-    income: transactions.filter(t => t.type === 'CREDIT').length,
-    recurring: transactions.filter(t => t.isRecurring).length,
-  }), [transactions]);
+    fixed: transactions.filter(
+      (t) =>
+        t.type === 'DEBIT' &&
+        t.categoryId &&
+        expenseClassMap.get(t.categoryId) === 'FIXED'
+    ).length,
+    variable: transactions.filter(
+      (t) =>
+        t.type === 'DEBIT' &&
+        t.categoryId &&
+        expenseClassMap.get(t.categoryId) === 'VARIABLE'
+    ).length,
+    recurring: transactions.filter((t) => t.isRecurring).length,
+  }), [transactions, expenseClassMap]);
 
   if (isLoading) {
     return (


### PR DESCRIPTION
## Summary

Sprint 1.7 — replaces Uscite/Entrate tabs on \`/dashboard/transactions\` with **Fisse / Variabili**, aligned with the existing "Costi Fissi" and "Costi Variabili" summary cards already driven by \`category.expense_class\`.

- TabKey: \`'all' | 'fixed' | 'variable' | 'recurring'\`
- Labels: Tutte / Fisse / Variabili / Ricorrenti
- \`filteredTransactions\` + \`tabCounts\` now use \`expenseClassMap\` predicates (DEBIT + expense_class matching)
- Summary cards unchanged (they already computed via \`expenseClassMap\`)
- Test expectations updated

## Design notes

- **Why remove Entrate**: the page is titled "Spese". Income (CREDIT) under an expense-oriented view was a taxonomy mismatch. If a combined view is needed later, it should live in a dedicated page or a secondary filter axis, not inside an expense-class tab set.
- **Drilldown pages**: \`/dashboard/transactions/[type]\` already handles \`fixed\` / \`variable\` / \`recurring\` routes (lines 122-125 of that file); summary card clicks continue to work.
- **Dependency array**: \`filteredTransactions\` and \`tabCounts\` now depend on \`expenseClassMap\` (was missing before as "expenses" filter didn't need it).

## Test plan

- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm --filter @money-wise/web test\` — existing transactions page test updated and passes (13/13)
- [ ] **Manual browser verification (human)**:
  - [ ] \`/dashboard/transactions\` shows 4 tabs: Tutte / Fisse / Variabili / Ricorrenti with correct counts
  - [ ] Clicking Fisse shows only DEBIT tx whose category is expense_class=FIXED
  - [ ] Clicking Variabili shows only DEBIT tx whose category is expense_class=VARIABLE
  - [ ] Summary card Costi Fissi click → navigates to /fixed drilldown (unchanged)

## Notes

- PR opened without \`auto-merge\` label — loop MANDATORY applica label dopo Copilot review clean
- Touches no \`supabase/migrations/**\`
- Worktree: \`~/dev/money-wise-sprint-1.7\` (manual worktree, explicit \`origin/develop\` base to avoid bootstrap-worktree.sh bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)