### PR TITLE
fix(sprint-1): post-deploy bug fixes — count:'exact' contract + banking_sync_logs export

### DIFF
--- a/apps/web/__tests__/services/categorization.client.test.ts
+++ b/apps/web/__tests__/services/categorization.client.test.ts
@@ -64,11 +64,11 @@ function updateChain(
   errorResult: { message: string } | null,
   count: number | null = 1
 ) {
+  const eq = vi.fn().mockResolvedValue({ error: errorResult, count });
   return {
-    update: vi.fn().mockReturnValue({
-      eq: vi.fn().mockResolvedValue({ error: errorResult, count }),
-    }),
+    update: vi.fn().mockReturnValue({ eq }),
     select: vi.fn(),
+    eq,
   };
 }
 
@@ -187,7 +187,7 @@ describe('categorizationClient.suggestCategory', () => {
 describe('categorizationClient.applyCategory', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('sends UPDATE with category_id and txId', async () => {
+  it('sends UPDATE with category_id and filters by txId via .eq("id", txId)', async () => {
     const chain = updateChain(null);
     mocks.fromSpy.mockReturnValueOnce(chain);
     await categorizationClient.applyCategory('tx-1', 'cat-food');
@@ -195,6 +195,9 @@ describe('categorizationClient.applyCategory', () => {
     // (checked separately — see "passes { count: 'exact' }" test).
     const callArgs = chain.update.mock.calls[0];
     expect(callArgs[0]).toEqual({ category_id: 'cat-food' });
+    // Regression guard: a refactor that drops/changes the filter would
+    // broadcast the UPDATE to every row in the user's scope.
+    expect(chain.eq).toHaveBeenCalledWith('id', 'tx-1');
   });
 
   // ⚠️ Contract test — bug observed post-deploy 2026-04-18.

--- a/apps/web/__tests__/services/categorization.client.test.ts
+++ b/apps/web/__tests__/services/categorization.client.test.ts
@@ -60,10 +60,13 @@ function categoriesChain(result: {
   };
 }
 
-function updateChain(errorResult: { message: string } | null) {
+function updateChain(
+  errorResult: { message: string } | null,
+  count: number | null = 1
+) {
   return {
     update: vi.fn().mockReturnValue({
-      eq: vi.fn().mockResolvedValue({ error: errorResult }),
+      eq: vi.fn().mockResolvedValue({ error: errorResult, count }),
     }),
     select: vi.fn(),
   };
@@ -188,7 +191,47 @@ describe('categorizationClient.applyCategory', () => {
     const chain = updateChain(null);
     mocks.fromSpy.mockReturnValueOnce(chain);
     await categorizationClient.applyCategory('tx-1', 'cat-food');
-    expect(chain.update).toHaveBeenCalledWith({ category_id: 'cat-food' });
+    // The payload is the first arg; the second arg is the count option
+    // (checked separately — see "passes { count: 'exact' }" test).
+    const callArgs = chain.update.mock.calls[0];
+    expect(callArgs[0]).toEqual({ category_id: 'cat-food' });
+  });
+
+  // ⚠️ Contract test — bug observed post-deploy 2026-04-18.
+  // Without `{ count: 'exact' }` passed to .update(), PostgREST returns
+  // `count: null` and the count === 0 branch below never fires — the UI
+  // would drop transactions as "reviewed" on no-op UPDATEs. This test
+  // pins the contract so future refactors can't silently disable the
+  // safety net.
+  it('passes { count: "exact" } as the second argument to update()', async () => {
+    const chain = updateChain(null);
+    mocks.fromSpy.mockReturnValueOnce(chain);
+    await categorizationClient.applyCategory('tx-1', 'cat-food');
+    expect(chain.update).toHaveBeenCalledWith(
+      { category_id: 'cat-food' },
+      { count: 'exact' }
+    );
+  });
+
+  // Integration test for the count-based safety net: when the driver
+  // reports zero rows affected (tx already categorized, removed, or
+  // RLS-blocked), we surface a 404 instead of silently succeeding.
+  it('throws apply_failed (404) when UPDATE affected zero rows', async () => {
+    mocks.fromSpy.mockReturnValueOnce(updateChain(null, 0));
+    await expect(
+      categorizationClient.applyCategory('tx-1', 'cat-food')
+    ).rejects.toMatchObject({
+      name: 'CategorizationApiError',
+      code: 'apply_failed',
+      statusCode: 404,
+    });
+  });
+
+  it('succeeds when UPDATE affected one row', async () => {
+    mocks.fromSpy.mockReturnValueOnce(updateChain(null, 1));
+    await expect(
+      categorizationClient.applyCategory('tx-1', 'cat-food')
+    ).resolves.toBeUndefined();
   });
 
   it('rejects empty txId / categoryId without touching DB', async () => {

--- a/apps/web/src/services/categorization.client.ts
+++ b/apps/web/src/services/categorization.client.ts
@@ -107,14 +107,14 @@ type SupabaseLike = {
     };
     update: (
       payload: Record<string, unknown>,
-      opts?: { count?: 'exact' | 'planned' | 'estimated' }
+      opts: { count: 'exact' }
     ) => {
       eq: (
         col: string,
         val: string
       ) => Promise<{
         error: { message: string } | null;
-        count?: number | null;
+        count: number | null;
       }>;
     };
   };

--- a/apps/web/src/services/categorization.client.ts
+++ b/apps/web/src/services/categorization.client.ts
@@ -105,7 +105,10 @@ type SupabaseLike = {
         error: { message: string } | null;
       }>;
     };
-    update: (payload: Record<string, unknown>) => {
+    update: (
+      payload: Record<string, unknown>,
+      opts?: { count?: 'exact' | 'planned' | 'estimated' }
+    ) => {
       eq: (
         col: string,
         val: string
@@ -270,11 +273,13 @@ export const categorizationClient = {
   /**
    * Persist a category choice on a transaction.
    *
-   * Returns the count of affected rows if the driver exposes it: 0 means
-   * the tx either no longer exists, was already categorized, or is hidden
-   * by RLS. Without this check a no-op UPDATE returns `error: null` and
-   * the UI would drop the transaction as "reviewed" even though nothing
-   * was persisted.
+   * We pass `{ count: 'exact' }` to `.update()` so PostgREST returns the
+   * number of rows actually affected. Without this option, `count` is
+   * always `null` and a no-op UPDATE (tx no longer exists, already
+   * categorized concurrently, or hidden by RLS) would pass as success —
+   * making the UI drop the transaction as "reviewed" without anything
+   * persisted. `count === 0` is therefore surfaced as a 404 so the UI
+   * can retry or refresh.
    */
   async applyCategory(txId: string, categoryId: string): Promise<void> {
     if (!txId || !categoryId) {
@@ -287,7 +292,7 @@ export const categorizationClient = {
     const supabase = createClient() as unknown as SupabaseLike;
     const { error, count } = await supabase
       .from('transactions')
-      .update({ category_id: categoryId })
+      .update({ category_id: categoryId }, { count: 'exact' })
       .eq('id', txId);
     if (error) {
       throw new CategorizationApiError(
@@ -297,9 +302,7 @@ export const categorizationClient = {
         error
       );
     }
-    // When the driver provides a row count, a 0 means the filter matched
-    // nothing — surface as a not-found so the UI can retry / refresh.
-    if (typeof count === 'number' && count === 0) {
+    if (count === 0) {
       throw new CategorizationApiError(
         'Transazione non trovata (potrebbe essere già categorizzata o rimossa)',
         404,

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "private": true,
   "workspaces": [
     "apps/*",
-    "packages/*",
-    "test-utils"
+    "packages/*"
   ],
   "overrides": {
     "ip": "npm:@webpod/ip@^0.6.1"

--- a/supabase/functions/account-delete/index.test.ts
+++ b/supabase/functions/account-delete/index.test.ts
@@ -67,18 +67,29 @@ Deno.test('parseInput: accepts valid input with exportDataFirst=false explicit',
 // Table allow-lists
 // ---------------------------------------------------------------------------
 
-Deno.test('USER_SCOPED_TABLES: covers every user-owned table from initial schema', () => {
+Deno.test('USER_SCOPED_TABLES: covers every table with a user_id FK to profiles', () => {
+  // Post-deploy fix (2026-04-18): `banking_sync_logs` is NOT in this list
+  // despite touching user activity — it has `account_id`, not `user_id`.
+  // See the accompanying comment in index.ts for the full rationale and
+  // the post-beta remediation options.
   const expected = [
     'audit_logs',
     'banking_customers',
     'banking_connections',
-    'banking_sync_logs',
     'user_preferences',
     'notifications',
     'push_subscriptions',
     'user_achievements',
   ]
   assertEquals([...USER_SCOPED_TABLES].sort(), expected.sort())
+})
+
+Deno.test('USER_SCOPED_TABLES: does NOT include banking_sync_logs (no user_id column)', () => {
+  // Regression guard: including banking_sync_logs makes the export query
+  // `.eq('user_id', userId)` fail silently, producing an incomplete
+  // JSON export for users who opt into exportDataFirst.
+  const user = new Set<string>(USER_SCOPED_TABLES)
+  assertEquals(user.has('banking_sync_logs'), false)
 })
 
 Deno.test('FAMILY_SCOPED_TABLES: covers every family-owned table from initial schema', () => {

--- a/supabase/functions/account-delete/index.ts
+++ b/supabase/functions/account-delete/index.ts
@@ -80,12 +80,22 @@ function createAdminClient() {
 // Data export
 // ---------------------------------------------------------------------------
 
-// Tables owned by the user via profiles.id
+// Tables owned by the user via profiles.id (schema invariant: they all
+// carry a `user_id UUID REFERENCES profiles(id) ON DELETE CASCADE` column).
+//
+// ⚠️ `banking_sync_logs` is NOT here despite touching user data: it has
+// `account_id` (FK to accounts) but NO `user_id` column. Including it would
+// cause the export query below to fail silently (PostgREST rejects the
+// `.eq('user_id', ...)` filter) and leave sync-log rows out of the JSON
+// export. For the common sole-member case, those rows cascade via
+// families → accounts and are still deleted server-side; for multi-member
+// families, the sync logs survive the user delete (known limitation, see
+// migration 20260417020000 header comment). Post-beta: either add user_id
+// to the table or join via accounts.family_id.
 const USER_SCOPED_TABLES = [
   'audit_logs',
   'banking_customers',
   'banking_connections',
-  'banking_sync_logs',
   'user_preferences',
   'notifications',
   'push_subscriptions',


### PR DESCRIPTION
## Summary

Three small fixes caught in the certosina review (2026-04-18) after Sprint 1 edge function + migrations landed on `develop`. The first two are the actual post-deploy bugs; the third is an infra hygiene fix that surfaced because this is the first PR to trigger the new Deno gate.

### Bug 1 — CRITICAL: `applyCategory()` missing `{ count: 'exact' }` option

**File**: `apps/web/src/services/categorization.client.ts:293-296`

`.update()` was invoked without the `{ count: 'exact' }` option, so PostgREST returned `count: null` on every call. The `count === 0` safety-net branch never fired → a transaction that was already categorized, deleted, or hidden by RLS would UPDATE nothing, the call would resolve successfully, and the UI would drop the row from the pending list as if reviewed. Silent data divergence.

**Fix**: pass `{ count: 'exact' }`, simplify the check, tighten the `SupabaseLike` type so the contract is type-enforced.

**Tests** (3 new, 17/17 pass):
- Contract test pinning `{ count: 'exact' }` arg shape — regression guard
- Integration: `count=0` → 404 `apply_failed`
- Integration: `count=1` → resolves undefined

### Bug 2 — MEDIUM: `banking_sync_logs` in user-scoped GDPR export

**File**: `supabase/functions/account-delete/index.ts:95-103`

`banking_sync_logs` was in `USER_SCOPED_TABLES` but the table has `account_id` (FK to accounts), no `user_id` column. The loop `.eq('user_id', userId)` fails silently at PostgREST → user's JSON export is missing those rows.

Server-side deletion still works for the sole-member case (families CASCADE → accounts CASCADE → banking_sync_logs). Multi-member survives the user delete — documented in migration `20260417020000` header as known post-beta limitation.

**Fix**: remove from `USER_SCOPED_TABLES` with inline comment pointing at the migration for rationale.

**Tests**: added Deno regression guard in `index.test.ts`:
```ts
Deno.test('USER_SCOPED_TABLES: does NOT include banking_sync_logs (no user_id column)', ...)
```

Edge function already redeployed via MCP (`account-delete` v2, ACTIVE).

### CI hygiene — remove phantom `test-utils` from root workspaces

**File**: `package.json:6-9`

Root `package.json` listed `"test-utils"` in `workspaces` but no such dir exists at repo root (real one lives at `packages/test-utils`). Invisible to pnpm (explicit omission in `pnpm-workspace.yaml`) but the new Deno gate from PR #442 reads the root `package.json` to resolve npm workspaces and fails: `Could not find package.json for workspace member in '…/test-utils/'`.

The gate had skipped every previous run via path filter (no `supabase/functions/**` changes in #449; #444 merged before the gate landed). This PR is the first to trigger it on touched edge-function code, exposing the inconsistency.

**Fix**: drop the phantom entry. `packages/test-utils` is already covered by `packages/*`; pnpm workspaces keep it excluded until its TS setup stabilizes.

## Test plan

- [x] `pnpm --filter @money-wise/web test __tests__/services/categorization.client.test.ts` → 17/17 pass locally
- [x] `pnpm typecheck` → clean
- [x] `pnpm lint` → clean (only pre-existing warnings)
- [x] Edge function `account-delete` redeployed (v2, ACTIVE)
- [ ] Deno gate green on re-run (third commit)
- [ ] CI green (ESLint + Deno test + typecheck + jsdom tests)
- [ ] Copilot review clean before auto-merge

## Branch policy

Paths touched: `apps/web/src/services/**`, `apps/web/__tests__/**`, `supabase/functions/account-delete/**`, `package.json`. No `supabase/migrations/**` → auto-merge workflow eligible after clean review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)