### PR TITLE
fix(bootstrap): hardening post-review — error handling + shell detection + rebuild note

### DIFF
--- a/.claude/scripts/bootstrap-dev.sh
+++ b/.claude/scripts/bootstrap-dev.sh
@@ -242,31 +242,46 @@ install_node_via_mise() {
         success "mise $(mise --version 2>/dev/null || echo installed) already present"
     fi
 
-    # 2. Persist shell activation (detect shell: bash / zsh; fish not auto-handled)
+    # 2. Persist shell activation — explicit cases for bash/zsh/fish, warn+skip for others.
+    # Writing wrong syntax to wrong rc file would silently break activation, so unknown
+    # shells get a manual-setup pointer instead of a best-guess fallback.
     local shell_name shell_rc activation_line
+    local skip_rc_write=false
     case "${SHELL:-/bin/bash}" in
         */zsh)
             shell_name="zsh"
             shell_rc="$HOME/.zshrc"
             activation_line='eval "$(mise activate zsh)"'
             ;;
-        */bash|*)
+        */bash)
             shell_name="bash"
             shell_rc="$HOME/.bashrc"
             activation_line='eval "$(mise activate bash)"'
             ;;
+        */fish)
+            shell_name="fish"
+            shell_rc="$HOME/.config/fish/config.fish"
+            activation_line='mise activate fish | source'
+            ;;
+        *)
+            warn "Unsupported shell detected (\$SHELL=${SHELL:-unknown}) — skipping rc-file activation"
+            warn "Manually add mise activation per https://mise.jdx.dev/installing-mise.html#activate-mise"
+            skip_rc_write=true
+            ;;
     esac
-    # fish users: add `mise activate fish | source` to ~/.config/fish/config.fish manually
 
-    if ! grep -qF "mise activate $shell_name" "$shell_rc" 2>/dev/null; then
-        if [[ "$DRY_RUN" == "true" ]]; then
-            info "[DRY RUN] Would append mise activation to $shell_rc"
+    if [[ "$skip_rc_write" != "true" ]]; then
+        if ! grep -qF "mise activate $shell_name" "$shell_rc" 2>/dev/null; then
+            if [[ "$DRY_RUN" == "true" ]]; then
+                info "[DRY RUN] Would append mise activation to $shell_rc"
+            else
+                mkdir -p "$(dirname "$shell_rc")"
+                echo "$activation_line" >> "$shell_rc"
+                success "Added mise activation to $shell_rc (applies to new shells)"
+            fi
         else
-            echo "$activation_line" >> "$shell_rc"
-            success "Added mise activation to $shell_rc (applies to new shells)"
+            success "mise activation already present in $shell_rc"
         fi
-    else
-        success "mise activation already present in $shell_rc"
     fi
 
     # 3. Install toolchain declared in mise.toml

--- a/.claude/scripts/bootstrap-dev.sh
+++ b/.claude/scripts/bootstrap-dev.sh
@@ -228,7 +228,11 @@ install_node_via_mise() {
                 rm -f "$_mise_installer"
                 return 1
             fi
-            sh "$_mise_installer"
+            if ! sh "$_mise_installer"; then
+                error "mise installer exited non-zero — check network, disk space, or permissions"
+                rm -f "$_mise_installer"
+                return 1
+            fi
             rm -f "$_mise_installer"
             # mise installs to ~/.local/bin by default — extend PATH for current shell
             export PATH="$HOME/.local/bin:$PATH"
@@ -238,17 +242,31 @@ install_node_via_mise() {
         success "mise $(mise --version 2>/dev/null || echo installed) already present"
     fi
 
-    # 2. Persist shell activation in ~/.bashrc (idempotent check)
-    local activation_line='eval "$(mise activate bash)"'
-    if ! grep -qF 'mise activate bash' "$HOME/.bashrc" 2>/dev/null; then
+    # 2. Persist shell activation (detect shell: bash / zsh; fish not auto-handled)
+    local shell_name shell_rc activation_line
+    case "${SHELL:-/bin/bash}" in
+        */zsh)
+            shell_name="zsh"
+            shell_rc="$HOME/.zshrc"
+            activation_line='eval "$(mise activate zsh)"'
+            ;;
+        */bash|*)
+            shell_name="bash"
+            shell_rc="$HOME/.bashrc"
+            activation_line='eval "$(mise activate bash)"'
+            ;;
+    esac
+    # fish users: add `mise activate fish | source` to ~/.config/fish/config.fish manually
+
+    if ! grep -qF "mise activate $shell_name" "$shell_rc" 2>/dev/null; then
         if [[ "$DRY_RUN" == "true" ]]; then
-            info "[DRY RUN] Would append mise activation to ~/.bashrc"
+            info "[DRY RUN] Would append mise activation to $shell_rc"
         else
-            echo "$activation_line" >> "$HOME/.bashrc"
-            success "Added mise activation to ~/.bashrc (applies to new shells)"
+            echo "$activation_line" >> "$shell_rc"
+            success "Added mise activation to $shell_rc (applies to new shells)"
         fi
     else
-        success "mise activation already present in ~/.bashrc"
+        success "mise activation already present in $shell_rc"
     fi
 
     # 3. Install toolchain declared in mise.toml
@@ -268,6 +286,8 @@ install_node_via_mise() {
     (cd "$PROJECT_ROOT" && mise install)
 
     # 4. Activate mise in current shell so subsequent steps see mise-managed bins
+    # Note: always use bash activation here because this script has #!/bin/bash shebang,
+    # regardless of the user's login shell (which governs step 2's rc-file choice).
     eval "$(mise activate bash)" 2>/dev/null || true
 
     # 5. PATH precedence: mise shims must win over apt/nvm-installed nodes.
@@ -483,6 +503,13 @@ print_summary() {
     echo "    pnpm dev:ready       # Full interactive dev setup"
     echo "    pnpm dev             # Start all dev servers"
     echo ""
+    if [[ "$RUNTIME_MANAGER" == "mise" ]] && [[ -d "$PROJECT_ROOT/node_modules" ]] && [[ "$DRY_RUN" != "true" ]]; then
+        echo -e "  ${YELLOW}Note:${NC} Node version is now managed by mise (from mise.toml)."
+        echo "  If node_modules was previously installed with a different Node major,"
+        echo "  native binaries (@parcel/watcher, @swc/core) may have ABI mismatches."
+        echo -e "  Rebuild to be safe: ${BLUE}rm -rf node_modules && pnpm install${NC}"
+        echo ""
+    fi
     if [[ "$DRY_RUN" == "true" ]]; then
         echo -e "  ${YELLOW}This was a dry run — no changes were made.${NC}"
         echo ""


### PR DESCRIPTION
## Summary

Follow-up to PR #452 addressing issues from post-merge **ultrathink review**. Scope: code hardening only (I1+I2+I3 from review), no functional change to the default env-conditional flag behavior.

### I1 — Error handling for `sh $_mise_installer`
Parallel to the `curl -fsSL … -o …` pattern that already has explicit check. Under `set -euo pipefail` the script would abort but with poor diagnostic. Now: `if ! sh …; then error "…"; return 1; fi` with actionable message.

### I2 — Shell detection (bash / zsh), fish fallback note
Previously hardcoded `~/.bashrc` + `mise activate bash`. Lucca WSL2 zsh users would silently break. Now detects via `$SHELL`, writes to the right rc file, fish users get a comment note (they need `mise activate fish | source`, incompatible with eval template).

Step 4 in-script activation stays `bash` because of `#!/bin/bash` shebang (not user shell).

### I3 — Rebuild note in `print_summary`
When switching apt/nvm → mise across Node majors, native binaries in `node_modules/` (@parcel/watcher, @swc/core) may be ABI-mismatched — breaks `pnpm dev:web` HMR but unit tests pass (jsdom doesn't exercise native). Summary now emits yellow Note recommending `rm -rf node_modules && pnpm install`.

## End-to-end validation (closes C1 from ultrathink review)

**The gap PR #452 left**: lo script post-`mise trust` fix non era mai stato runnato end-to-end in una singola passata — smoke test era frammentato (installer fails → Edit → manual trust + install, mai re-run dello script integro).

**Validation eseguita su Steam Deck** (clean slate):
```bash
rm -f ~/.local/bin/mise
rm -rf ~/.local/share/mise
sed -i '/mise activate/d' ~/.bashrc
bash .claude/scripts/bootstrap-dev.sh --runtime-manager=mise --env-only --skip-claude
```

Esito: exit 0, ogni step eseguito in sequenza:
1. ✅ mise installer via `curl https://mise.run` (I1 error path non triggered)
2. ✅ `Added mise activation to /home/deck/.bashrc` (I2 shell detection: bash)
3. ✅ `mise trust /home/deck/dev/money-wise` (gotcha #4 dalla PR parent)
4. ✅ `mise node@22.12.0` + `mise pnpm@10.24.0` installati con GPG signature verified
5. ✅ `PATH precedence OK — mise shim wins: /home/deck/.local/share/mise/installs/node/22.12.0/bin/node`
6. ✅ Print summary shows I3 rebuild note

Questo chiude il rischio "discovery-on-Lucca" identificato come C1 nella review.

## Test plan

- [ ] GitHub Actions CI green (lint + typecheck + 6 security jobs + claude-review)
- [ ] Copilot review senza nuovi blocker
- [ ] Verify on Lucca WSL2 fresh setup (deferred, Track D Sprint Infra 1.α-prep)

## Refs

- **Parent PR**: #452
- **Ultrathink review** (2026-04-19): identificato C1 (script non end-to-end testato) + I1+I2+I3
- **Memory additions**:
  - `vault/memory/feedback_mise_trust_first_run.md` — reusable beyond MoneyWise
  - `vault/memory/feedback_auto_merge_label_timing.md` — precisazione 5-min buffer post-fix
  - `vault/memory/feedback_pr_lifecycle_loop_workflow.md` — step 6 gate aggiornato
- **Session log**: `vault/daily/2026-04-19.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)