### PR TITLE
fix(onboarding): AI prefs persistence + post-submit redirect (closes #459 #462)

### DIFF
--- a/apps/web/__tests__/components/onboarding/WizardPianoGenerato.test.tsx
+++ b/apps/web/__tests__/components/onboarding/WizardPianoGenerato.test.tsx
@@ -383,7 +383,7 @@ describe('WizardPianoGenerato (Sprint 1.5)', () => {
 
   // ---- 5. handleSubmit — success path --------------------------------------
   describe('handleSubmit — success', () => {
-    it('calls persistPlan, toggles isPersisting on/off, and navigates to /dashboard', async () => {
+    it('calls persistPlan with aiPreferences, toggles isPersisting, and navigates to /dashboard/goals', async () => {
       const actions: StoreActionSpies = {
         nextStep: vi.fn(),
         prevStep: vi.fn(),
@@ -399,6 +399,7 @@ describe('WizardPianoGenerato (Sprint 1.5)', () => {
             allocationPreview: makeAllocation([GOAL_TEMP_ID]),
             userOverrides: {},
           },
+          step5: { enableAiCategorization: true, enableAiInsights: false },
           _actions: actions,
         })
       );
@@ -412,15 +413,20 @@ describe('WizardPianoGenerato (Sprint 1.5)', () => {
       });
       // userId first arg
       expect(mockPersistPlan.mock.calls[0]![0]).toBe('u1');
+      // aiPreferences forwarded from step5
+      const persistInput = mockPersistPlan.mock.calls[0]![1] as {
+        aiPreferences: { enableAiCategorization: boolean; enableAiInsights: boolean };
+      };
+      expect(persistInput.aiPreferences).toEqual({ enableAiCategorization: true, enableAiInsights: false });
       // setIsPersisting toggled true → false
       expect(actions.setIsPersisting).toHaveBeenNthCalledWith(1, true);
       expect(actions.setIsPersisting).toHaveBeenNthCalledWith(2, false);
       expect(actions.setPersistedPlanId).toHaveBeenCalledWith('plan-uuid');
-      // setUser called with onboarded: true to prevent redirect loop on /dashboard
+      // setUser called with onboarded: true to prevent redirect loop
       expect(mockSetUser).toHaveBeenCalledWith(
         expect.objectContaining({ id: 'u1', onboarded: true })
       );
-      expect(mockRouterPush).toHaveBeenCalledWith('/dashboard');
+      expect(mockRouterPush).toHaveBeenCalledWith('/dashboard/goals');
     });
   });
 

--- a/apps/web/__tests__/services/onboarding-plan.client.test.ts
+++ b/apps/web/__tests__/services/onboarding-plan.client.test.ts
@@ -160,6 +160,10 @@ const INPUT_BASE = {
       },
     },
   ],
+  aiPreferences: {
+    enableAiCategorization: true,
+    enableAiInsights: false,
+  },
 };
 
 beforeEach(() => {
@@ -232,6 +236,8 @@ describe('onboardingPlanClient.persistPlan — happy path', () => {
     goalsChain.__queueInsert({ data: { id: 'goal-uuid-2' }, error: null });
     // Insert allocations (no .select, awaited directly)
     allocChain.__queueInsert({ data: null, error: null });
+    // profiles SELECT preferences (new step 4)
+    profilesChain.single.mockResolvedValueOnce({ data: { preferences: null }, error: null });
 
     const result = await onboardingPlanClient.persistPlan(USER_ID, INPUT_BASE);
 
@@ -258,6 +264,7 @@ describe('onboardingPlanClient.persistPlan — happy path', () => {
     goalsChain.__queueInsert({ data: { id: 'g1' }, error: null });
     goalsChain.__queueInsert({ data: { id: 'g2' }, error: null });
     allocChain.__queueInsert({ data: null, error: null });
+    profilesChain.single.mockResolvedValueOnce({ data: { preferences: null }, error: null });
 
     await onboardingPlanClient.persistPlan(USER_ID, {
       ...INPUT_BASE,
@@ -285,6 +292,8 @@ describe('onboardingPlanClient.persistPlan — replace-on-exist', () => {
     goalsChain.__queueInsert({ data: { id: 'new-g1' }, error: null });
     goalsChain.__queueInsert({ data: { id: 'new-g2' }, error: null });
     allocChain.__queueInsert({ data: null, error: null });
+    // profiles SELECT preferences (new step 4)
+    profilesChain.single.mockResolvedValueOnce({ data: { preferences: { theme: 'dark' } }, error: null });
 
     const result = await onboardingPlanClient.persistPlan(USER_ID, INPUT_BASE);
 
@@ -481,6 +490,60 @@ describe('onboardingPlanClient.loadPlan', () => {
       statusCode: 400,
     });
     expect(fromMock).not.toHaveBeenCalled();
+  });
+});
+
+// =============================================================================
+// persistPlan — AI preferences persistence (#459)
+// =============================================================================
+describe('onboardingPlanClient.persistPlan — AI preferences persistence', () => {
+  it('merges aiPreferences into profiles.preferences preserving existing keys', async () => {
+    plansChain.maybeSingle.mockResolvedValueOnce({ data: null, error: null });
+    plansChain.__queueInsert({ data: { id: 'plan-pf-ok' }, error: null });
+    goalsChain.__queueInsert({ data: { id: 'g1' }, error: null });
+    goalsChain.__queueInsert({ data: { id: 'g2' }, error: null });
+    allocChain.__queueInsert({ data: null, error: null });
+    // profiles SELECT preferences — returns existing key 'theme' that must be preserved
+    profilesChain.single.mockResolvedValueOnce({
+      data: { preferences: { theme: 'dark', notifications: true } },
+      error: null,
+    });
+
+    await onboardingPlanClient.persistPlan(USER_ID, INPUT_BASE);
+
+    // profiles UPDATE must merge ai sub-key while preserving existing keys
+    const updateArg = profilesChain.update.mock.calls[0]![0] as {
+      onboarded: boolean;
+      preferences: { theme: string; notifications: boolean; ai: { enableAiCategorization: boolean; enableAiInsights: boolean } };
+    };
+    expect(updateArg.onboarded).toBe(true);
+    expect(updateArg.preferences.theme).toBe('dark');
+    expect(updateArg.preferences.notifications).toBe(true);
+    expect(updateArg.preferences.ai).toEqual({
+      enableAiCategorization: true,
+      enableAiInsights: false,
+    });
+  });
+
+  it('throws when profiles SELECT preferences fails', async () => {
+    plansChain.maybeSingle.mockResolvedValueOnce({ data: null, error: null });
+    plansChain.__queueInsert({ data: { id: 'plan-pf-err' }, error: null });
+    goalsChain.__queueInsert({ data: { id: 'g1' }, error: null });
+    goalsChain.__queueInsert({ data: { id: 'g2' }, error: null });
+    allocChain.__queueInsert({ data: null, error: null });
+    // profiles SELECT fails
+    profilesChain.single.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'preferences RLS denied' },
+    });
+
+    await expect(
+      onboardingPlanClient.persistPlan(USER_ID, INPUT_BASE)
+    ).rejects.toMatchObject({
+      name: 'OnboardingPlanApiError',
+      statusCode: 500,
+      message: expect.stringContaining('preferences RLS denied'),
+    });
   });
 });
 

--- a/apps/web/src/components/onboarding/WizardPianoGenerato.tsx
+++ b/apps/web/src/components/onboarding/WizardPianoGenerato.tsx
@@ -31,6 +31,7 @@ export function WizardPianoGenerato() {
   const step2 = useOnboardingPlanStore((s) => s.step2);
   const step3 = useOnboardingPlanStore((s) => s.step3);
   const allocationPreview = useOnboardingPlanStore((s) => s.step4.allocationPreview);
+  const step5 = useOnboardingPlanStore((s) => s.step5);
   const setIsPersisting = useOnboardingPlanStore((s) => s.setIsPersisting);
   const setPersistedPlanId = useOnboardingPlanStore((s) => s.setPersistedPlanId);
   const isPersisting = useOnboardingPlanStore((s) => s.isPersisting);
@@ -103,12 +104,16 @@ export function WizardPianoGenerato() {
             },
           };
         }),
+        aiPreferences: {
+          enableAiCategorization: step5.enableAiCategorization,
+          enableAiInsights: step5.enableAiInsights,
+        },
       });
       setPersistedPlanId(planId);
       // Update in-memory auth store so OnboardingGate does not redirect again
-      // when the user lands on /dashboard (profiles.onboarded is already true in DB).
+      // when the user lands on /dashboard/goals (profiles.onboarded is already true in DB).
       setUser({ ...user, onboarded: true });
-      router.push('/dashboard');
+      router.push('/dashboard/goals');
     } catch (err) {
       const msg =
         err instanceof OnboardingPlanApiError

--- a/apps/web/src/services/onboarding-plan.client.ts
+++ b/apps/web/src/services/onboarding-plan.client.ts
@@ -62,6 +62,10 @@ export interface PersistPlanInput {
       reasoning: string;
     };
   }>;
+  aiPreferences: {
+    enableAiCategorization: boolean;
+    enableAiInsights: boolean;
+  };
 }
 
 export interface PersistPlanResult {
@@ -224,14 +228,35 @@ export const onboardingPlanClient = {
       );
     }
 
-    // 4. Flip profiles.onboarded = true now that the plan is fully persisted.
-    // This is the canonical moment: goals + allocations exist, plan is committed.
-    // Caller (WizardPianoGenerato) is responsible for updating the in-memory
-    // auth store (setUser) so the OnboardingGate redirect effect does not fire
-    // again when the user lands on /dashboard.
+    // 4. Merge AI preferences into profiles.preferences, then flip onboarded = true.
+    // Fetch existing preferences first to avoid clobbering other preference keys
+    // (e.g. theme, notifications). Merge under the 'ai' sub-key, then UPDATE in
+    // a single round-trip (Copilot review PR #459: two separate UPDATEs risk race).
+    const { data: profileRow, error: profFetchErr } = await supabase
+      .from('profiles')
+      .select('preferences')
+      .eq('id', userId)
+      .single();
+
+    if (profFetchErr) {
+      throw new OnboardingPlanApiError(
+        `Failed to load preferences for merge: ${profFetchErr.message}`,
+        500,
+        profFetchErr,
+      );
+    }
+
+    const mergedPreferences = {
+      ...((profileRow?.preferences as Record<string, unknown>) || {}),
+      ai: {
+        enableAiCategorization: input.aiPreferences.enableAiCategorization,
+        enableAiInsights: input.aiPreferences.enableAiInsights,
+      },
+    };
+
     const { error: onboardedErr } = await supabase
       .from('profiles')
-      .update({ onboarded: true })
+      .update({ onboarded: true, preferences: mergedPreferences })
       .eq('id', userId);
 
     if (onboardedErr) {
@@ -240,7 +265,7 @@ export const onboardingPlanClient = {
       // surface the error and the user retries rather than silently ending up in
       // a redirect loop.
       throw new OnboardingPlanApiError(
-        `Piano salvato ma impossibile aggiornare onboarded: ${onboardedErr.message}`,
+        `Piano salvato ma impossibile aggiornare profilo: ${onboardedErr.message}`,
         500,
         onboardedErr,
       );


### PR DESCRIPTION
## Summary

- **#459 CRIT-04 AI preferences persistence**: `step5` (`enableAiCategorization` + `enableAiInsights`) was collected in the wizard but never persisted. Now `persistPlan` fetches existing `profiles.preferences`, merges the `ai` sub-key (preserving all other preference keys like `theme`, `notifications`), and UPDATEs `profiles` with `onboarded: true` + merged preferences in a single round-trip.
- **#462 HIGH-05 Post-submit redirect**: After wizard completion, redirect changed from `/dashboard` to `/dashboard/goals` so users land directly on their newly-created goals.
- `PersistPlanInput` extended with `aiPreferences: { enableAiCategorization, enableAiInsights }` field.

## Test plan

- [x] 17/17 service tests green (`onboarding-plan.client.test.ts`) — 2 new tests: merge preserves existing preference keys, throws on profiles SELECT failure
- [x] 16/16 wizard component tests green (`WizardPianoGenerato.test.tsx`) — success test updated to assert `aiPreferences` forwarding and `/dashboard/goals` redirect
- [x] `pnpm --filter @money-wise/web typecheck` — clean (0 errors)
- [x] `pnpm --filter @money-wise/web lint` — 0 errors, 3 pre-existing warnings
- [x] Pre-commit hook: lint + typecheck + build all passed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)