### PR TITLE
fix(settings): theme persistence to DB (closes #467)

### DIFF
--- a/apps/web/__tests__/services/user-preferences.client.test.ts
+++ b/apps/web/__tests__/services/user-preferences.client.test.ts
@@ -201,6 +201,83 @@ describe('userPreferencesClient.updateNotifications', () => {
   });
 });
 
+describe('userPreferencesClient.updateTheme', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    chain.update.mockReset().mockReturnValue(chain);
+    chain.eq.mockReset().mockResolvedValue(makeEqResolver(null));
+  });
+
+  it('persists theme merged with existing preferences', async () => {
+    const current: UserPreferences = {
+      theme: 'dracula',
+      language: 'it',
+    };
+
+    await userPreferencesClient.updateTheme(USER_ID, current, 'italian');
+
+    expect(fromMock).toHaveBeenCalledWith('profiles');
+    expect(chain.update).toHaveBeenCalledTimes(1);
+    const payload = chain.update.mock.calls[0][0].preferences;
+    expect(payload.theme).toBe('italian');
+    // Other keys must be preserved
+    expect(payload.language).toBe('it');
+    expect(chain.eq).toHaveBeenCalledWith('id', USER_ID);
+  });
+
+  it('handles null existing preferences (first-time write)', async () => {
+    await userPreferencesClient.updateTheme(USER_ID, null, 'dracula');
+
+    const payload = chain.update.mock.calls[0][0].preferences;
+    expect(payload.theme).toBe('dracula');
+  });
+
+  it('handles undefined existing preferences', async () => {
+    await userPreferencesClient.updateTheme(USER_ID, undefined, 'system');
+
+    const payload = chain.update.mock.calls[0][0].preferences;
+    expect(payload.theme).toBe('system');
+  });
+
+  it('preserves notifications when updating theme', async () => {
+    const current: UserPreferences = {
+      theme: 'system',
+      notifications: {
+        channels: { email: false, push: true, inApp: true },
+        types: defaultNotificationPreferences().types,
+        quietHours: defaultNotificationPreferences().quietHours,
+      },
+    };
+
+    await userPreferencesClient.updateTheme(USER_ID, current, 'dracula');
+
+    const payload = chain.update.mock.calls[0][0].preferences;
+    expect(payload.theme).toBe('dracula');
+    expect(payload.notifications).toBeDefined();
+    expect(payload.notifications.channels.email).toBe(false);
+  });
+
+  it('throws UserPreferencesApiError when userId is empty', async () => {
+    await expect(
+      userPreferencesClient.updateTheme('', null, 'italian')
+    ).rejects.toBeInstanceOf(UserPreferencesApiError);
+  });
+
+  it('throws UserPreferencesApiError when Supabase returns an error', async () => {
+    chain.eq.mockResolvedValueOnce(
+      makeEqResolver({ message: 'RLS violation' })
+    );
+
+    await expect(
+      userPreferencesClient.updateTheme(USER_ID, {}, 'dracula')
+    ).rejects.toMatchObject({
+      name: 'UserPreferencesApiError',
+      statusCode: 500,
+      message: expect.stringContaining('RLS violation'),
+    });
+  });
+});
+
 describe('UserPreferencesApiError', () => {
   it('carries statusCode and optional details', () => {
     const err = new UserPreferencesApiError('boom', 418, { x: 1 });

--- a/apps/web/app/dashboard/settings/page.tsx
+++ b/apps/web/app/dashboard/settings/page.tsx
@@ -34,6 +34,8 @@ import { Label } from '@/components/ui/label';
 import { Card } from '@/components/ui/card';
 import { useAuthStore } from '@/store/auth.store';
 import { useTheme, type Theme } from '@/hooks/useTheme';
+import { userPreferencesClient } from '@/services/user-preferences.client';
+import type { UserPreferences } from '@/types/user-preferences';
 
 // =============================================================================
 // Types & Constants
@@ -196,6 +198,24 @@ export default function SettingsPage() {
       setError(err instanceof Error ? err.message : 'Impossibile salvare le modifiche');
     } finally {
       setIsSaving(false);
+    }
+  };
+
+  // Theme change — immediately applies via ThemeProvider (localStorage) and
+  // persists to profiles.preferences in the background.
+  // Fire-and-forget: UI is not blocked on DB write; shows error on failure.
+  const handleThemeChange = async (newTheme: Theme) => {
+    setTheme(newTheme);
+    if (user?.id) {
+      try {
+        await userPreferencesClient.updateTheme(
+          user.id,
+          (user.preferences as UserPreferences | null | undefined),
+          newTheme
+        );
+      } catch {
+        setError('Tema cambiato localmente. Sincronizzazione con il server fallita — riprova.');
+      }
     }
   };
 
@@ -388,7 +408,7 @@ export default function SettingsPage() {
                 <motion.button
                   key={t.id}
                   whileTap={{ scale: 0.98 }}
-                  onClick={() => setTheme(t.id)}
+                  onClick={() => void handleThemeChange(t.id)}
                   className={`p-4 rounded-2xl border-2 text-left transition-all ${
                     theme === t.id
                       ? 'border-emerald-500 ring-2 ring-emerald-200 dark:ring-emerald-800'

--- a/apps/web/src/services/user-preferences.client.ts
+++ b/apps/web/src/services/user-preferences.client.ts
@@ -10,6 +10,7 @@
 import { createClient } from '@/utils/supabase/client';
 import type {
   NotificationPreferences,
+  ThemePreference,
   UserPreferences,
 } from '@/types/user-preferences';
 
@@ -99,6 +100,23 @@ export const userPreferencesClient = {
     };
     await persistPreferences(userId, merged);
     return merged;
+  },
+
+  /**
+   * Convenience: update just the theme, preserving all other preference keys.
+   * Caller passes the current in-memory preferences to avoid a read round-trip.
+   * Fire-and-forget safe — caller should catch and surface an error on failure.
+   */
+  async updateTheme(
+    userId: string,
+    currentPreferences: UserPreferences | null | undefined,
+    theme: ThemePreference
+  ): Promise<void> {
+    const merged: UserPreferences = {
+      ...(currentPreferences ?? {}),
+      theme,
+    };
+    await persistPreferences(userId, merged);
   },
 };
 


### PR DESCRIPTION
## Summary

- Theme selection (Dracula / Italian Style / Sistema) now triggers `userPreferencesClient.updateTheme()` immediately after the `setTheme()` localStorage call
- `updateTheme()` merges the new theme into existing `profiles.preferences` without overwriting other keys (notifications, language, etc.)
- UI update is not blocked on the DB write (fire-and-forget); DB error surfaces via the page's existing `setError` state

## Root cause

`apps/web/app/dashboard/settings/page.tsx:391` called only `setTheme(t.id)` which writes `localStorage` via `ThemeProvider`. No Supabase PATCH was ever issued. On reload, `getInitialTheme(user?.preferences?.theme)` reads the DB value (unchanged), reverting the theme.

## Before / After

| | Before | After |
|--|--|--|
| Network on theme click | No PATCH to `/rest/v1/profiles` | PATCH issued immediately |
| After reload | Theme reverts to previous DB value | Theme persists from DB |
| DB failure | Silent (no feedback) | Error shown inline via `setError` |

## Files changed

- `apps/web/src/services/user-preferences.client.ts` — added `updateTheme()` method (caller-merge pattern, consistent with `updateNotifications`)
- `apps/web/app/dashboard/settings/page.tsx` — added `handleThemeChange` handler, wired to theme button onClick
- `apps/web/__tests__/services/user-preferences.client.test.ts` — 6 new tests for `updateTheme` (merge, null/undefined prefs, notifications preserved, empty userId, Supabase error)

## Manual QA baseline (2026-04-20)

Confirmed by issue #467 comment: Dracula → Italian Style, localStorage updated but Network PATCH absent, reload reverts. Fix addresses this exactly.

## Test plan

- [x] `pnpm --filter @money-wise/web typecheck` — GREEN
- [x] `pnpm --filter @money-wise/web lint` — GREEN (0 errors, 3 pre-existing warnings)
- [x] `pnpm --filter @money-wise/web exec vitest run __tests__/services/user-preferences.client.test.ts` — 17/17 GREEN
- [ ] Post-merge manual QA: Dracula → Italian Style → reload → theme must persist + Network PATCH visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)