### PR TITLE
fix(onboarding): Step 1 income input validation (closes #457)

### DIFF
--- a/apps/web/__tests__/components/onboarding/StepIncome.test.tsx
+++ b/apps/web/__tests__/components/onboarding/StepIncome.test.tsx
@@ -1,0 +1,251 @@
+/**
+ * Tests for StepIncome — Sprint 1.5.1 CRIT-02 (issue #457).
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '../../utils/test-utils';
+import type { WizardState } from '@/types/onboarding-plan';
+import {
+  selectCanAdvanceFromStep1,
+  INCOME_MIN,
+  INCOME_MAX,
+} from '@/store/onboarding-plan.store';
+
+vi.mock('framer-motion', () => ({
+  motion: new Proxy(
+    {},
+    {
+      get: (_target: unknown, prop: string | symbol) => {
+        if (prop === '__esModule') return false;
+        return ({
+          children,
+          initial: _initial,
+          animate: _animate,
+          exit: _exit,
+          transition: _transition,
+          whileHover: _whileHover,
+          whileTap: _whileTap,
+          whileInView: _whileInView,
+          variants: _variants,
+          ...rest
+        }: Record<string, unknown>) => {
+          const Tag = typeof prop === 'string' ? prop : 'div';
+          return React.createElement(Tag as string, rest, children as React.ReactNode);
+        };
+      },
+    }
+  ),
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+const mockPlanStore = vi.fn();
+vi.mock('@/store/onboarding-plan.store', () => ({
+  useOnboardingPlanStore: (selector?: (s: unknown) => unknown) => {
+    const state = mockPlanStore();
+    return selector ? selector(state) : state;
+  },
+  INCOME_MIN: 100,
+  INCOME_MAX: 100_000,
+  selectCanAdvanceFromStep1: (s: WizardState): boolean => {
+    const income = s.step1.monthlyIncome;
+    return income >= 100 && income <= 100_000;
+  },
+}));
+
+import { StepIncome } from '@/components/onboarding/steps/StepIncome';
+
+type StepState = Pick<WizardState, 'step1'> & {
+  updateIncome: ReturnType<typeof vi.fn>;
+};
+
+function makeState(overrides: Partial<StepState> = {}): StepState {
+  return {
+    step1: { monthlyIncome: 0 },
+    updateIncome: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('StepIncome — validation (issue #457)', () => {
+  beforeEach(() => {
+    mockPlanStore.mockReset();
+  });
+
+  it('renders a text input (not number) with inputMode="decimal"', () => {
+    mockPlanStore.mockReturnValue(makeState());
+    render(<StepIncome />);
+    const input = screen.getByRole('textbox', { name: /reddito netto mensile/i });
+    expect(input).toHaveAttribute('type', 'text');
+    expect(input).toHaveAttribute('inputMode', 'decimal');
+  });
+
+  it('calls updateIncome(0) when input is cleared', () => {
+    const updateIncome = vi.fn();
+    mockPlanStore.mockReturnValue(makeState({ step1: { monthlyIncome: 2500 }, updateIncome }));
+    render(<StepIncome />);
+    const input = screen.getByRole('textbox', { name: /reddito netto mensile/i });
+    fireEvent.change(input, { target: { value: '' } });
+    expect(updateIncome).toHaveBeenLastCalledWith(0);
+  });
+
+  it('does NOT show error for empty input (no blur yet)', () => {
+    mockPlanStore.mockReturnValue(makeState());
+    render(<StepIncome />);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('shows error after blur when input is non-numeric ("abc")', () => {
+    mockPlanStore.mockReturnValue(makeState());
+    render(<StepIncome />);
+    const input = screen.getByRole('textbox', { name: /reddito netto mensile/i });
+    fireEvent.change(input, { target: { value: 'abc' } });
+    fireEvent.blur(input);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toHaveTextContent(/numero valido/i);
+  });
+
+  it('calls updateIncome(0) for non-numeric input', () => {
+    const updateIncome = vi.fn();
+    mockPlanStore.mockReturnValue(makeState({ updateIncome }));
+    render(<StepIncome />);
+    const input = screen.getByRole('textbox', { name: /reddito netto mensile/i });
+    fireEvent.change(input, { target: { value: 'abc' } });
+    expect(updateIncome).toHaveBeenLastCalledWith(0);
+  });
+
+  it('shows error after blur when income is below EUR100 ("50")', () => {
+    mockPlanStore.mockReturnValue(makeState());
+    render(<StepIncome />);
+    const input = screen.getByRole('textbox', { name: /reddito netto mensile/i });
+    fireEvent.change(input, { target: { value: '50' } });
+    fireEvent.blur(input);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toHaveTextContent(/100/);
+  });
+
+  it('shows error after blur when income exceeds EUR100.000 ("200000")', () => {
+    mockPlanStore.mockReturnValue(makeState());
+    render(<StepIncome />);
+    const input = screen.getByRole('textbox', { name: /reddito netto mensile/i });
+    fireEvent.change(input, { target: { value: '200000' } });
+    fireEvent.blur(input);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toHaveTextContent(/100/);
+  });
+
+  it('accepts valid integer "2500" and calls updateIncome(2500)', () => {
+    const updateIncome = vi.fn();
+    mockPlanStore.mockReturnValue(makeState({ updateIncome }));
+    render(<StepIncome />);
+    const input = screen.getByRole('textbox', { name: /reddito netto mensile/i });
+    fireEvent.change(input, { target: { value: '2500' } });
+    expect(updateIncome).toHaveBeenLastCalledWith(2500);
+  });
+
+  it('shows no error after blur for valid integer "2500"', () => {
+    mockPlanStore.mockReturnValue(makeState());
+    render(<StepIncome />);
+    const input = screen.getByRole('textbox', { name: /reddito netto mensile/i });
+    fireEvent.change(input, { target: { value: '2500' } });
+    fireEvent.blur(input);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('accepts "2500,50" (comma decimal) and calls updateIncome(2500.5)', () => {
+    const updateIncome = vi.fn();
+    mockPlanStore.mockReturnValue(makeState({ updateIncome }));
+    render(<StepIncome />);
+    const input = screen.getByRole('textbox', { name: /reddito netto mensile/i });
+    fireEvent.change(input, { target: { value: '2500,50' } });
+    expect(updateIncome).toHaveBeenLastCalledWith(2500.5);
+  });
+
+  it('shows no error after blur for "2500,50"', () => {
+    mockPlanStore.mockReturnValue(makeState());
+    render(<StepIncome />);
+    const input = screen.getByRole('textbox', { name: /reddito netto mensile/i });
+    fireEvent.change(input, { target: { value: '2500,50' } });
+    fireEvent.blur(input);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('accepts "2500.50" (dot decimal) and calls updateIncome(2500.5)', () => {
+    const updateIncome = vi.fn();
+    mockPlanStore.mockReturnValue(makeState({ updateIncome }));
+    render(<StepIncome />);
+    const input = screen.getByRole('textbox', { name: /reddito netto mensile/i });
+    fireEvent.change(input, { target: { value: '2500.50' } });
+    expect(updateIncome).toHaveBeenLastCalledWith(2500.5);
+  });
+
+  it('shows no error after blur for "2500.50"', () => {
+    mockPlanStore.mockReturnValue(makeState());
+    render(<StepIncome />);
+    const input = screen.getByRole('textbox', { name: /reddito netto mensile/i });
+    fireEvent.change(input, { target: { value: '2500.50' } });
+    fireEvent.blur(input);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('renders a "Preferisco saltare" button', () => {
+    mockPlanStore.mockReturnValue(makeState());
+    render(<StepIncome />);
+    expect(screen.getByRole('button', { name: /preferisco saltare/i })).toBeInTheDocument();
+  });
+
+  it('calls updateIncome(0) when skip button is clicked', () => {
+    const updateIncome = vi.fn();
+    mockPlanStore.mockReturnValue(makeState({ step1: { monthlyIncome: 2500 }, updateIncome }));
+    render(<StepIncome />);
+    fireEvent.click(screen.getByRole('button', { name: /preferisco saltare/i }));
+    expect(updateIncome).toHaveBeenLastCalledWith(0);
+  });
+
+  it('shows skip warning after skip button click', () => {
+    mockPlanStore.mockReturnValue(makeState());
+    render(<StepIncome />);
+    fireEvent.click(screen.getByRole('button', { name: /preferisco saltare/i }));
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent(/allocazione/i);
+  });
+});
+
+describe('selectCanAdvanceFromStep1 selector', () => {
+  function makeWizardState(monthlyIncome: number): WizardState {
+    return {
+      currentStep: 1,
+      step1: { monthlyIncome },
+      step2: { monthlySavingsTarget: 0, essentialsPct: 50 },
+      step3: { goals: [] },
+      step4: { allocationPreview: null, userOverrides: {} },
+      step5: { enableAiCategorization: true, enableAiInsights: true },
+      isPersisting: false,
+      persistedPlanId: null,
+    };
+  }
+
+  it('returns false for income = 0 (initial / skipped)', () => {
+    expect(selectCanAdvanceFromStep1(makeWizardState(0))).toBe(false);
+  });
+
+  it('returns false for income below INCOME_MIN', () => {
+    expect(selectCanAdvanceFromStep1(makeWizardState(INCOME_MIN - 1))).toBe(false);
+  });
+
+  it('returns true for income = INCOME_MIN (boundary)', () => {
+    expect(selectCanAdvanceFromStep1(makeWizardState(INCOME_MIN))).toBe(true);
+  });
+
+  it('returns true for income = INCOME_MAX (boundary)', () => {
+    expect(selectCanAdvanceFromStep1(makeWizardState(INCOME_MAX))).toBe(true);
+  });
+
+  it('returns false for income above INCOME_MAX', () => {
+    expect(selectCanAdvanceFromStep1(makeWizardState(INCOME_MAX + 1))).toBe(false);
+  });
+
+  it('returns true for typical income value (2500)', () => {
+    expect(selectCanAdvanceFromStep1(makeWizardState(2500))).toBe(true);
+  });
+});

--- a/apps/web/__tests__/components/onboarding/WizardPianoGenerato.test.tsx
+++ b/apps/web/__tests__/components/onboarding/WizardPianoGenerato.test.tsx
@@ -88,6 +88,9 @@ vi.mock('@/store/onboarding-plan.store', () => ({
     const state = mockPlanStore();
     return selector ? selector(state) : state;
   },
+  selectCanAdvanceFromStep1: () => true,
+  INCOME_MIN: 100,
+  INCOME_MAX: 100_000,
 }));
 
 // --------------------------------------------------------------------------

--- a/apps/web/src/components/onboarding/WizardPianoGenerato.tsx
+++ b/apps/web/src/components/onboarding/WizardPianoGenerato.tsx
@@ -3,7 +3,10 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { AnimatePresence, motion } from 'framer-motion';
-import { useOnboardingPlanStore } from '@/store/onboarding-plan.store';
+import {
+  useOnboardingPlanStore,
+  selectCanAdvanceFromStep1,
+} from '@/store/onboarding-plan.store';
 import { useAuthStore } from '@/store/auth.store';
 import { onboardingPlanClient, OnboardingPlanApiError } from '@/services/onboarding-plan.client';
 import { StepIncome } from './steps/StepIncome';
@@ -40,9 +43,15 @@ export function WizardPianoGenerato() {
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [prevStepRef, setPrevStepRef] = useState(currentStep);
 
+  // Step 1 gate: income must be within bounds to advance -- fixes #457
+  const canAdvanceStep1 = useOnboardingPlanStore(selectCanAdvanceFromStep1);
+
   const isLastStep = currentStep === 5;
   // Submission is gated on having a user + valid allocation preview + at least 1 goal.
   const canSubmit = !!userId && !!allocationPreview && step3.goals.length > 0 && !isPersisting;
+
+  /** True when the current step allows advancing to the next one. */
+  const canAdvance = currentStep === 1 ? canAdvanceStep1 : true;
 
   // Diagnostic reason shown to user at Step 5 when canSubmit is false — so they
   // know WHY the button is disabled (not a mysterious stuck state).
@@ -243,7 +252,7 @@ export function WizardPianoGenerato() {
               )}
             </Button>
           ) : (
-            <Button onClick={handleNext}>
+            <Button onClick={handleNext} disabled={!canAdvance}>
               Avanti
               <ChevronRight className="w-4 h-4 ml-2" />
             </Button>

--- a/apps/web/src/components/onboarding/steps/StepIncome.tsx
+++ b/apps/web/src/components/onboarding/steps/StepIncome.tsx
@@ -1,10 +1,76 @@
 'use client';
 
+import { useState, useId } from 'react';
+import { AlertCircle, SkipForward } from 'lucide-react';
 import { useOnboardingPlanStore } from '@/store/onboarding-plan.store';
+
+/** Minimum monthly income (euros/month). Must match INCOME_MIN in onboarding-plan.store. */
+const INCOME_MIN = 100;
+/** Maximum monthly income (euros/month). Must match INCOME_MAX in onboarding-plan.store. */
+const INCOME_MAX = 100_000;
+
+/** Accept integers or decimals with . or , separator (up to 2 digits). */
+const INCOME_REGEX = /^\d+([.,]\d{1,2})?$/;
+
+/** Parse income string (accepting both "." and "," as decimal separator). */
+function parseIncome(raw: string): number {
+  return parseFloat(raw.replace(',', '.'));
+}
+
+/** Validate a raw income string. Returns null if valid, error message if invalid. */
+function validateIncome(raw: string): string | null {
+  if (!raw.trim()) return null;
+  if (!INCOME_REGEX.test(raw.trim())) {
+    return 'Inserisci un numero valido (es. 2.500 o 2.500,50)';
+  }
+  const value = parseIncome(raw.trim());
+  if (isNaN(value) || value < INCOME_MIN || value > INCOME_MAX) {
+    return `Il reddito deve essere un numero tra EUR${INCOME_MIN.toLocaleString('it-IT')} e EUR${INCOME_MAX.toLocaleString('it-IT')}`;
+  }
+  return null;
+}
 
 export function StepIncome() {
   const monthlyIncome = useOnboardingPlanStore((s) => s.step1.monthlyIncome);
   const updateIncome = useOnboardingPlanStore((s) => s.updateIncome);
+
+  const inputId = useId();
+
+  const [rawValue, setRawValue] = useState<string>(
+    monthlyIncome > 0 ? String(monthlyIncome) : ''
+  );
+  const [hasBlurred, setHasBlurred] = useState(false);
+  const [skipped, setSkipped] = useState(false);
+
+  const validationError = validateIncome(rawValue);
+  const showError = hasBlurred && validationError !== null && rawValue.trim() !== '';
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value;
+    setRawValue(val);
+    setSkipped(false);
+    if (val.trim() === '') {
+      updateIncome(0);
+      return;
+    }
+    const error = validateIncome(val);
+    if (!error) {
+      updateIncome(parseIncome(val.trim()));
+    } else {
+      updateIncome(0);
+    }
+  };
+
+  const handleBlur = () => {
+    setHasBlurred(true);
+  };
+
+  const handleSkip = () => {
+    setRawValue('');
+    setHasBlurred(false);
+    setSkipped(true);
+    updateIncome(0);
+  };
 
   return (
     <div className="space-y-4">
@@ -12,22 +78,66 @@ export function StepIncome() {
       <p className="text-sm text-muted-foreground">
         Quanto percepisci in media al mese, dopo le tasse? Questo è il punto di partenza del tuo piano.
       </p>
-      <div suppressHydrationWarning>
-        <label htmlFor="monthly-income" className="text-sm font-medium text-foreground block mb-1">
-          Reddito netto mensile (€)
+
+      <div>
+        <label htmlFor={inputId} className="text-sm font-medium text-foreground block mb-1">
+          Reddito netto mensile (EUR)
         </label>
         <input
-          id="monthly-income"
-          type="number"
-          min={0}
-          step={100}
-          value={monthlyIncome || ''}
-          onChange={(e) => updateIncome(Number(e.target.value) || 0)}
-          className="w-full bg-muted/50 border border-border rounded-xl px-3 py-2.5 text-sm outline-none focus:ring-2 focus:ring-blue-500 text-foreground"
-          placeholder="es. 2500"
-          suppressHydrationWarning
+          id={inputId}
+          type="text"
+          inputMode="decimal"
+          value={rawValue}
+          onChange={handleChange}
+          onBlur={handleBlur}
+          className={`w-full bg-muted/50 border rounded-xl px-3 py-2.5 text-sm outline-none focus:ring-2 focus:ring-blue-500 text-foreground transition-colors ${
+            showError ? 'border-red-400 focus:ring-red-400' : 'border-border'
+          }`}
+          placeholder="es. 2.500 oppure 2.500,50"
+          aria-describedby={showError ? `${inputId}-error` : `${inputId}-hint`}
+          aria-invalid={showError}
         />
+
+        {showError ? (
+          <p
+            id={`${inputId}-error`}
+            role="alert"
+            className="mt-1.5 text-xs text-red-600 dark:text-red-400 flex items-center gap-1"
+          >
+            <AlertCircle className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
+            {validationError}
+          </p>
+        ) : (
+          <p
+            id={`${inputId}-hint`}
+            className="mt-1.5 text-xs text-muted-foreground"
+          >
+            Inserisci il tuo reddito netto mensile (es. 2.500,50)
+          </p>
+        )}
       </div>
+
+      <div className="pt-1">
+        <button
+          type="button"
+          onClick={handleSkip}
+          className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground transition-colors"
+        >
+          <SkipForward className="w-3 h-3 inline mr-1" aria-hidden="true" />
+          Preferisco saltare
+        </button>
+      </div>
+
+      {skipped && (
+        <div
+          role="status"
+          className="p-3 rounded-xl bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800"
+        >
+          <p className="text-xs text-amber-700 dark:text-amber-300">
+            Senza reddito, il piano di allocazione (Passo 4) non potra essere calcolato. Potrai completarlo in seguito dalle impostazioni.
+          </p>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/store/onboarding-plan.store.ts
+++ b/apps/web/src/store/onboarding-plan.store.ts
@@ -15,6 +15,24 @@ import type {
   AllocationResult,
 } from '@/types/onboarding-plan';
 
+// -------------------------------------------------------------------------
+// Validation bounds (exported for selectCanAdvanceFromStep1 + tests)
+// -------------------------------------------------------------------------
+
+/** Minimum monthly income accepted in Step 1 (EUR/month). */
+export const INCOME_MIN = 100;
+/** Maximum monthly income accepted in Step 1 (EUR/month). */
+export const INCOME_MAX = 100_000;
+
+/**
+ * Returns true when Step 1 income value is within accepted bounds.
+ * 0 = not yet entered (initial state) or skipped -> false.
+ */
+export const selectCanAdvanceFromStep1 = (s: WizardState): boolean => {
+  const income = s.step1.monthlyIncome;
+  return income >= INCOME_MIN && income <= INCOME_MAX;
+};
+
 interface Actions {
   setStep: (step: WizardStep) => void;
   nextStep: () => void;


### PR DESCRIPTION
## Summary

Fixes #457 — Step 1 (reddito mensile) had no validation, allowing users to advance with income=0, which caused NaN in Step 4 allocation calculations.

- **`StepIncome.tsx`**: Rewritten with `type="text"` + `inputMode="decimal"` (market standard for numeric input with mobile decimal keyboard). Local `rawValue` state tracks string as typed; error shows only after blur. Regex `/^\d+([.,]\d{1,2})?$/` accepts both comma and dot decimal separators (Italian UX). "Preferisco saltare" skip button sets income to 0 and shows amber `role="status"` warning.
- **`onboarding-plan.store.ts`**: Exports `INCOME_MIN = 100`, `INCOME_MAX = 100_000`, and pure selector `selectCanAdvanceFromStep1` (usable with Zustand subscribe pattern).
- **`WizardPianoGenerato.tsx`**: "Avanti" button disabled on Step 1 when `selectCanAdvanceFromStep1` returns false (income not in [100, 100_000]).
- **`StepIncome.test.tsx`**: 22 tests — component validation (text input type, empty/blur/non-numeric/below-min/above-max/valid-integer/comma-decimal/dot-decimal/skip), selector boundary tests (0, INCOME_MIN-1, INCOME_MIN, INCOME_MAX, INCOME_MAX+1, 2500).

## Test plan

- [ ] `pnpm --filter @money-wise/web test -- apps/web/__tests__/components/onboarding/StepIncome.test.tsx` — all 22 pass
- [ ] Input accepts `2500`, `2.500,50`, `2500.50`; rejects `abc`, `50`, `200000`
- [ ] Error message appears after blur, not on first keystroke
- [ ] "Preferisco saltare" resets income to 0 and shows amber warning
- [ ] "Avanti" button is disabled with income=0 or invalid, enabled with valid income
- [ ] CI green on `fix/issue-457-wt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)