### PR TITLE
refactor(onboarding): allocation algorithm waterfall beta+gamma (closes #458)

### DIFF
--- a/apps/web/__tests__/lib/onboarding/allocation.test.ts
+++ b/apps/web/__tests__/lib/onboarding/allocation.test.ts
@@ -16,28 +16,28 @@ import type {
 
 const TODAY = new Date('2026-04-19T00:00:00.000Z');
 
+/** UTC-safe ISO date string (avoids local-timezone ±1 day drift). */
 function isoDate(date: Date): string {
-  const y = date.getFullYear();
-  const mo = String(date.getMonth() + 1).padStart(2, '0');
-  const d = String(date.getDate()).padStart(2, '0');
-  return `${y}-${mo}-${d}`;
+  return date.toISOString().slice(0, 10);
 }
 
 function monthsFromToday(n: number): string {
   const d = new Date(TODAY);
-  d.setMonth(d.getMonth() + n);
+  d.setUTCMonth(d.getUTCMonth() + n);
   return isoDate(d);
 }
 
 function daysFromToday(n: number): string {
   const d = new Date(TODAY);
-  d.setDate(d.getDate() + n);
+  d.setUTCDate(d.getUTCDate() + n);
   return isoDate(d);
 }
 
+/** Deterministic ID counter — avoids Math.random() nondeterminism in the suite. */
+let _goalIdCounter = 0;
 function makeGoal(partial: Partial<AllocationGoalInput>): AllocationGoalInput {
   return {
-    id: partial.id ?? `goal-${Math.random().toString(36).slice(2, 8)}`,
+    id: partial.id ?? `goal-${++_goalIdCounter}`,
     name: partial.name ?? 'Generic Goal',
     target: partial.target ?? 1000,
     current: partial.current ?? 0,
@@ -62,7 +62,11 @@ function sumAllocated(result: AllocationResult): number {
 const EPS = 0.02;
 
 describe('computeAllocation -- beta+gamma waterfall (issue #458)', () => {
-  beforeEach(() => { vi.useFakeTimers(); vi.setSystemTime(TODAY); });
+  beforeEach(() => {
+    _goalIdCounter = 0;
+    vi.useFakeTimers();
+    vi.setSystemTime(TODAY);
+  });
   afterEach(() => { vi.useRealTimers(); });
 
   it('single ALTA goal with deadline 24mo consumes entire pool', () => {
@@ -110,7 +114,7 @@ describe('computeAllocation -- beta+gamma waterfall (issue #458)', () => {
     const media = result.items.find((it) => it.goalId === 'g-media');
     expect(alta!.monthlyAmount).toBeCloseTo(500, 2);
     expect(alta!.deadlineFeasible).toBe(false);
-    expect(alta!.warnings.some((w) => /insufficienti|savings|necessari/i.test(w))).toBe(true);
+    expect(alta!.warnings.some((w) => /insufficiente|necessari|budget/i.test(w))).toBe(true);
     expect(media!.monthlyAmount).toBeCloseTo(0, 2);
     expect(media!.deadlineFeasible).toBe(false);
     expect(media!.warnings.length).toBeGreaterThan(0);
@@ -148,7 +152,7 @@ describe('computeAllocation -- beta+gamma waterfall (issue #458)', () => {
     expect(emerg!.monthlyAmount).toBeCloseTo(140, 2);
     expect(debt!.monthlyAmount).toBeCloseTo(210, 2);
     expect(debt!.deadlineFeasible).toBe(false);
-    expect(debt!.warnings.some((w) => /insufficienti|savings|necessari/i.test(w))).toBe(true);
+    expect(debt!.warnings.some((w) => /insufficiente|necessari|budget/i.test(w))).toBe(true);
     expect(result.warnings.some((w) => /waterfall puro|senza protezione/i.test(w))).toBe(true);
     expect(result.totalAllocated).toBeCloseTo(350, 2);
     expect(result.unallocated).toBeCloseTo(0, 2);
@@ -247,7 +251,7 @@ describe('computeAllocation -- beta+gamma waterfall (issue #458)', () => {
     });
     const result = computeAllocation(input);
     expect(result.incomeAfterEssentials).toBeCloseTo(400, 2);
-    expect(result.warnings.some((w) => /target|reddito|risparmio|superato|essenziali|essentials/i.test(w))).toBe(true);
+    expect(result.warnings.some((w) => /target|reddito|risparmio|superato|essenziali|essentials|supera/i.test(w))).toBe(true);
     expect(result.totalAllocated).toBeLessThanOrEqual(400 + EPS);
   });
 
@@ -346,7 +350,7 @@ describe('computeAllocation -- beta+gamma waterfall (issue #458)', () => {
     expect(alta!.deadlineFeasible).toBe(true);
     expect(media!.monthlyAmount).toBeCloseTo(0, 2);
     expect(media!.deadlineFeasible).toBe(true);
-    expect(media!.warnings.some((w) => /esaurit|allocazione|savings/i.test(w))).toBe(true);
+    expect(media!.warnings.some((w) => /esaurit|allocazione|budget/i.test(w))).toBe(true);
   });
 
   it('priority=1 goal with deadline > 12mo and no emergency name: NOT treated as emergency', () => {

--- a/apps/web/__tests__/lib/onboarding/allocation.test.ts
+++ b/apps/web/__tests__/lib/onboarding/allocation.test.ts
@@ -1,24 +1,8 @@
 /**
- * Sprint 1.5 — Onboarding Piano Generato / Stream C (test-specialist)
+ * Sprint 1.5.1 - Issue #458: beta+gamma waterfall algorithm
  *
- * TDD test suite for the allocation algorithm owned by Stream B
- * (`apps/web/src/lib/onboarding/allocation.ts`). Written AGAINST the
- * type contract at `apps/web/src/types/onboarding-plan.ts`.
- *
- * Coverage matrix (≥6 mandatory edge cases + 2 bonus):
- *   1. Happy path — 3 goals varied priority, savings 500, income 2500.
- *   2. target=0 skip — goal with target 0 → monthlyAmount 0 + reasoning hint.
- *   3. Deadline passed — deadline < today → deadlineFeasible false + warning.
- *   4. Priority duplicate order preserved — stable sort vs input order.
- *   5. Emergency fund override — priority 1 "Fondo Emergenza" gets ≥40%.
- *   6. Deadline <12mo urgency boost — closer deadline wins more monthly.
- *   7. (Bonus) savings target > income_after_essentials → global warning.
- *   8. (Bonus) empty goals array → items [] + unallocated full + warning.
- *
- * NOTE: If Stream B has not yet committed
- * `apps/web/src/lib/onboarding/allocation.ts`, this suite pre-fails at
- * import resolution. That is the expected TDD handshake and resolves
- * once Stream B merges.
+ * Full rewrite. Previous proportional-distribution tests INTENTIONALLY deleted.
+ * Test count: 21 cases.
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -30,35 +14,30 @@ import type {
   PriorityRank,
 } from '@/types/onboarding-plan';
 
-// ─────────────────────────────────────────────────────────────────────────
-// Test fixtures / helpers
-// ─────────────────────────────────────────────────────────────────────────
+const TODAY = new Date('2026-04-19T00:00:00.000Z');
 
-/** Deterministic "today" reference to build deadline fixtures around. */
-const TODAY = new Date('2026-04-19T00:00:00Z');
-
-/** Format a Date as ISO date-only string (YYYY-MM-DD), as stored in DB. */
 function isoDate(date: Date): string {
-  return date.toISOString().slice(0, 10);
+  const y = date.getFullYear();
+  const mo = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${mo}-${d}`;
 }
 
-/** Offset "today" by N months (UTC). */
 function monthsFromToday(n: number): string {
   const d = new Date(TODAY);
-  d.setUTCMonth(d.getUTCMonth() + n);
+  d.setMonth(d.getMonth() + n);
   return isoDate(d);
 }
 
-/** Offset "today" by N days (UTC). */
 function daysFromToday(n: number): string {
   const d = new Date(TODAY);
-  d.setUTCDate(d.getUTCDate() + n);
+  d.setDate(d.getDate() + n);
   return isoDate(d);
 }
 
 function makeGoal(partial: Partial<AllocationGoalInput>): AllocationGoalInput {
   return {
-    id: partial.id ?? `goal-${Math.random().toString(36).slice(2, 10)}`,
+    id: partial.id ?? `goal-${Math.random().toString(36).slice(2, 8)}`,
     name: partial.name ?? 'Generic Goal',
     target: partial.target ?? 1000,
     current: partial.current ?? 0,
@@ -73,368 +52,314 @@ function makeInput(partial: Partial<AllocationInput>): AllocationInput {
     monthlySavingsTarget: partial.monthlySavingsTarget ?? 500,
     essentialsPct: partial.essentialsPct ?? 50,
     goals: partial.goals ?? [],
-    emergencyFundMonths: partial.emergencyFundMonths,
   };
 }
 
-/** Sum of per-goal monthlyAmount. */
 function sumAllocated(result: AllocationResult): number {
-  return result.items.reduce((acc, it) => acc + it.monthlyAmount, 0);
+  return Math.round(result.items.reduce((acc, it) => acc + it.monthlyAmount, 0) * 100) / 100;
 }
 
-// Floating-point-safe comparison tolerance for currency sums.
-const EPS = 0.01;
+const EPS = 0.02;
 
-// ─────────────────────────────────────────────────────────────────────────
-// Test suite
-// ─────────────────────────────────────────────────────────────────────────
+describe('computeAllocation -- beta+gamma waterfall (issue #458)', () => {
+  beforeEach(() => { vi.useFakeTimers(); vi.setSystemTime(TODAY); });
+  afterEach(() => { vi.useRealTimers(); });
 
-describe('computeAllocation (Stream B algorithm contract)', () => {
-  // Freeze system time to TODAY so deadline/urgency calculations in the
-  // algorithm (which internally uses `new Date()`) are deterministic across
-  // CI runs and local execution. Addresses Copilot review on PR #455.
-  beforeEach(() => {
-    vi.useFakeTimers();
-    vi.setSystemTime(TODAY);
+  it('single ALTA goal with deadline 24mo consumes entire pool', () => {
+    const input = makeInput({
+      monthlyIncome: 2000, essentialsPct: 50, monthlySavingsTarget: 500,
+      goals: [makeGoal({ id: 'g-alta', name: 'Acconto Casa', target: 12000, current: 0, deadline: monthsFromToday(24), priority: 1 })],
+    });
+    const result = computeAllocation(input);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].goalId).toBe('g-alta');
+    expect(result.items[0].monthlyAmount).toBeCloseTo(500, 2);
+    expect(result.items[0].deadlineFeasible).toBe(true);
+    expect(result.totalAllocated).toBeCloseTo(500, 2);
+    expect(result.unallocated).toBeCloseTo(0, 2);
   });
 
-  afterEach(() => {
-    vi.useRealTimers();
+  it('2 goals ALTA+MEDIA sufficient budget -- both fully funded', () => {
+    const input = makeInput({
+      monthlyIncome: 2500, essentialsPct: 50, monthlySavingsTarget: 500,
+      goals: [
+        makeGoal({ id: 'g-alta', name: 'Risparmio Alta', target: 4800, current: 0, deadline: monthsFromToday(24), priority: 1 }),
+        makeGoal({ id: 'g-media', name: 'Risparmio Media', target: 3000, current: 0, deadline: monthsFromToday(20), priority: 2 }),
+      ],
+    });
+    const result = computeAllocation(input);
+    const alta = result.items.find((it) => it.goalId === 'g-alta');
+    const media = result.items.find((it) => it.goalId === 'g-media');
+    expect(alta!.monthlyAmount).toBeCloseTo(200, 2);
+    expect(alta!.deadlineFeasible).toBe(true);
+    expect(media!.monthlyAmount).toBeCloseTo(150, 2);
+    expect(media!.deadlineFeasible).toBe(true);
+    expect(result.totalAllocated).toBeLessThanOrEqual(500 + EPS);
   });
 
-
-  // ───────────────────────────────────────────────────────────────────────
-  // 1. Happy path
-  // ───────────────────────────────────────────────────────────────────────
-  describe('happy path', () => {
-    it('distributes savings target across 3 varied-priority goals', () => {
-      const input = makeInput({
-        monthlyIncome: 2500,
-        monthlySavingsTarget: 500,
-        essentialsPct: 50,
-        goals: [
-          makeGoal({
-            id: 'g-high',
-            name: 'Acconto Casa',
-            target: 20000,
-            priority: 1,
-            deadline: monthsFromToday(36),
-          }),
-          makeGoal({
-            id: 'g-mid',
-            name: 'Auto',
-            target: 8000,
-            priority: 2,
-            deadline: monthsFromToday(24),
-          }),
-          makeGoal({
-            id: 'g-low',
-            name: 'Viaggio',
-            target: 2000,
-            priority: 3,
-            deadline: monthsFromToday(18),
-          }),
-        ],
-      });
-
-      const result = computeAllocation(input);
-
-      expect(result.items).toHaveLength(3);
-      // income 2500 × 50% essentials = 1250 available → 500 savings target fits.
-      expect(result.incomeAfterEssentials).toBeCloseTo(1250, 2);
-      // totalAllocated must not exceed the requested savings target.
-      expect(result.totalAllocated).toBeLessThanOrEqual(500 + EPS);
-      // Sum consistency with items.
-      expect(sumAllocated(result)).toBeCloseTo(result.totalAllocated, 2);
-      // unallocated = savingsTarget - totalAllocated (non-negative).
-      expect(result.unallocated).toBeGreaterThanOrEqual(0);
-      expect(result.unallocated).toBeCloseTo(500 - result.totalAllocated, 2);
-      // Every goal must receive positive allocation in happy path.
-      for (const item of result.items) {
-        expect(item.monthlyAmount).toBeGreaterThan(0);
-        expect(typeof item.reasoning).toBe('string');
-        expect(item.reasoning.length).toBeGreaterThan(0);
-        expect(Array.isArray(item.warnings)).toBe(true);
-      }
-      // No global warning under these nominal conditions.
-      expect(Array.isArray(result.warnings)).toBe(true);
+  it('2 goals insufficient pool -- ALTA partial, MEDIA 0 + warning', () => {
+    const input = makeInput({
+      monthlyIncome: 2500, essentialsPct: 50, monthlySavingsTarget: 500,
+      goals: [
+        makeGoal({ id: 'g-alta', name: 'Investimento casa', target: 18000, current: 0, deadline: monthsFromToday(30), priority: 1 }),
+        makeGoal({ id: 'g-media', name: 'Vacanza MEDIA', target: 6000, current: 0, deadline: monthsFromToday(30), priority: 2 }),
+      ],
     });
+    const result = computeAllocation(input);
+    const alta = result.items.find((it) => it.goalId === 'g-alta');
+    const media = result.items.find((it) => it.goalId === 'g-media');
+    expect(alta!.monthlyAmount).toBeCloseTo(500, 2);
+    expect(alta!.deadlineFeasible).toBe(false);
+    expect(alta!.warnings.some((w) => /insufficienti|savings|necessari/i.test(w))).toBe(true);
+    expect(media!.monthlyAmount).toBeCloseTo(0, 2);
+    expect(media!.deadlineFeasible).toBe(false);
+    expect(media!.warnings.length).toBeGreaterThan(0);
   });
 
-  // ───────────────────────────────────────────────────────────────────────
-  // 2. target=0 skip
-  // ───────────────────────────────────────────────────────────────────────
-  describe('target=0 skip', () => {
-    it('allocates 0 to a goal with target=0 and adds reasoning', () => {
-      const input = makeInput({
-        monthlySavingsTarget: 300,
-        goals: [
-          makeGoal({
-            id: 'g-zero',
-            name: 'Placeholder',
-            target: 0,
-            priority: 2,
-          }),
-        ],
-      });
-
-      const result = computeAllocation(input);
-      expect(result.items).toHaveLength(1);
-      const [item] = result.items;
-      expect(item.goalId).toBe('g-zero');
-      expect(item.monthlyAmount).toBe(0);
-      // Reasoning must explicitly flag missing target.
-      expect(item.reasoning.toLowerCase()).toMatch(
-        /target|nessun.*importo|non specificato|obiettivo vuoto/,
-      );
-      // Because nothing was allocated, unallocated must equal savings target.
-      expect(result.unallocated).toBeCloseTo(300, 2);
-      expect(result.totalAllocated).toBeCloseTo(0, 2);
+  it('3 goals ALTA+ALTA+MEDIA -- items in INPUT order', () => {
+    const input = makeInput({
+      monthlyIncome: 2500, essentialsPct: 50, monthlySavingsTarget: 300,
+      goals: [
+        makeGoal({ id: 'g-a1', name: 'Goal A ALTA', target: 4500, current: 0, deadline: monthsFromToday(30), priority: 1 }),
+        makeGoal({ id: 'g-a2', name: 'Goal B ALTA', target: 4500, current: 0, deadline: monthsFromToday(30), priority: 1 }),
+        makeGoal({ id: 'g-media', name: 'Goal C MEDIA', target: 6000, current: 0, deadline: monthsFromToday(30), priority: 2 }),
+      ],
     });
+    const result = computeAllocation(input);
+    expect(result.items[0].goalId).toBe('g-a1');
+    expect(result.items[1].goalId).toBe('g-a2');
+    expect(result.items[2].goalId).toBe('g-media');
+    expect(result.items[0].monthlyAmount).toBeCloseTo(150, 2);
+    expect(result.items[1].monthlyAmount).toBeCloseTo(150, 2);
+    expect(result.items[2].monthlyAmount).toBeCloseTo(0, 2);
   });
 
-  // ───────────────────────────────────────────────────────────────────────
-  // 3. Deadline passed flag
-  // ───────────────────────────────────────────────────────────────────────
-  describe('deadline passed', () => {
-    it('marks deadlineFeasible=false and adds warning when deadline < today', () => {
-      const input = makeInput({
-        monthlySavingsTarget: 400,
-        goals: [
-          makeGoal({
-            id: 'g-past',
-            name: 'Obiettivo Scaduto',
-            target: 1000,
-            priority: 2,
-            // 30 days in the past.
-            deadline: daysFromToday(-30),
-          }),
-        ],
-      });
-
-      const result = computeAllocation(input);
-      expect(result.items).toHaveLength(1);
-      const [item] = result.items;
-      expect(item.deadlineFeasible).toBe(false);
-      // At least one warning must mention the deadline.
-      expect(item.warnings.length).toBeGreaterThan(0);
-      expect(
-        item.warnings.some((w) =>
-          /deadline|scadenz|scadut|trascors|passat|passed/i.test(w),
-        ),
-      ).toBe(true);
+  it('350e pool: emerg floor 140 + debt 210 + gamma warning (issue #458 scenario)', () => {
+    const input = makeInput({
+      monthlyIncome: 3000, essentialsPct: 50, monthlySavingsTarget: 350,
+      goals: [
+        makeGoal({ id: 'g-debt', name: 'Estinzione debito', target: 7000, current: 0, deadline: monthsFromToday(20), priority: 1 }),
+        makeGoal({ id: 'g-emerg', name: 'Fondo Emergenza', target: 1000, current: 0, deadline: null, priority: 2 }),
+      ],
     });
+    const result = computeAllocation(input);
+    const debt = result.items.find((it) => it.goalId === 'g-debt');
+    const emerg = result.items.find((it) => it.goalId === 'g-emerg');
+    expect(emerg!.monthlyAmount).toBeCloseTo(140, 2);
+    expect(debt!.monthlyAmount).toBeCloseTo(210, 2);
+    expect(debt!.deadlineFeasible).toBe(false);
+    expect(debt!.warnings.some((w) => /insufficienti|savings|necessari/i.test(w))).toBe(true);
+    expect(result.warnings.some((w) => /waterfall puro|senza protezione/i.test(w))).toBe(true);
+    expect(result.totalAllocated).toBeCloseTo(350, 2);
+    expect(result.unallocated).toBeCloseTo(0, 2);
   });
 
-  // ───────────────────────────────────────────────────────────────────────
-  // 4. Priority duplicate — stable order preserved
-  // ───────────────────────────────────────────────────────────────────────
-  describe('priority duplicate stable order', () => {
-    it('preserves input order when two goals share the same priority', () => {
-      const input = makeInput({
-        monthlySavingsTarget: 200,
-        goals: [
-          makeGoal({
-            id: 'g-first',
-            name: 'Primo',
-            target: 1000,
-            priority: 2,
-            deadline: monthsFromToday(12),
-          }),
-          makeGoal({
-            id: 'g-second',
-            name: 'Secondo',
-            target: 1000,
-            priority: 2,
-            deadline: monthsFromToday(12),
-          }),
-        ],
-      });
-
-      const result = computeAllocation(input);
-      expect(result.items).toHaveLength(2);
-      // Stable sort: identical priority + deadline + target → input order wins.
-      expect(result.items[0].goalId).toBe('g-first');
-      expect(result.items[1].goalId).toBe('g-second');
+  it('"Fondo Emergenza" priority BASSA still gets emergency floor (name trumps priority)', () => {
+    const pool = 500;
+    const input = makeInput({
+      monthlyIncome: 2500, essentialsPct: 50, monthlySavingsTarget: pool,
+      goals: [
+        makeGoal({ id: 'g-alta', name: 'Casa', target: 15000, current: 0, deadline: monthsFromToday(30), priority: 1 }),
+        makeGoal({ id: 'g-emerg', name: 'Fondo Emergenza', target: 3000, current: 0, deadline: null, priority: 3 }),
+      ],
     });
+    const result = computeAllocation(input);
+    expect(result.items.find((it) => it.goalId === 'g-emerg')!.monthlyAmount).toBeGreaterThanOrEqual(pool * 0.4 - EPS);
   });
 
-  // ───────────────────────────────────────────────────────────────────────
-  // 5. Emergency fund override (priority 1 + name "Fondo Emergenza")
-  // ───────────────────────────────────────────────────────────────────────
-  describe('emergency fund override', () => {
-    it('allocates ≥40% of savings target to "Fondo Emergenza" priority 1', () => {
-      const savings = 500;
-      const input = makeInput({
-        monthlyIncome: 3000,
-        monthlySavingsTarget: savings,
-        essentialsPct: 50,
-        goals: [
-          makeGoal({
-            id: 'g-emergency',
-            name: 'Fondo Emergenza',
-            target: 15000,
-            priority: 1,
-            deadline: monthsFromToday(36),
-          }),
-          makeGoal({
-            id: 'g-vacation',
-            name: 'Vacanza',
-            target: 2000,
-            priority: 3,
-            deadline: monthsFromToday(18),
-          }),
-        ],
-      });
-
-      const result = computeAllocation(input);
-      expect(result.items).toHaveLength(2);
-      const emergency = result.items.find((it) => it.goalId === 'g-emergency');
-      const vacation = result.items.find((it) => it.goalId === 'g-vacation');
-      expect(emergency).toBeDefined();
-      expect(vacation).toBeDefined();
-
-      // Emergency gets at least 40% of the savings target.
-      expect(emergency!.monthlyAmount / savings).toBeGreaterThanOrEqual(0.4);
-      // And must be strictly greater than the low-priority vacation goal.
-      expect(emergency!.monthlyAmount).toBeGreaterThan(vacation!.monthlyAmount);
-    });
+  it('empty goals -> items=[], full unallocated, warning', () => {
+    const result = computeAllocation(makeInput({ monthlySavingsTarget: 250, goals: [] }));
+    expect(result.items).toEqual([]);
+    expect(result.totalAllocated).toBeCloseTo(0, 2);
+    expect(result.unallocated).toBeCloseTo(250, 2);
+    expect(result.warnings.some((w) => /nessun.*obiettivo|no goals|vuot/i.test(w))).toBe(true);
   });
 
-  // ───────────────────────────────────────────────────────────────────────
-  // 6. Deadline <12mo urgency boost
-  // ───────────────────────────────────────────────────────────────────────
-  describe('deadline urgency boost', () => {
-    it('allocates more monthly to a closer-deadline twin of the same goal', () => {
-      const input = makeInput({
-        monthlyIncome: 2500,
-        monthlySavingsTarget: 400,
-        essentialsPct: 50,
-        goals: [
-          makeGoal({
-            id: 'g-soon',
-            name: 'Viaggio Breve',
-            target: 1500,
-            priority: 2,
-            deadline: monthsFromToday(6), // <12mo → urgency boost expected
-          }),
-          makeGoal({
-            id: 'g-later',
-            name: 'Viaggio Breve',
-            target: 1500,
-            priority: 2,
-            deadline: monthsFromToday(36), // 3 years away → no boost
-          }),
-        ],
-      });
-
-      const result = computeAllocation(input);
-      const soon = result.items.find((it) => it.goalId === 'g-soon');
-      const later = result.items.find((it) => it.goalId === 'g-later');
-      expect(soon).toBeDefined();
-      expect(later).toBeDefined();
-      // The urgent one must win strictly more monthly allocation.
-      expect(soon!.monthlyAmount).toBeGreaterThan(later!.monthlyAmount);
+  it('goal with target=0 -> monthlyAmount=0, deadlineFeasible=true', () => {
+    const input = makeInput({
+      monthlySavingsTarget: 300,
+      goals: [makeGoal({ id: 'g-zero', name: 'Placeholder', target: 0, priority: 2 })],
     });
+    const result = computeAllocation(input);
+    expect(result.items[0].monthlyAmount).toBe(0);
+    expect(result.items[0].deadlineFeasible).toBe(true);
+    expect(result.items[0].reasoning.toLowerCase()).toMatch(/target|non specificato/);
   });
 
-  // ───────────────────────────────────────────────────────────────────────
-  // 7. (Bonus) savings target > income_after_essentials → global warning
-  // ───────────────────────────────────────────────────────────────────────
-  describe('savings target exceeds income after essentials', () => {
-    it('surfaces a global warning when savings target > income_after_essentials', () => {
-      // income 2000, essentials 80% → 400 available → target 800 impossible.
-      const input = makeInput({
-        monthlyIncome: 2000,
-        essentialsPct: 80,
-        monthlySavingsTarget: 800,
-        goals: [
-          makeGoal({
-            id: 'g-any',
-            name: 'Qualsiasi',
-            target: 1000,
-            priority: 2,
-            deadline: monthsFromToday(12),
-          }),
-        ],
-      });
-
-      const result = computeAllocation(input);
-      expect(result.incomeAfterEssentials).toBeCloseTo(400, 2);
-      expect(result.warnings.length).toBeGreaterThan(0);
-      expect(
-        result.warnings.some((w) =>
-          /savings|obiettivo di risparmio|eccede|exceed|reddito|income/i.test(
-            w,
-          ),
-        ),
-      ).toBe(true);
-      // totalAllocated cannot exceed incomeAfterEssentials.
-      expect(result.totalAllocated).toBeLessThanOrEqual(400 + EPS);
+  it('past deadline -> deadlineFeasible=false + deadline warning', () => {
+    const input = makeInput({
+      monthlySavingsTarget: 400,
+      goals: [makeGoal({ id: 'g-past', name: 'Scaduto', target: 1000, current: 0, deadline: daysFromToday(-30), priority: 2 })],
     });
+    const result = computeAllocation(input);
+    expect(result.items[0].deadlineFeasible).toBe(false);
+    expect(result.items[0].warnings.some((w) => /scadenz|trascors|passat|superata/i.test(w))).toBe(true);
   });
 
-  // ───────────────────────────────────────────────────────────────────────
-  // 8. (Bonus) empty goals array
-  // ───────────────────────────────────────────────────────────────────────
-  describe('empty goals array', () => {
-    it('returns items=[], full unallocated, and a "no goals" warning', () => {
-      const input = makeInput({
-        monthlySavingsTarget: 250,
-        goals: [],
-      });
-
-      const result = computeAllocation(input);
-      expect(result.items).toEqual([]);
-      expect(result.totalAllocated).toBeCloseTo(0, 2);
-      expect(result.unallocated).toBeCloseTo(250, 2);
-      expect(result.warnings.length).toBeGreaterThan(0);
-      expect(
-        result.warnings.some((w) =>
-          /nessun.*obiettivo|no goals|empty|vuot/i.test(w),
-        ),
-      ).toBe(true);
+  it('all BASSA goals -> waterfall sequential by input order', () => {
+    const input = makeInput({
+      monthlyIncome: 2000, essentialsPct: 50, monthlySavingsTarget: 300,
+      goals: [
+        makeGoal({ id: 'b1', name: 'Bassa 1', target: 1000, current: 0, deadline: monthsFromToday(10), priority: 3 }),
+        makeGoal({ id: 'b2', name: 'Bassa 2', target: 1000, current: 0, deadline: monthsFromToday(10), priority: 3 }),
+        makeGoal({ id: 'b3', name: 'Bassa 3', target: 2000, current: 0, deadline: monthsFromToday(10), priority: 3 }),
+      ],
     });
+    const result = computeAllocation(input);
+    expect(result.items[0].goalId).toBe('b1');
+    expect(result.items[1].goalId).toBe('b2');
+    expect(result.items[2].goalId).toBe('b3');
+    expect(result.items[0].monthlyAmount).toBeCloseTo(100, 2);
+    expect(result.items[1].monthlyAmount).toBeCloseTo(100, 2);
+    expect(result.items[2].monthlyAmount).toBeCloseTo(100, 2);
   });
 
-  // ───────────────────────────────────────────────────────────────────────
-  // Aggregate invariants (cross-cutting sanity)
-  // ───────────────────────────────────────────────────────────────────────
-  describe('aggregate invariants', () => {
-    it('never allocates more than min(savingsTarget, incomeAfterEssentials)', () => {
-      const input = makeInput({
-        monthlyIncome: 2500,
-        monthlySavingsTarget: 500,
-        essentialsPct: 50,
-        goals: [
-          makeGoal({ id: 'a', target: 1000, priority: 1 }),
-          makeGoal({ id: 'b', target: 1000, priority: 2 }),
-          makeGoal({ id: 'c', target: 1000, priority: 3 }),
-        ],
-      });
-      const result = computeAllocation(input);
-      const cap = Math.min(500, result.incomeAfterEssentials);
-      expect(result.totalAllocated).toBeLessThanOrEqual(cap + EPS);
-      expect(sumAllocated(result)).toBeCloseTo(result.totalAllocated, 2);
+  it('gamma warning NOT emitted when emergency floor impact < 5%', () => {
+    const input = makeInput({
+      monthlyIncome: 4000, essentialsPct: 50, monthlySavingsTarget: 1000,
+      goals: [
+        makeGoal({ id: 'g-alta', name: 'Investimento', target: 19200, current: 0, deadline: monthsFromToday(20), priority: 1 }),
+        makeGoal({ id: 'g-emerg', name: 'Fondo Emergenza', target: 40, current: 0, deadline: null, priority: 2 }),
+      ],
     });
+    const result = computeAllocation(input);
+    expect(result.items.find((it) => it.goalId === 'g-emerg')!.monthlyAmount).toBeCloseTo(40, 2);
+    expect(result.warnings.some((w) => /waterfall puro|senza protezione/i.test(w))).toBe(false);
+  });
 
-    it('returns one item per input goal (no duplicates, no drops)', () => {
-      const ids = ['p', 'q', 'r', 's'];
-      const input = makeInput({
-        monthlySavingsTarget: 400,
-        goals: ids.map((id, idx) =>
-          makeGoal({
-            id,
-            target: 500 + idx * 100,
-            priority: ((idx % 3) + 1) as PriorityRank,
-            deadline: monthsFromToday(12 + idx),
-          }),
-        ),
-      });
-      const result = computeAllocation(input);
-      expect(result.items.map((it) => it.goalId).sort()).toEqual(
-        [...ids].sort(),
-      );
+  it('gamma warning emitted when emergency floor impact >= 5%', () => {
+    const input = makeInput({
+      monthlyIncome: 4000, essentialsPct: 50, monthlySavingsTarget: 1000,
+      goals: [
+        makeGoal({ id: 'g-alta', name: 'Investimento', target: 50000, current: 0, deadline: monthsFromToday(50), priority: 1 }),
+        makeGoal({ id: 'g-emerg', name: 'Fondo Emergenza', target: 60, current: 0, deadline: null, priority: 2 }),
+      ],
     });
+    const result = computeAllocation(input);
+    expect(result.items.find((it) => it.goalId === 'g-alta')!.monthlyAmount).toBeCloseTo(940, 2);
+    expect(result.warnings.some((w) => /waterfall puro|senza protezione/i.test(w))).toBe(true);
+  });
+
+  it('savings target > income after essentials -> global warning, pool capped', () => {
+    const input = makeInput({
+      monthlyIncome: 2000, essentialsPct: 80, monthlySavingsTarget: 800,
+      goals: [makeGoal({ id: 'g', name: 'Qualsiasi', target: 1000, priority: 2, deadline: monthsFromToday(20) })],
+    });
+    const result = computeAllocation(input);
+    expect(result.incomeAfterEssentials).toBeCloseTo(400, 2);
+    expect(result.warnings.some((w) => /target|reddito|risparmio|superato|essenziali|essentials/i.test(w))).toBe(true);
+    expect(result.totalAllocated).toBeLessThanOrEqual(400 + EPS);
+  });
+
+  it('totalAllocated always equals sum of items monthlyAmount', () => {
+    const input = makeInput({
+      monthlyIncome: 2500, essentialsPct: 50, monthlySavingsTarget: 500,
+      goals: [
+        makeGoal({ id: 'a', name: 'A', target: 1000, priority: 1, deadline: monthsFromToday(20) }),
+        makeGoal({ id: 'b', name: 'Fondo Emergenza', target: 5000, priority: 2, deadline: null }),
+        makeGoal({ id: 'c', name: 'C', target: 2000, priority: 3, deadline: monthsFromToday(20) }),
+      ],
+    });
+    const result = computeAllocation(input);
+    expect(sumAllocated(result)).toBeCloseTo(result.totalAllocated, 2);
+    expect(result.totalAllocated + result.unallocated).toBeCloseTo(500, 2);
+  });
+
+  it('returns exactly one item per input goal', () => {
+    const ids = ['p', 'q', 'r', 's'];
+    const input = makeInput({
+      monthlySavingsTarget: 400,
+      goals: ids.map((id, idx) =>
+        makeGoal({ id, name: `Goal ${id}`, target: 500 + idx * 100, priority: ((idx % 3) + 1) as PriorityRank, deadline: monthsFromToday(20 + idx) }),
+      ),
+    });
+    const result = computeAllocation(input);
+    expect(result.items.map((it) => it.goalId).sort()).toEqual([...ids].sort());
+  });
+
+  it('never over-allocates beyond savings pool cap', () => {
+    const input = makeInput({
+      monthlyIncome: 2500, monthlySavingsTarget: 500, essentialsPct: 50,
+      goals: [
+        makeGoal({ id: 'a', name: 'A', target: 10000, priority: 1, deadline: monthsFromToday(20) }),
+        makeGoal({ id: 'b', name: 'B', target: 10000, priority: 2, deadline: monthsFromToday(20) }),
+        makeGoal({ id: 'c', name: 'C', target: 10000, priority: 3, deadline: monthsFromToday(20) }),
+      ],
+    });
+    const result = computeAllocation(input);
+    expect(result.totalAllocated).toBeLessThanOrEqual(Math.min(500, result.incomeAfterEssentials) + EPS);
+  });
+
+  it('emergency alone receives min(pool*0.4, need), rest unallocated', () => {
+    const input = makeInput({
+      monthlyIncome: 2500, essentialsPct: 50, monthlySavingsTarget: 500,
+      goals: [makeGoal({ id: 'g-emerg', name: 'Fondo Emergenza', target: 100, current: 0, deadline: null, priority: 2 })],
+    });
+    const result = computeAllocation(input);
+    expect(result.items[0].monthlyAmount).toBeCloseTo(100, 2);
+    expect(result.unallocated).toBeCloseTo(400, 2);
+  });
+
+  it('emergency fully funded -> floor=0, all pool to waterfall', () => {
+    const input = makeInput({
+      monthlyIncome: 2500, essentialsPct: 50, monthlySavingsTarget: 500,
+      goals: [
+        makeGoal({ id: 'g-emerg', name: 'Fondo Emergenza', target: 1000, current: 1000, deadline: null, priority: 2 }),
+        makeGoal({ id: 'g-alta', name: 'Investimento', target: 10000, current: 0, deadline: monthsFromToday(20), priority: 1 }),
+      ],
+    });
+    const result = computeAllocation(input);
+    expect(result.items.find((it) => it.goalId === 'g-emerg')!.monthlyAmount).toBeCloseTo(0, 2);
+    expect(result.items.find((it) => it.goalId === 'g-alta')!.monthlyAmount).toBeCloseTo(500, 2);
+  });
+
+  it('ALTA allocated before MEDIA and BASSA in constrained budget', () => {
+    const input = makeInput({
+      monthlyIncome: 2000, essentialsPct: 50, monthlySavingsTarget: 200,
+      goals: [
+        makeGoal({ id: 'bassa', name: 'Bassa', target: 4000, current: 0, deadline: monthsFromToday(20), priority: 3 }),
+        makeGoal({ id: 'media', name: 'Media', target: 4000, current: 0, deadline: monthsFromToday(20), priority: 2 }),
+        makeGoal({ id: 'alta', name: 'Alta', target: 4000, current: 0, deadline: monthsFromToday(20), priority: 1 }),
+      ],
+    });
+    const result = computeAllocation(input);
+    expect(result.items.find((it) => it.goalId === 'alta')!.monthlyAmount).toBeCloseTo(200, 2);
+    expect(result.items.find((it) => it.goalId === 'media')!.monthlyAmount).toBeCloseTo(0, 2);
+    expect(result.items.find((it) => it.goalId === 'bassa')!.monthlyAmount).toBeCloseTo(0, 2);
+    expect(result.items[0].goalId).toBe('bassa');
+    expect(result.items[1].goalId).toBe('media');
+    expect(result.items[2].goalId).toBe('alta');
+  });
+
+  it('open-ended goal with 0 allocation -> deadlineFeasible=true + exhausted warning', () => {
+    const input = makeInput({
+      monthlyIncome: 2000, essentialsPct: 50, monthlySavingsTarget: 100,
+      goals: [
+        makeGoal({ id: 'g-alta', name: 'Alta openended', target: 500, current: 0, deadline: null, priority: 1 }),
+        makeGoal({ id: 'g-media', name: 'Media openended', target: 500, current: 0, deadline: null, priority: 2 }),
+      ],
+    });
+    const result = computeAllocation(input);
+    const alta = result.items.find((it) => it.goalId === 'g-alta');
+    const media = result.items.find((it) => it.goalId === 'g-media');
+    expect(alta!.monthlyAmount).toBeCloseTo(100, 2);
+    expect(alta!.deadlineFeasible).toBe(true);
+    expect(media!.monthlyAmount).toBeCloseTo(0, 2);
+    expect(media!.deadlineFeasible).toBe(true);
+    expect(media!.warnings.some((w) => /esaurit|allocazione|savings/i.test(w))).toBe(true);
+  });
+
+  it('priority=1 goal with deadline > 12mo and no emergency name: NOT treated as emergency', () => {
+    const input = makeInput({
+      monthlyIncome: 2500, essentialsPct: 50, monthlySavingsTarget: 300,
+      goals: [
+        makeGoal({ id: 'g-casa', name: 'Acconto Casa', target: 7200, current: 0, deadline: monthsFromToday(24), priority: 1 }),
+        makeGoal({ id: 'g-viaggio', name: 'Viaggio', target: 3000, current: 0, deadline: monthsFromToday(24), priority: 3 }),
+      ],
+    });
+    const result = computeAllocation(input);
+    expect(result.items.find((it) => it.goalId === 'g-casa')!.monthlyAmount).toBeCloseTo(300, 2);
+    expect(result.items.find((it) => it.goalId === 'g-viaggio')!.monthlyAmount).toBeCloseTo(0, 2);
+    expect(result.totalAllocated).toBeCloseTo(300, 2);
   });
 });

--- a/apps/web/src/lib/onboarding/allocation.ts
+++ b/apps/web/src/lib/onboarding/allocation.ts
@@ -1,17 +1,15 @@
 /**
  * Sprint 1.5 — Onboarding Piano Generato
- * Allocation algorithm — Stream B implementation.
+ * Allocation algorithm — beta+gamma waterfall hybrid (issue #458 rewrite).
  *
- * DETERMINISM: output is deterministic given the same `(input, current date)`.
- * Time is captured once at function entry via `new Date()`. Tests should use
- * `vi.setSystemTime()` / `vi.useFakeTimers()` to freeze time.
+ * beta: emergency goal gets min(savingsPool x 0.4, need) as safety-net floor
+ * BEFORE waterfall runs.
  *
- * EMERGENCY FUND MODEL: the emergency goal is INCLUDED in the priority-weighted
- * pool and receives `max(priority-share, 40% × savingsPool)` capped at the
- * remaining need (target - current). When the 40% floor exceeds the priority
- * share, other goals' shares are scaled down pro-rata so the total still sums
- * to savingsPool. (Updated after integration reconcile 9daad36 — previous
- * docstring described an older "excluded from pool" design.)
+ * Waterfall: remaining pool distributed to non-emergency goals sorted ASC by
+ * priority (ALTA=1 first). Each goal consumes min(remainingPool, requiredMonthly).
+ *
+ * gamma: when emergency floor impacts top non-emergency goal by >=5% of
+ * savingsPool, surfaces Italian-language warning with pure-waterfall simulation.
  *
  * @module allocation
  */
@@ -21,27 +19,11 @@ import type {
   AllocationResult,
   AllocationResultItem,
   AllocationGoalInput,
-  PriorityRank,
 } from '@/types/onboarding-plan';
-import { PRIORITY_URGENCY_FACTOR } from '@/types/onboarding-plan';
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Internal helpers (not exported)
-// ─────────────────────────────────────────────────────────────────────────────
-
-/** Emergency fund name patterns (case-insensitive). */
 const _EMERGENCY_NAME_PATTERN = /emergenza|emergency/i;
-
-/** Months threshold for "imminent deadline" urgency boost. */
-const _URGENCY_MONTHS = 12;
-
-/** Emergency override fraction of the available savings pool. */
 const _EMERGENCY_OVERRIDE_FRACTION = 0.4;
 
-/**
- * Returns the number of whole months between `from` and `to`.
- * Negative when `to` is in the past.
- */
 function _monthsDiff(from: Date, to: Date): number {
   const yearDiff = to.getFullYear() - from.getFullYear();
   const monthDiff = to.getMonth() - from.getMonth();
@@ -49,21 +31,11 @@ function _monthsDiff(from: Date, to: Date): number {
   return yearDiff * 12 + monthDiff + dayAdjust;
 }
 
-/**
- * Parses `deadline` string (YYYY-MM-DD or ISO) to a LOCAL Date at midnight.
- * Returns null when the string is falsy or unparseable.
- *
- * Timezone-safe: `new Date('YYYY-MM-DD')` is parsed as UTC midnight, which
- * when read back via local getters (getMonth/getDate) can shift by one day
- * in non-UTC timezones. We parse explicitly as local-midnight instead to
- * align with `_monthsDiff`'s local-accessor usage. (Copilot review PR #455)
- */
 function _parseDeadline(deadline: string | null): Date | null {
   if (!deadline) return null;
   const datePart = deadline.slice(0, 10);
   const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(datePart);
   if (!match) {
-    // Fallback: non-date-only string, try generic parse (may be full ISO)
     const fallback = new Date(deadline);
     return isNaN(fallback.getTime()) ? null : fallback;
   }
@@ -75,218 +47,146 @@ function _parseDeadline(deadline: string | null): Date | null {
   return new Date(year, month - 1, day);
 }
 
-/**
- * Returns true when the goal qualifies as the emergency fund goal.
- * Condition: name matches the emergency pattern OR
- * (priority=1 AND deadline is in the future AND ≤ 12 months away).
- *
- * Past deadlines (negative months) are explicitly excluded — a priority=1
- * goal with a deadline already passed should NOT trigger emergency override
- * (it'd steal budget from other actionable goals). (Copilot review PR #455)
- */
 function _isEmergencyGoal(goal: AllocationGoalInput, now: Date): boolean {
   if (_EMERGENCY_NAME_PATTERN.test(goal.name)) return true;
   if (goal.priority === 1) {
     const deadlineDate = _parseDeadline(goal.deadline);
     if (deadlineDate !== null) {
       const months = _monthsDiff(now, deadlineDate);
-      if (months >= 0 && months <= _URGENCY_MONTHS) return true;
+      if (months >= 0 && months <= 12) return true;
     }
   }
   return false;
 }
 
-/**
- * Computes the effective weight for a goal considering urgency boost.
- * If `deadline` is within 12 months from `now`, weight is multiplied by 1.5.
- */
-function _effectiveWeight(goal: AllocationGoalInput, now: Date): number {
-  const base: number = PRIORITY_URGENCY_FACTOR[goal.priority as PriorityRank];
-  const deadlineDate = _parseDeadline(goal.deadline);
-  if (deadlineDate !== null) {
-    const months = _monthsDiff(now, deadlineDate);
-    if (months >= 0 && months <= _URGENCY_MONTHS) {
-      return base * 1.5;
-    }
-  }
-  return base;
-}
-
-/**
- * Builds a human-readable Italian reasoning string for a goal allocation.
- */
-function _buildReasoning(
-  goal: AllocationGoalInput,
-  monthlyAmount: number,
-  isEmergency: boolean,
-  urgencyBoosted: boolean,
-  deadlinePassed: boolean,
-): string {
-  if (goal.target === 0) {
-    return 'Target non specificato';
-  }
-  if (isEmergency) {
-    return `Fondo di emergenza: allocazione prioritaria del ${Math.round(_EMERGENCY_OVERRIDE_FRACTION * 100)}% del budget mensile disponibile per garantire sicurezza finanziaria.`;
-  }
-  const priorityLabel =
-    goal.priority === 1 ? 'alta' : goal.priority === 2 ? 'media' : 'bassa';
-  const parts: string[] = [`Priorità ${priorityLabel}`];
-  if (urgencyBoosted) {
-    parts.push('scadenza ravvicinata → allocation aumentata del 50%');
-  }
-  if (deadlinePassed) {
-    parts.push('scadenza già superata — allocation mantenuta per completare il goal');
-  }
-  parts.push(`importo mensile: €${monthlyAmount.toFixed(2)}`);
-  return parts.join(' · ');
-}
-
-/**
- * Rounds a number to 2 decimal places (cents precision).
- */
 function _round2(n: number): number {
   return Math.round(n * 100) / 100;
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Public API
-// ─────────────────────────────────────────────────────────────────────────────
+function _buildReasoning(
+  goal: AllocationGoalInput,
+  monthlyAmount: number,
+  isEmergency: boolean,
+  deadlinePassed: boolean,
+  requiredMonthly: number,
+  remainingPoolBefore: number,
+): string {
+  if (goal.target === 0) return 'Target non specificato';
+  if (isEmergency) {
+    return `Fondo di emergenza: allocazione prioritaria del ${Math.round(_EMERGENCY_OVERRIDE_FRACTION * 100)}% del budget mensile disponibile come protezione finanziaria.`;
+  }
+  const priorityLabel = goal.priority === 1 ? 'alta' : goal.priority === 2 ? 'media' : 'bassa';
+  const parts: string[] = [`Priorita ${priorityLabel}`];
+  if (deadlinePassed) parts.push('scadenza gia superata -- allocazione mantenuta per completare il goal');
+  const consumed = Math.min(remainingPoolBefore, _round2(requiredMonthly));
+  parts.push(`waterfall: consumato EUR${consumed.toFixed(2)} su EUR${remainingPoolBefore.toFixed(2)} disponibili`);
+  parts.push(`importo mensile: EUR${monthlyAmount.toFixed(2)}`);
+  return parts.join(' - ');
+}
 
-/**
- * Computes a deterministic monthly allocation plan from onboarding wizard input.
- *
- * The algorithm:
- * 1. Identifies the emergency fund goal (by name pattern or priority+deadline).
- * 2. Reserves up to 40% of the savings pool for the emergency fund (capped at need).
- * 3. Distributes the remainder among other goals weighted by priority × urgency.
- * 4. Produces one `AllocationResultItem` per input goal (including skipped ones).
- *
- * Deterministic per `(input, current date)`. Tests should freeze time with
- * `vi.setSystemTime()` to get fully reproducible results.
- *
- * @param input - Full allocation input from the onboarding wizard.
- * @returns `AllocationResult` with per-goal items, totals, and global warnings.
- */
+function _formatDistribution(pairs: Array<{ name: string; amount: number }>): string {
+  return pairs.map((p) => `${p.name} EUR${p.amount.toFixed(2)}`).join(', ');
+}
+
+interface _WaterfallEntry {
+  goal: AllocationGoalInput;
+  originalIndex: number;
+  requiredMonthly: number;
+  amount: number;
+}
+
+function _runWaterfall(
+  sorted: Array<{ goal: AllocationGoalInput; originalIndex: number }>,
+  pool: number,
+  now: Date,
+): _WaterfallEntry[] {
+  let remainingPool = pool;
+  const results: _WaterfallEntry[] = [];
+  for (const { goal, originalIndex } of sorted) {
+    const need = Math.max(0, goal.target - goal.current);
+    const deadlineDate = _parseDeadline(goal.deadline);
+    const monthsLeft = deadlineDate ? _monthsDiff(now, deadlineDate) : null;
+    const requiredMonthly =
+      monthsLeft !== null && monthsLeft > 0 ? need / monthsLeft : need;
+    const amount = _round2(Math.min(remainingPool, requiredMonthly));
+    results.push({ goal, originalIndex, requiredMonthly, amount });
+    remainingPool = _round2(remainingPool - amount);
+  }
+  return results;
+}
+
 export function computeAllocation(input: AllocationInput): AllocationResult {
   const now = new Date();
+  const { monthlyIncome, monthlySavingsTarget, essentialsPct, goals } = input;
 
-  const {
-    monthlyIncome,
-    monthlySavingsTarget,
-    essentialsPct,
-    goals,
-  } = input;
-
-  // ── Derived totals ──────────────────────────────────────────────────────
   const incomeAfterEssentials = _round2(monthlyIncome * (1 - essentialsPct / 100));
   const savingsPool = _round2(Math.min(monthlySavingsTarget, incomeAfterEssentials));
-
   const globalWarnings: string[] = [];
 
   if (monthlySavingsTarget > incomeAfterEssentials) {
     globalWarnings.push(
-      `Il target di risparmio mensile (€${monthlySavingsTarget.toFixed(2)}) supera il reddito disponibile dopo le spese essenziali (€${incomeAfterEssentials.toFixed(2)}). Il piano è stato calcolato sul reddito disponibile effettivo.`,
+      `Il target di risparmio mensile (EUR${monthlySavingsTarget.toFixed(2)}) supera il reddito disponibile dopo le spese essenziali (EUR${incomeAfterEssentials.toFixed(2)}). Il piano e stato calcolato sul reddito disponibile effettivo.`,
     );
   }
 
-  // ── Empty goals edge case ───────────────────────────────────────────────
   if (goals.length === 0) {
     globalWarnings.push('Nessun obiettivo definito. Il budget mensile disponibile rimane non allocato.');
-    return {
-      items: [],
-      incomeAfterEssentials,
-      totalAllocated: 0,
-      unallocated: savingsPool,
-      warnings: globalWarnings,
-    };
+    return { items: [], incomeAfterEssentials, totalAllocated: 0, unallocated: savingsPool, warnings: globalWarnings };
   }
 
-  // ── Identify emergency goal (first match wins) ──────────────────────────
   const emergencyIndex = goals.findIndex((g) => _isEmergencyGoal(g, now));
 
-  // ── Priority-weighted distribution including emergency goal ─────────────
-  // Emergency is NOT excluded from the pool — instead it gets max(priority-share, 40% floor)
-  // capped at remaining need. If floor applies, other goals are scaled down pro-rata.
-  const eligibleForPool = goals
-    .map((g, idx) => ({ g, idx }))
-    .filter(({ g }) => g.target > 0);
+  let emergencyAmount = 0;
+  let remainingPool = savingsPool;
 
-  // Compute effective weights
-  const weightMap = new Map<number, number>(); // index → weight
-  let totalWeight = 0;
-  for (const { g, idx } of eligibleForPool) {
-    const w = _effectiveWeight(g, now);
-    weightMap.set(idx, w);
-    totalWeight += w;
-  }
-
-  // Raw priority-weighted shares (includes emergency)
-  const rawShares = new Map<number, number>(); // index → amount
-  for (const { idx } of eligibleForPool) {
-    const w = weightMap.get(idx) ?? 0;
-    const share = totalWeight > 0 ? savingsPool * (w / totalWeight) : 0;
-    rawShares.set(idx, share);
-  }
-
-  // Emergency override: if priority-share < 40% floor, bump emergency up and scale
-  // other goals down proportionally to preserve sum = savingsPool.
   if (emergencyIndex >= 0 && goals[emergencyIndex]!.target > 0) {
     const emergencyGoal = goals[emergencyIndex]!;
     const emergencyNeed = Math.max(0, emergencyGoal.target - emergencyGoal.current);
-    const emergencyFloor = savingsPool * _EMERGENCY_OVERRIDE_FRACTION;
-    const prioShare = rawShares.get(emergencyIndex) ?? 0;
-    // Target: max(priority-share, 40% floor), capped at remaining need
-    const desired = Math.min(Math.max(prioShare, emergencyFloor), emergencyNeed);
+    emergencyAmount = _round2(Math.min(savingsPool * _EMERGENCY_OVERRIDE_FRACTION, emergencyNeed));
+    remainingPool = _round2(savingsPool - emergencyAmount);
+  }
 
-    if (desired > prioShare) {
-      // Bump emergency, scale others pro-rata down
-      const deficit = desired - prioShare;
-      const othersTotal = savingsPool - prioShare;
-      if (othersTotal > 0) {
-        const scaleFactor = 1 - deficit / othersTotal;
-        for (const { idx } of eligibleForPool) {
-          if (idx === emergencyIndex) continue;
-          const s = rawShares.get(idx) ?? 0;
-          rawShares.set(idx, Math.max(0, s * scaleFactor));
-        }
-      }
-      rawShares.set(emergencyIndex, desired);
-    } else if (desired < prioShare) {
-      // Priority share > need: cap at need, redistribute surplus to others pro-rata
-      const surplus = prioShare - desired;
-      const othersTotal = savingsPool - prioShare;
-      if (othersTotal > 0) {
-        const scaleFactor = 1 + surplus / othersTotal;
-        for (const { idx } of eligibleForPool) {
-          if (idx === emergencyIndex) continue;
-          const s = rawShares.get(idx) ?? 0;
-          rawShares.set(idx, s * scaleFactor);
-        }
-      }
-      rawShares.set(emergencyIndex, desired);
+  const otherGoals: Array<{ goal: AllocationGoalInput; originalIndex: number }> = goals
+    .map((goal, originalIndex) => ({ goal, originalIndex }))
+    .filter(({ originalIndex, goal }) => originalIndex !== emergencyIndex && goal.target > 0)
+    .sort((a, b) => (a.goal.priority as number) - (b.goal.priority as number));
+
+  const waterfallResults = _runWaterfall(otherGoals, remainingPool, now);
+
+  if (emergencyAmount > 0 && otherGoals.length > 0 && savingsPool > 0) {
+    const allNonZeroGoals: Array<{ goal: AllocationGoalInput; originalIndex: number }> = goals
+      .map((goal, originalIndex) => ({ goal, originalIndex }))
+      .filter(({ goal }) => goal.target > 0)
+      .sort((a, b) => (a.goal.priority as number) - (b.goal.priority as number));
+
+    const pureWaterfallResults = _runWaterfall(allNonZeroGoals, savingsPool, now);
+    const topGoalId = otherGoals[0]!.goal.id;
+    const actualTopAmount = waterfallResults[0]?.amount ?? 0;
+    const pureTopEntry = pureWaterfallResults.find((e) => e.goal.id === topGoalId);
+    const pureTopAmount = pureTopEntry?.amount ?? 0;
+    const delta = Math.abs(pureTopAmount - actualTopAmount) / savingsPool;
+
+    if (delta >= 0.05) {
+      const simPairs = pureWaterfallResults.map((e) => ({ name: e.goal.name, amount: e.amount }));
+      globalWarnings.push(
+        `Con waterfall puro senza protezione emergenza, il budget andrebbe: ${_formatDistribution(simPairs)}`,
+      );
     }
   }
 
-  // Round all shares and compute residual
-  const rawAllocations = new Map<number, number>();
-  let rawTotal = 0;
-  for (const { idx } of eligibleForPool) {
-    const rounded = _round2(rawShares.get(idx) ?? 0);
-    rawAllocations.set(idx, rounded);
-    rawTotal += rounded;
-  }
-
-  // Fix rounding residual: assign to highest-priority eligible goal (stable input order)
-  const roundingResidual = _round2(savingsPool - rawTotal);
-  if (roundingResidual !== 0 && eligibleForPool.length > 0) {
-    const highestPriorityEntry = eligibleForPool.reduce((best, curr) =>
-      curr.g.priority < best.g.priority ? curr : best,
+  const waterfallConsumed = _round2(waterfallResults.reduce((sum, e) => sum + e.amount, 0));
+  const postWaterfallResidual = _round2(remainingPool - waterfallConsumed);
+  if (postWaterfallResidual > 0) {
+    globalWarnings.push(
+      `Savings residuo di EUR${postWaterfallResidual.toFixed(2)} non allocato (tutti i goal sono stati finanziati per intero).`,
     );
-    const existing = rawAllocations.get(highestPriorityEntry.idx) ?? 0;
-    rawAllocations.set(highestPriorityEntry.idx, _round2(existing + roundingResidual));
   }
 
-  // ── Build per-goal result items (preserve input order) ────────────────
+  const waterfallAmountMap = new Map<number, _WaterfallEntry>();
+  for (const entry of waterfallResults) {
+    waterfallAmountMap.set(entry.originalIndex, entry);
+  }
+
   const items: AllocationResultItem[] = [];
 
   for (let i = 0; i < goals.length; i++) {
@@ -294,85 +194,92 @@ export function computeAllocation(input: AllocationInput): AllocationResult {
     const isEmergency = i === emergencyIndex;
     const itemWarnings: string[] = [];
 
-    // ── Skip: target=0 ────────────────────────────────────────────────
     if (goal.target === 0) {
       items.push({
-        goalId: goal.id,
-        monthlyAmount: 0,
-        deadlineFeasible: true, // vacuous truth
+        goalId: goal.id, monthlyAmount: 0, deadlineFeasible: true,
         reasoning: 'Target non specificato',
-        warnings: ['Target non specificato: il goal non riceverà allocazione.'],
+        warnings: ['Target non specificato: il goal non ricevera allocazione.'],
       });
       continue;
     }
 
-    // ── Compute monthlyAmount ─────────────────────────────────────────
-    const monthlyAmount: number = rawAllocations.get(i) ?? 0;
+    if (isEmergency) {
+      const deadlineDate = _parseDeadline(goal.deadline);
+      let deadlineFeasible = true;
+      if (deadlineDate !== null) {
+        const monthsLeft = _monthsDiff(now, deadlineDate);
+        if (monthsLeft < 0) {
+          deadlineFeasible = false;
+          itemWarnings.push('La scadenza di questo goal e gia trascorsa.');
+        } else if (emergencyAmount > 0) {
+          const remaining = Math.max(0, goal.target - goal.current);
+          const reqM = monthsLeft > 0 ? remaining / monthsLeft : Infinity;
+          if (reqM > emergencyAmount) {
+            deadlineFeasible = false;
+            itemWarnings.push(`Con EUR${emergencyAmount.toFixed(2)}/mese non sara possibile raggiungere l'obiettivo entro la scadenza (necessari EUR${reqM.toFixed(2)}/mese).`);
+          }
+        } else {
+          const remaining = Math.max(0, goal.target - goal.current);
+          if (remaining > 0) {
+            deadlineFeasible = false;
+            itemWarnings.push('Nessun importo allocato: la scadenza non sara rispettata.');
+          }
+        }
+      }
+      items.push({
+        goalId: goal.id, monthlyAmount: emergencyAmount, deadlineFeasible,
+        reasoning: _buildReasoning(goal, emergencyAmount, true, false, emergencyAmount, savingsPool),
+        warnings: itemWarnings,
+      });
+      continue;
+    }
 
-    // ── Deadline feasibility ──────────────────────────────────────────
+    const entry = waterfallAmountMap.get(i);
+    if (entry === undefined) {
+      items.push({ goalId: goal.id, monthlyAmount: 0, deadlineFeasible: true, reasoning: 'Target non specificato', warnings: [] });
+      continue;
+    }
+
+    const { amount, requiredMonthly } = entry;
+    const priorConsumed = _round2(waterfallResults.slice(0, waterfallResults.indexOf(entry)).reduce((sum, e) => sum + e.amount, 0));
+    const remainingPoolBefore = _round2(remainingPool - priorConsumed);
+
     const deadlineDate = _parseDeadline(goal.deadline);
     let deadlineFeasible = true;
-    const urgencyBoosted = !isEmergency && (() => {
-      if (!deadlineDate) return false;
-      const months = _monthsDiff(now, deadlineDate);
-      return months >= 0 && months <= _URGENCY_MONTHS;
-    })();
-
     let deadlinePassed = false;
+
     if (deadlineDate !== null) {
       const monthsLeft = _monthsDiff(now, deadlineDate);
       if (monthsLeft < 0) {
-        // Deadline already passed
-        deadlineFeasible = false;
-        deadlinePassed = true;
-        itemWarnings.push('La scadenza di questo goal è già trascorsa.');
-      } else if (monthlyAmount > 0) {
-        // Check if monthly contribution covers what's needed
-        const remaining = Math.max(0, goal.target - goal.current);
-        const requiredMonthly = monthsLeft > 0 ? remaining / monthsLeft : Infinity;
-        if (requiredMonthly > monthlyAmount) {
+        deadlineFeasible = false; deadlinePassed = true;
+        itemWarnings.push('La scadenza di questo goal e gia trascorsa.');
+      } else if (amount > 0) {
+        if (requiredMonthly > amount + 0.005) {
           deadlineFeasible = false;
-          itemWarnings.push(
-            `Con €${monthlyAmount.toFixed(2)}/mese non sarà possibile raggiungere l'obiettivo entro la scadenza (necessari €${requiredMonthly.toFixed(2)}/mese).`,
-          );
+          itemWarnings.push(`Savings insufficienti per raggiungere questo goal in tempo (necessari EUR${requiredMonthly.toFixed(2)}/mese, allocati EUR${amount.toFixed(2)}/mese).`);
         }
       } else {
-        // No allocation and a future deadline
         const remaining = Math.max(0, goal.target - goal.current);
         if (remaining > 0) {
           deadlineFeasible = false;
-          itemWarnings.push('Nessun importo allocato: la scadenza non sarà rispettata.');
+          itemWarnings.push('Savings insufficienti per raggiungere questo goal: importo allocato EUR0.00.');
         }
+      }
+    } else {
+      if (amount === 0) {
+        const remaining = Math.max(0, goal.target - goal.current);
+        if (remaining > 0) itemWarnings.push('Savings esauriti: questo goal non ricevera allocazione in questo mese.');
       }
     }
 
-    // ── Reasoning ────────────────────────────────────────────────────
-    const reasoning = _buildReasoning(
-      goal,
-      monthlyAmount,
-      isEmergency,
-      urgencyBoosted,
-      deadlinePassed,
-    );
-
     items.push({
-      goalId: goal.id,
-      monthlyAmount,
-      deadlineFeasible,
-      reasoning,
+      goalId: goal.id, monthlyAmount: amount, deadlineFeasible,
+      reasoning: _buildReasoning(goal, amount, false, deadlinePassed, requiredMonthly, remainingPoolBefore),
       warnings: itemWarnings,
     });
   }
 
-  // ── Aggregate totals ──────────────────────────────────────────────────
   const totalAllocated = _round2(items.reduce((sum, it) => sum + it.monthlyAmount, 0));
   const unallocated = _round2(savingsPool - totalAllocated);
-
-  return {
-    items,
-    incomeAfterEssentials,
-    totalAllocated,
-    unallocated,
-    warnings: globalWarnings,
-  };
+  return { items, incomeAfterEssentials, totalAllocated, unallocated, warnings: globalWarnings };
 }

--- a/apps/web/src/lib/onboarding/allocation.ts
+++ b/apps/web/src/lib/onboarding/allocation.ts
@@ -23,6 +23,12 @@ import type {
 
 const _EMERGENCY_NAME_PATTERN = /emergenza|emergency/i;
 const _EMERGENCY_OVERRIDE_FRACTION = 0.4;
+/** Maximum months-to-deadline for a priority=1 goal to be treated as emergency. */
+const _EMERGENCY_DEADLINE_MONTHS = 12;
+
+function _fmtEur(amount: number): string {
+  return `€${amount.toLocaleString('it-IT', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
 
 function _monthsDiff(from: Date, to: Date): number {
   const yearDiff = to.getFullYear() - from.getFullYear();
@@ -53,7 +59,7 @@ function _isEmergencyGoal(goal: AllocationGoalInput, now: Date): boolean {
     const deadlineDate = _parseDeadline(goal.deadline);
     if (deadlineDate !== null) {
       const months = _monthsDiff(now, deadlineDate);
-      if (months >= 0 && months <= 12) return true;
+      if (months >= 0 && months <= _EMERGENCY_DEADLINE_MONTHS) return true;
     }
   }
   return false;
@@ -76,16 +82,16 @@ function _buildReasoning(
     return `Fondo di emergenza: allocazione prioritaria del ${Math.round(_EMERGENCY_OVERRIDE_FRACTION * 100)}% del budget mensile disponibile come protezione finanziaria.`;
   }
   const priorityLabel = goal.priority === 1 ? 'alta' : goal.priority === 2 ? 'media' : 'bassa';
-  const parts: string[] = [`Priorita ${priorityLabel}`];
-  if (deadlinePassed) parts.push('scadenza gia superata -- allocazione mantenuta per completare il goal');
+  const parts: string[] = [`Priorità ${priorityLabel}`];
+  if (deadlinePassed) parts.push('scadenza già superata — allocazione mantenuta per completare il goal');
   const consumed = Math.min(remainingPoolBefore, _round2(requiredMonthly));
-  parts.push(`waterfall: consumato EUR${consumed.toFixed(2)} su EUR${remainingPoolBefore.toFixed(2)} disponibili`);
-  parts.push(`importo mensile: EUR${monthlyAmount.toFixed(2)}`);
-  return parts.join(' - ');
+  parts.push(`waterfall: consumato ${_fmtEur(consumed)} su ${_fmtEur(remainingPoolBefore)} disponibili`);
+  parts.push(`importo mensile: ${_fmtEur(monthlyAmount)}`);
+  return parts.join(' — ');
 }
 
 function _formatDistribution(pairs: Array<{ name: string; amount: number }>): string {
-  return pairs.map((p) => `${p.name} EUR${p.amount.toFixed(2)}`).join(', ');
+  return pairs.map((p) => `${p.name} ${_fmtEur(p.amount)}`).join(', ');
 }
 
 interface _WaterfallEntry {
@@ -93,6 +99,8 @@ interface _WaterfallEntry {
   originalIndex: number;
   requiredMonthly: number;
   amount: number;
+  /** Pool available BEFORE this entry consumed its share (for O(1) reasoning display). */
+  remainingPoolBefore: number;
 }
 
 function _runWaterfall(
@@ -108,8 +116,9 @@ function _runWaterfall(
     const monthsLeft = deadlineDate ? _monthsDiff(now, deadlineDate) : null;
     const requiredMonthly =
       monthsLeft !== null && monthsLeft > 0 ? need / monthsLeft : need;
+    const remainingPoolBefore = remainingPool;
     const amount = _round2(Math.min(remainingPool, requiredMonthly));
-    results.push({ goal, originalIndex, requiredMonthly, amount });
+    results.push({ goal, originalIndex, requiredMonthly, amount, remainingPoolBefore });
     remainingPool = _round2(remainingPool - amount);
   }
   return results;
@@ -125,7 +134,7 @@ export function computeAllocation(input: AllocationInput): AllocationResult {
 
   if (monthlySavingsTarget > incomeAfterEssentials) {
     globalWarnings.push(
-      `Il target di risparmio mensile (EUR${monthlySavingsTarget.toFixed(2)}) supera il reddito disponibile dopo le spese essenziali (EUR${incomeAfterEssentials.toFixed(2)}). Il piano e stato calcolato sul reddito disponibile effettivo.`,
+      `Il target di risparmio mensile (${_fmtEur(monthlySavingsTarget)}) supera il reddito disponibile dopo le spese essenziali (${_fmtEur(incomeAfterEssentials)}). Il piano è stato calcolato sul reddito disponibile effettivo.`,
     );
   }
 
@@ -178,7 +187,7 @@ export function computeAllocation(input: AllocationInput): AllocationResult {
   const postWaterfallResidual = _round2(remainingPool - waterfallConsumed);
   if (postWaterfallResidual > 0) {
     globalWarnings.push(
-      `Savings residuo di EUR${postWaterfallResidual.toFixed(2)} non allocato (tutti i goal sono stati finanziati per intero).`,
+      `Budget residuo di ${_fmtEur(postWaterfallResidual)} non allocato (tutti gli obiettivi sono stati finanziati per intero).`,
     );
   }
 
@@ -198,7 +207,7 @@ export function computeAllocation(input: AllocationInput): AllocationResult {
       items.push({
         goalId: goal.id, monthlyAmount: 0, deadlineFeasible: true,
         reasoning: 'Target non specificato',
-        warnings: ['Target non specificato: il goal non ricevera allocazione.'],
+        warnings: ['Target non specificato: il goal non riceverà allocazione.'],
       });
       continue;
     }
@@ -210,19 +219,19 @@ export function computeAllocation(input: AllocationInput): AllocationResult {
         const monthsLeft = _monthsDiff(now, deadlineDate);
         if (monthsLeft < 0) {
           deadlineFeasible = false;
-          itemWarnings.push('La scadenza di questo goal e gia trascorsa.');
+          itemWarnings.push('La scadenza di questo goal è già trascorsa.');
         } else if (emergencyAmount > 0) {
           const remaining = Math.max(0, goal.target - goal.current);
           const reqM = monthsLeft > 0 ? remaining / monthsLeft : Infinity;
           if (reqM > emergencyAmount) {
             deadlineFeasible = false;
-            itemWarnings.push(`Con EUR${emergencyAmount.toFixed(2)}/mese non sara possibile raggiungere l'obiettivo entro la scadenza (necessari EUR${reqM.toFixed(2)}/mese).`);
+            itemWarnings.push(`Con ${_fmtEur(emergencyAmount)}/mese non sarà possibile raggiungere l'obiettivo entro la scadenza (necessari ${_fmtEur(reqM)}/mese).`);
           }
         } else {
           const remaining = Math.max(0, goal.target - goal.current);
           if (remaining > 0) {
             deadlineFeasible = false;
-            itemWarnings.push('Nessun importo allocato: la scadenza non sara rispettata.');
+            itemWarnings.push('Nessun importo allocato: la scadenza non sarà rispettata.');
           }
         }
       }
@@ -236,13 +245,15 @@ export function computeAllocation(input: AllocationInput): AllocationResult {
 
     const entry = waterfallAmountMap.get(i);
     if (entry === undefined) {
-      items.push({ goalId: goal.id, monthlyAmount: 0, deadlineFeasible: true, reasoning: 'Target non specificato', warnings: [] });
-      continue;
+      // This branch is an invariant violation: every non-emergency goal with target > 0
+      // is added to otherGoals and must appear in waterfallAmountMap. If reached,
+      // the filter/sort logic has diverged from this loop.
+      throw new Error(
+        `Invariant violation: missing waterfall allocation for non-emergency goal with target > 0 (goalId: ${goal.id}).`,
+      );
     }
 
-    const { amount, requiredMonthly } = entry;
-    const priorConsumed = _round2(waterfallResults.slice(0, waterfallResults.indexOf(entry)).reduce((sum, e) => sum + e.amount, 0));
-    const remainingPoolBefore = _round2(remainingPool - priorConsumed);
+    const { amount, requiredMonthly, remainingPoolBefore } = entry;
 
     const deadlineDate = _parseDeadline(goal.deadline);
     let deadlineFeasible = true;
@@ -252,23 +263,23 @@ export function computeAllocation(input: AllocationInput): AllocationResult {
       const monthsLeft = _monthsDiff(now, deadlineDate);
       if (monthsLeft < 0) {
         deadlineFeasible = false; deadlinePassed = true;
-        itemWarnings.push('La scadenza di questo goal e gia trascorsa.');
+        itemWarnings.push('La scadenza di questo goal è già trascorsa.');
       } else if (amount > 0) {
         if (requiredMonthly > amount + 0.005) {
           deadlineFeasible = false;
-          itemWarnings.push(`Savings insufficienti per raggiungere questo goal in tempo (necessari EUR${requiredMonthly.toFixed(2)}/mese, allocati EUR${amount.toFixed(2)}/mese).`);
+          itemWarnings.push(`Budget insufficiente per raggiungere questo goal in tempo (necessari ${_fmtEur(requiredMonthly)}/mese, allocati ${_fmtEur(amount)}/mese).`);
         }
       } else {
         const remaining = Math.max(0, goal.target - goal.current);
         if (remaining > 0) {
           deadlineFeasible = false;
-          itemWarnings.push('Savings insufficienti per raggiungere questo goal: importo allocato EUR0.00.');
+          itemWarnings.push(`Budget insufficiente per raggiungere questo goal: importo allocato ${_fmtEur(0)}.`);
         }
       }
     } else {
       if (amount === 0) {
         const remaining = Math.max(0, goal.target - goal.current);
-        if (remaining > 0) itemWarnings.push('Savings esauriti: questo goal non ricevera allocazione in questo mese.');
+        if (remaining > 0) itemWarnings.push('Budget esaurito: questo goal non riceverà allocazione in questo mese.');
       }
     }
 

--- a/apps/web/src/types/onboarding-plan.ts
+++ b/apps/web/src/types/onboarding-plan.ts
@@ -102,7 +102,9 @@ export interface AllocationResultItem {
 
 /**
  * Full algorithm output.
- * Sum of items' monthlyAmount should equal min(monthlySavingsTarget, incomeAfterEssentials).
+ * `totalAllocated` = sum of items' monthlyAmount ≤ min(monthlySavingsTarget, incomeAfterEssentials).
+ * `unallocated` = savingsPool - totalAllocated (may be > 0 when all goals are fully funded
+ * before the pool is exhausted — see `warnings` for the "budget residuo" notice).
  */
 export interface AllocationResult {
   items: AllocationResultItem[];


### PR DESCRIPTION
## Summary

Closes #458 — `computeAllocation` distributed savings proportionally (weighted by priority) instead of waterfall. High-priority goals were under-funded in constrained budgets.

## Algorithm: Before / After

| Aspect | Before (proportional) | After (beta+gamma waterfall) |
|---|---|---|
| Distribution | Weighted shares: priority x urgency factor, all goals receive proportional slice | Sequential waterfall: ALTA goals drained first, then MEDIA, then BASSA |
| Emergency | `max(priority-share, 40% floor)`, others scaled down | `min(pool x 0.4, need)` as hard floor BEFORE waterfall |
| Urgency boost | x1.5 weight for deadline <12mo | Removed (subsumed by waterfall ordering) |
| User scenario (#458): 350e pool, debt ALTA 350/mo, Fondo Emergenza | 240e debt + 110e emergency (proportional) | 140e emergency floor + 210e debt + gamma warning |
| Residual | Always sum = pool | May leave unallocated when all goals fully covered |
| Education | None | gamma warning when emergency floor shifts top goal >=5% |

## Test migration note

Existing 10 test cases in `allocation.test.ts` are INTENTIONALLY DELETED.
They tested proportional-distribution semantics which are now obsolete.
21 new waterfall-specific test cases added.

## Files changed

- `apps/web/src/lib/onboarding/allocation.ts` — full rewrite of `computeAllocation`
- `apps/web/__tests__/lib/onboarding/allocation.test.ts` — full rewrite, 21 tests

## Breaking change

`computeAllocation` output values change. `deadlineFeasible` semantics change
for partially-funded goals. `reasoning` text changes to waterfall language.
Consumers: `StepPlanReview.tsx` renders dynamically (no hardcoded values impacted).

## Test plan

- [x] `pnpm --filter @money-wise/web typecheck` — PASS
- [x] `pnpm --filter @money-wise/web lint` — PASS (0 errors, 3 pre-existing warnings)
- [x] `pnpm test __tests__/lib/onboarding/allocation.test.ts` — 21/21 PASS
- [x] Full suite: 80 test files, 1593 tests PASS, 2 skipped
- [x] Issue #458 scenario verified: 350e pool => 140e emergency + 210e debt + gamma warning

Generated with [Claude Code](https://claude.com/claude-code)