### PR TITLE
fix(onboarding): Step 2 slider granularity 1% + arrow keys + quick ±5 buttons (closes #465)

### DIFF
--- a/apps/web/__tests__/components/onboarding/StepSavingsTarget.test.tsx
+++ b/apps/web/__tests__/components/onboarding/StepSavingsTarget.test.tsx
@@ -198,4 +198,88 @@ describe('StepSavingsTarget (Sprint 1.5)', () => {
 
     expect(updateSavingsTarget).toHaveBeenCalledWith(500, 65);
   });
+
+  it('slider step is 1 (granularity fix #465)', () => {
+    mockPlanStore.mockReturnValue(makeState());
+    render(<StepSavingsTarget />);
+
+    const slider = screen.getByLabelText(/Quota spese essenziali/i);
+    expect(slider).toHaveAttribute('step', '1');
+  });
+
+  it('slider accepts non-multiple-of-5 values (e.g. 47%)', () => {
+    const updateSavingsTarget = vi.fn();
+    mockPlanStore.mockReturnValue(
+      makeState({
+        step2: { monthlySavingsTarget: 500, essentialsPct: 50 },
+        updateSavingsTarget,
+      })
+    );
+    render(<StepSavingsTarget />);
+
+    const slider = screen.getByLabelText(/Quota spese essenziali/i);
+    fireEvent.change(slider, { target: { value: '47' } });
+
+    expect(updateSavingsTarget).toHaveBeenCalledWith(500, 47);
+  });
+
+  it('"+5" button increases essentialsPct by 5', () => {
+    const updateSavingsTarget = vi.fn();
+    mockPlanStore.mockReturnValue(
+      makeState({
+        step2: { monthlySavingsTarget: 500, essentialsPct: 50 },
+        updateSavingsTarget,
+      })
+    );
+    render(<StepSavingsTarget />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Aumenta di 5%/i }));
+
+    expect(updateSavingsTarget).toHaveBeenCalledWith(500, 55);
+  });
+
+  it('"−5" button decreases essentialsPct by 5', () => {
+    const updateSavingsTarget = vi.fn();
+    mockPlanStore.mockReturnValue(
+      makeState({
+        step2: { monthlySavingsTarget: 500, essentialsPct: 50 },
+        updateSavingsTarget,
+      })
+    );
+    render(<StepSavingsTarget />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Diminuisci di 5%/i }));
+
+    expect(updateSavingsTarget).toHaveBeenCalledWith(500, 45);
+  });
+
+  it('"+5" button clamps at max 80', () => {
+    const updateSavingsTarget = vi.fn();
+    mockPlanStore.mockReturnValue(
+      makeState({
+        step2: { monthlySavingsTarget: 500, essentialsPct: 78 },
+        updateSavingsTarget,
+      })
+    );
+    render(<StepSavingsTarget />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Aumenta di 5%/i }));
+
+    expect(updateSavingsTarget).toHaveBeenCalledWith(500, 80);
+  });
+
+  it('"−5" button clamps at min 20', () => {
+    const updateSavingsTarget = vi.fn();
+    mockPlanStore.mockReturnValue(
+      makeState({
+        step2: { monthlySavingsTarget: 500, essentialsPct: 22 },
+        updateSavingsTarget,
+      })
+    );
+    render(<StepSavingsTarget />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Diminuisci di 5%/i }));
+
+    expect(updateSavingsTarget).toHaveBeenCalledWith(500, 20);
+  });
 });

--- a/apps/web/src/components/onboarding/steps/StepSavingsTarget.tsx
+++ b/apps/web/src/components/onboarding/steps/StepSavingsTarget.tsx
@@ -111,19 +111,47 @@ export function StepSavingsTarget() {
           </div>
         )}
 
-        <input
-          id="essentials-pct"
-          type="range"
-          min={20}
-          max={80}
-          step={5}
-          value={step2.essentialsPct}
-          onChange={(e) =>
-            updateSavingsTarget(step2.monthlySavingsTarget, Number(e.target.value))
-          }
-          className="w-full accent-blue-600"
-          suppressHydrationWarning
-        />
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            aria-label="Diminuisci di 5%"
+            onClick={() =>
+              updateSavingsTarget(
+                step2.monthlySavingsTarget,
+                Math.max(20, step2.essentialsPct - 5)
+              )
+            }
+            className="shrink-0 w-9 h-9 rounded-lg border border-border bg-muted/50 text-sm font-semibold text-foreground hover:bg-muted active:scale-95 transition-all select-none"
+          >
+            −5
+          </button>
+          <input
+            id="essentials-pct"
+            type="range"
+            min={20}
+            max={80}
+            step={1}
+            value={step2.essentialsPct}
+            onChange={(e) =>
+              updateSavingsTarget(step2.monthlySavingsTarget, Number(e.target.value))
+            }
+            className="w-full accent-blue-600"
+            suppressHydrationWarning
+          />
+          <button
+            type="button"
+            aria-label="Aumenta di 5%"
+            onClick={() =>
+              updateSavingsTarget(
+                step2.monthlySavingsTarget,
+                Math.min(80, step2.essentialsPct + 5)
+              )
+            }
+            className="shrink-0 w-9 h-9 rounded-lg border border-border bg-muted/50 text-sm font-semibold text-foreground hover:bg-muted active:scale-95 transition-all select-none"
+          >
+            +5
+          </button>
+        </div>
         <p className="text-xs text-muted-foreground mt-1">
           Affitto, bollette, alimentari, trasporti — le spese che non puoi evitare.
           {income > 0 && (


### PR DESCRIPTION
## Summary

- Change native `<input type="range">` step from `5` to `1` — arrow keys now give ±1% precision out of the box
- Add `−5` / `+5` quick-adjust buttons flanking the slider, clamped to [20, 80] (existing business bounds)
- 5 new unit tests: step attribute, non-multiple-of-5 value (47%), ±5 button clicks, clamp at min/max boundaries

## Test plan

- [x] All 1629 existing tests pass (81 test files, 0 failures)
- [x] `slider step=1` attribute test
- [x] `fireEvent.change` with value `47` (non-multiple-of-5)
- [x] `+5` button click dispatches `updateSavingsTarget(500, 55)`
- [x] `−5` button click dispatches `updateSavingsTarget(500, 45)`
- [x] `+5` from 78 clamps to 80; `−5` from 22 clamps to 20

Closes #465

🤖 Generated with [Claude Code](https://claude.com/claude-code)