### PR TITLE
fix(onboarding): edit goal mid-wizard + aggiusta chip (closes #460)

### DIFF
--- a/apps/web/__tests__/components/onboarding/StepGoals.test.tsx
+++ b/apps/web/__tests__/components/onboarding/StepGoals.test.tsx
@@ -31,9 +31,11 @@ type Goal = {
 };
 
 const mockAddGoal = vi.fn();
+const mockUpdateGoal = vi.fn();
 const mockRemoveGoal = vi.fn();
 const mockSetAddGoalModalOpen = vi.fn();
 const mockSetEditingPresetId = vi.fn();
+const mockSetEditingGoal = vi.fn();
 
 const mockStore = vi.fn();
 vi.mock('@/store/onboarding-plan.store', () => ({
@@ -46,16 +48,20 @@ vi.mock('@/store/onboarding-plan.store', () => ({
 function makeStoreState(
   goals: Goal[] = [],
   isAddGoalModalOpen = false,
-  editingPresetId: string | null = null
+  editingPresetId: string | null = null,
+  editingGoalId: string | null = null
 ) {
   return {
     step3: { goals },
     addGoal: mockAddGoal,
+    updateGoal: mockUpdateGoal,
     removeGoal: mockRemoveGoal,
     isAddGoalModalOpen,
     editingPresetId,
+    editingGoalId,
     setAddGoalModalOpen: mockSetAddGoalModalOpen,
     setEditingPresetId: mockSetEditingPresetId,
+    setEditingGoal: mockSetEditingGoal,
   };
 }
 
@@ -68,7 +74,7 @@ import { StepGoals } from '@/components/onboarding/steps/StepGoals';
 describe('StepGoals', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockStore.mockReturnValue(makeStoreState([]));
+    mockStore.mockReturnValue(makeStoreState([], false, null, null));
   });
 
   // ---- 1. Initial state -----------------------------------------------------
@@ -245,5 +251,82 @@ describe('StepGoals', () => {
     );
     render(<StepGoals />);
     expect(screen.queryByText(/Nessun obiettivo ancora/i)).not.toBeInTheDocument();
+  });
+
+  // ---- 6. Edit mode (issue #460) -----------------------------------------------
+
+  it('renders "Modifica" button for each goal in the list', () => {
+    mockStore.mockReturnValue(
+      makeStoreState([
+        { tempId: 'g-edit', name: 'Goal Esistente', target: 3000, deadline: null, priority: 2 },
+      ])
+    );
+    render(<StepGoals />);
+    expect(screen.getByLabelText(/Modifica Goal Esistente/i)).toBeInTheDocument();
+  });
+
+  it('"Modifica" button calls setEditingGoal + setEditingPresetId(null) + setAddGoalModalOpen(true)', async () => {
+    mockStore.mockReturnValue(
+      makeStoreState([
+        { tempId: 'g-edit', name: 'Obiettivo Test', target: 5000, deadline: null, priority: 1 },
+      ])
+    );
+    render(<StepGoals />);
+    await userEvent.click(screen.getByLabelText(/Modifica Obiettivo Test/i));
+
+    expect(mockSetEditingGoal).toHaveBeenCalledWith('g-edit');
+    expect(mockSetEditingPresetId).toHaveBeenCalledWith(null);
+    expect(mockSetAddGoalModalOpen).toHaveBeenCalledWith(true);
+  });
+
+  it('modal in edit mode shows title "Modifica obiettivo" and pre-fills values', () => {
+    mockStore.mockReturnValue(
+      makeStoreState(
+        [{ tempId: 'g-edit', name: 'Fondo Auto', target: 8000, deadline: '2027-01-01', priority: 2 }],
+        true,   // isAddGoalModalOpen
+        null,   // editingPresetId
+        'g-edit' // editingGoalId
+      )
+    );
+    render(<StepGoals />);
+
+    expect(screen.getByRole('heading', { name: /Modifica obiettivo/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/Nome/i)).toHaveValue('Fondo Auto');
+    expect(screen.getByLabelText(/Target \(€\)/i)).toHaveValue(8000);
+  });
+
+  it('submitting edit modal calls updateGoal with correct tempId and patch', async () => {
+    mockStore.mockReturnValue(
+      makeStoreState(
+        [{ tempId: 'g-edit', name: 'Vecchio Nome', target: 1000, deadline: null, priority: 3 }],
+        true,
+        null,
+        'g-edit'
+      )
+    );
+    render(<StepGoals />);
+
+    // Change the name — use role+name to avoid ambiguity with aria-label on "Modifica" button
+    const nameInput = screen.getByRole('textbox', { name: /Nome/i });
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, 'Nuovo Nome');
+
+    await userEvent.click(screen.getByRole('button', { name: /^Salva$/ }));
+
+    await waitFor(() => {
+      expect(mockUpdateGoal).toHaveBeenCalledWith(
+        'g-edit',
+        expect.objectContaining({ name: 'Nuovo Nome', target: 1000 })
+      );
+      expect(mockAddGoal).not.toHaveBeenCalled();
+      expect(mockSetAddGoalModalOpen).toHaveBeenCalledWith(false);
+      expect(mockSetEditingGoal).toHaveBeenCalledWith(null);
+    });
+  });
+
+  it('modal in add mode (editingGoalId null) still shows "Aggiungi" button', () => {
+    mockStore.mockReturnValue(makeStoreState([], true, null, null));
+    render(<StepGoals />);
+    expect(screen.getByRole('button', { name: /^Aggiungi$/ })).toBeInTheDocument();
   });
 });

--- a/apps/web/__tests__/components/onboarding/StepPlanReview.test.tsx
+++ b/apps/web/__tests__/components/onboarding/StepPlanReview.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * Tests for StepPlanReview — issue #460 "Aggiusta goal" chip.
+ *
+ * Covers:
+ * - Chip renders for goals with deadlineFeasible === false
+ * - Chip does NOT render for goals with deadlineFeasible === true
+ * - Chip click calls prevStep + setEditingGoal(tempId) + setAddGoalModalOpen(true)
+ * - Multiple goals: only infeasible ones show chip
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '../../utils/test-utils';
+import userEvent from '@testing-library/user-event';
+import type { PriorityRank, AllocationResult, WizardGoalDraft } from '@/types/onboarding-plan';
+
+// --------------------------------------------------------------------------
+// Store mock
+// --------------------------------------------------------------------------
+
+const mockSetAllocationPreview = vi.fn();
+const mockPrevStep = vi.fn();
+const mockSetEditingGoal = vi.fn();
+const mockSetAddGoalModalOpen = vi.fn();
+
+const mockStore = vi.fn();
+vi.mock('@/store/onboarding-plan.store', () => ({
+  useOnboardingPlanStore: (selector?: (s: unknown) => unknown) => {
+    const state = mockStore();
+    return selector ? selector(state) : state;
+  },
+}));
+
+// Allocation module mock — returns null so component shows "Aggiungi obiettivo" state
+// unless we provide allocationPreview directly in store state
+vi.mock('@/lib/onboarding/allocation', () => ({
+  computeAllocation: vi.fn(() => null),
+}));
+
+function makeGoal(tempId: string, name: string, priority: PriorityRank = 2): WizardGoalDraft {
+  return { tempId, name, target: 5000, deadline: '2025-12-31', priority };
+}
+
+function makeAllocation(
+  goalId: string,
+  monthlyAmount: number,
+  deadlineFeasible: boolean
+) {
+  return {
+    goalId,
+    monthlyAmount,
+    deadlineFeasible,
+    reasoning: deadlineFeasible ? 'On track' : 'Target troppo ambizioso per la scadenza',
+    warnings: [],
+  };
+}
+
+function makeStoreState(
+  goals: WizardGoalDraft[] = [],
+  allocationItems: ReturnType<typeof makeAllocation>[] = []
+) {
+  const allocationPreview: AllocationResult | null =
+    allocationItems.length > 0
+      ? {
+          items: allocationItems,
+          incomeAfterEssentials: 2000,
+          totalAllocated: allocationItems.reduce((s, i) => s + i.monthlyAmount, 0),
+          unallocated: 0,
+          warnings: [],
+        }
+      : null;
+
+  return {
+    step1: { monthlyIncome: 3000 },
+    step2: { monthlySavingsTarget: 500, essentialsPct: 50 },
+    step3: { goals },
+    step4: { allocationPreview, userOverrides: {} },
+    setAllocationPreview: mockSetAllocationPreview,
+    prevStep: mockPrevStep,
+    setEditingGoal: mockSetEditingGoal,
+    setAddGoalModalOpen: mockSetAddGoalModalOpen,
+  };
+}
+
+import { StepPlanReview } from '@/components/onboarding/steps/StepPlanReview';
+
+// --------------------------------------------------------------------------
+// Tests
+// --------------------------------------------------------------------------
+
+describe('StepPlanReview — "Aggiusta goal" chip (issue #460)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders "Aggiusta goal" chip for goal with deadlineFeasible === false', () => {
+    const goals = [makeGoal('g1', 'Comprare Casa')];
+    const allocations = [makeAllocation('g1', 200, false)];
+    mockStore.mockReturnValue(makeStoreState(goals, allocations));
+
+    render(<StepPlanReview />);
+
+    expect(screen.getByRole('button', { name: /Aggiusta goal Comprare Casa/i })).toBeInTheDocument();
+    expect(screen.getByText(/⚠️/)).toBeInTheDocument();
+    expect(screen.getByText(/Aggiusta goal/i)).toBeInTheDocument();
+  });
+
+  it('does NOT render chip when deadlineFeasible === true', () => {
+    const goals = [makeGoal('g2', 'Fondo Emergenza')];
+    const allocations = [makeAllocation('g2', 300, true)];
+    mockStore.mockReturnValue(makeStoreState(goals, allocations));
+
+    render(<StepPlanReview />);
+
+    expect(screen.queryByRole('button', { name: /Aggiusta goal/i })).not.toBeInTheDocument();
+  });
+
+  it('chip click calls prevStep + setEditingGoal(tempId) + setAddGoalModalOpen(true)', async () => {
+    const goals = [makeGoal('g-infeasible', 'Goal Difficile')];
+    const allocations = [makeAllocation('g-infeasible', 50, false)];
+    mockStore.mockReturnValue(makeStoreState(goals, allocations));
+
+    render(<StepPlanReview />);
+
+    await userEvent.click(screen.getByRole('button', { name: /Aggiusta goal Goal Difficile/i }));
+
+    await waitFor(() => {
+      expect(mockSetEditingGoal).toHaveBeenCalledWith('g-infeasible');
+      expect(mockSetAddGoalModalOpen).toHaveBeenCalledWith(true);
+      expect(mockPrevStep).toHaveBeenCalled();
+    });
+  });
+
+  it('only infeasible goals show chip — feasible goal in same list does not', () => {
+    const goals = [
+      makeGoal('g-ok', 'Fondo Emergenza'),
+      makeGoal('g-bad', 'Comprare Villa'),
+    ];
+    const allocations = [
+      makeAllocation('g-ok', 300, true),
+      makeAllocation('g-bad', 100, false),
+    ];
+    mockStore.mockReturnValue(makeStoreState(goals, allocations));
+
+    render(<StepPlanReview />);
+
+    // Only the infeasible one gets a chip
+    const chips = screen.getAllByRole('button', { name: /Aggiusta goal/i });
+    expect(chips).toHaveLength(1);
+    expect(chips[0]).toHaveAccessibleName(/Aggiusta goal Comprare Villa/i);
+  });
+
+  it('shows "Aggiungi almeno un obiettivo" placeholder when no goals', () => {
+    mockStore.mockReturnValue(makeStoreState([], []));
+    render(<StepPlanReview />);
+    expect(screen.getByText(/Aggiungi almeno un obiettivo/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/onboarding/steps/StepGoals.tsx
+++ b/apps/web/src/components/onboarding/steps/StepGoals.tsx
@@ -1,13 +1,14 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
 import { useOnboardingPlanStore } from '@/store/onboarding-plan.store';
-import { PRIORITY_LABEL_IT, type PriorityRank } from '@/types/onboarding-plan';
+import { PRIORITY_LABEL_IT, type PriorityRank, type WizardGoalDraft } from '@/types/onboarding-plan';
 import { Button } from '@/components/ui/button';
 import {
   Plus,
   X,
+  Pencil,
   PiggyBank,
   Landmark,
   TrendingUp,
@@ -130,16 +131,28 @@ interface AddGoalModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   presetId: string | null;
+  /** When non-null, modal is in edit mode pre-populated from this goal draft. */
+  editingGoal: WizardGoalDraft | null;
   onSubmit: (goal: { name: string; target: number; deadline: string | null; priority: PriorityRank }) => void;
 }
 
-function AddGoalModal({ open, onOpenChange, presetId, onSubmit }: AddGoalModalProps) {
+function AddGoalModal({ open, onOpenChange, presetId, editingGoal, onSubmit }: AddGoalModalProps) {
   const [draft, setDraft] = useState(EMPTY_DRAFT);
 
-  // Pre-fill draft whenever the modal opens with a preset
+  const isEditMode = editingGoal !== null;
+
+  // Pre-fill draft whenever the modal opens — edit goal takes priority over preset
   useEffect(() => {
     if (open) {
-      if (presetId) {
+      if (editingGoal) {
+        // Edit mode: pre-populate from existing goal
+        setDraft({
+          name: editingGoal.name,
+          target: String(editingGoal.target),
+          deadline: editingGoal.deadline ?? '',
+          priority: editingGoal.priority,
+        });
+      } else if (presetId) {
         const preset = PRESET_GOALS.find((p) => p.id === presetId);
         if (preset) {
           setDraft({
@@ -153,7 +166,7 @@ function AddGoalModal({ open, onOpenChange, presetId, onSubmit }: AddGoalModalPr
         setDraft(EMPTY_DRAFT);
       }
     }
-  }, [open, presetId]);
+  }, [open, presetId, editingGoal]);
 
   const handleSubmit = () => {
     const target = Number(draft.target);
@@ -179,7 +192,7 @@ function AddGoalModal({ open, onOpenChange, presetId, onSubmit }: AddGoalModalPr
               id="add-goal-dialog-title"
               className="text-base font-semibold text-foreground"
             >
-              Aggiungi un obiettivo
+              {isEditMode ? 'Modifica obiettivo' : 'Aggiungi un obiettivo'}
             </Dialog.Title>
             <Dialog.Close asChild>
               <button
@@ -259,7 +272,9 @@ function AddGoalModal({ open, onOpenChange, presetId, onSubmit }: AddGoalModalPr
             <Dialog.Close asChild>
               <Button variant="outline">Annulla</Button>
             </Dialog.Close>
-            <Button onClick={handleSubmit}>Aggiungi</Button>
+            <Button onClick={handleSubmit}>
+              {isEditMode ? 'Salva' : 'Aggiungi'}
+            </Button>
           </div>
         </Dialog.Content>
       </Dialog.Portal>
@@ -274,14 +289,41 @@ function AddGoalModal({ open, onOpenChange, presetId, onSubmit }: AddGoalModalPr
 export function StepGoals() {
   const goals = useOnboardingPlanStore((s) => s.step3.goals);
   const addGoal = useOnboardingPlanStore((s) => s.addGoal);
+  const updateGoal = useOnboardingPlanStore((s) => s.updateGoal);
   const removeGoal = useOnboardingPlanStore((s) => s.removeGoal);
   const isAddGoalModalOpen = useOnboardingPlanStore((s) => s.isAddGoalModalOpen);
   const editingPresetId = useOnboardingPlanStore((s) => s.editingPresetId);
+  const editingGoalId = useOnboardingPlanStore((s) => s.editingGoalId);
   const setAddGoalModalOpen = useOnboardingPlanStore((s) => s.setAddGoalModalOpen);
   const setEditingPresetId = useOnboardingPlanStore((s) => s.setEditingPresetId);
+  const setEditingGoal = useOnboardingPlanStore((s) => s.setEditingGoal);
+
+  // Refs for scroll-into-view when returning from Step 4 with a goal to edit
+  const goalRefs = useRef<Map<string, HTMLLIElement>>(new Map());
+
+  // Scroll the editing goal into view when editingGoalId is set (e.g., from Step 4 chip click)
+  useEffect(() => {
+    if (editingGoalId) {
+      const el = goalRefs.current.get(editingGoalId);
+      if (el && typeof el.scrollIntoView === 'function') {
+        el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
+    }
+  }, [editingGoalId]);
+
+  // Resolve the goal being edited (null in add mode)
+  const editingGoalDraft = editingGoalId
+    ? (goals.find((g) => g.tempId === editingGoalId) ?? null)
+    : null;
 
   const openModal = (presetId: string | null = null) => {
     setEditingPresetId(presetId);
+    setAddGoalModalOpen(true);
+  };
+
+  const openEditModal = (tempId: string) => {
+    setEditingGoal(tempId);
+    setEditingPresetId(null);
     setAddGoalModalOpen(true);
   };
 
@@ -289,13 +331,21 @@ export function StepGoals() {
     if (!open) {
       setAddGoalModalOpen(false);
       setEditingPresetId(null);
+      setEditingGoal(null);
     }
   };
 
   const handleSubmit = (goal: { name: string; target: number; deadline: string | null; priority: PriorityRank }) => {
-    addGoal(goal);
+    if (editingGoalId) {
+      // Edit mode: update existing goal
+      updateGoal(editingGoalId, goal);
+    } else {
+      // Add mode: create new goal
+      addGoal(goal);
+    }
     setAddGoalModalOpen(false);
     setEditingPresetId(null);
+    setEditingGoal(null);
   };
 
   return (
@@ -339,7 +389,15 @@ export function StepGoals() {
           {goals.map((g) => (
             <li
               key={g.tempId}
-              className="flex items-center justify-between p-3 rounded-xl border border-border bg-card"
+              ref={(el) => {
+                if (el) goalRefs.current.set(g.tempId, el);
+                else goalRefs.current.delete(g.tempId);
+              }}
+              className={`flex items-center justify-between p-3 rounded-xl border bg-card transition-colors ${
+                editingGoalId === g.tempId
+                  ? 'border-blue-500 ring-2 ring-blue-200 dark:ring-blue-900'
+                  : 'border-border'
+              }`}
             >
               <div>
                 <p className="text-sm font-medium text-foreground">{g.name}</p>
@@ -348,13 +406,22 @@ export function StepGoals() {
                   {g.deadline ? ` — entro ${g.deadline}` : ''}
                 </p>
               </div>
-              <button
-                onClick={() => removeGoal(g.tempId)}
-                className="p-2 rounded-lg hover:bg-muted"
-                aria-label={`Rimuovi ${g.name}`}
-              >
-                <X className="w-4 h-4 text-muted-foreground" />
-              </button>
+              <div className="flex items-center gap-1">
+                <button
+                  onClick={() => openEditModal(g.tempId)}
+                  className="p-2 rounded-lg hover:bg-muted"
+                  aria-label={`Modifica ${g.name}`}
+                >
+                  <Pencil className="w-4 h-4 text-muted-foreground" />
+                </button>
+                <button
+                  onClick={() => removeGoal(g.tempId)}
+                  className="p-2 rounded-lg hover:bg-muted"
+                  aria-label={`Rimuovi ${g.name}`}
+                >
+                  <X className="w-4 h-4 text-muted-foreground" />
+                </button>
+              </div>
             </li>
           ))}
         </ul>
@@ -383,6 +450,7 @@ export function StepGoals() {
         open={isAddGoalModalOpen}
         onOpenChange={closeModal}
         presetId={editingPresetId}
+        editingGoal={editingGoalDraft}
         onSubmit={handleSubmit}
       />
     </div>

--- a/apps/web/src/components/onboarding/steps/StepPlanReview.tsx
+++ b/apps/web/src/components/onboarding/steps/StepPlanReview.tsx
@@ -29,6 +29,9 @@ export function StepPlanReview() {
   const step3 = useOnboardingPlanStore((s) => s.step3);
   const allocationPreview = useOnboardingPlanStore((s) => s.step4.allocationPreview);
   const setAllocationPreview = useOnboardingPlanStore((s) => s.setAllocationPreview);
+  const prevStep = useOnboardingPlanStore((s) => s.prevStep);
+  const setEditingGoal = useOnboardingPlanStore((s) => s.setEditingGoal);
+  const setAddGoalModalOpen = useOnboardingPlanStore((s) => s.setAddGoalModalOpen);
 
   const incomeAfterEssentials =
     step1.monthlyIncome * (1 - step2.essentialsPct / 100);
@@ -153,12 +156,22 @@ export function StepPlanReview() {
                     <p className="text-sm font-medium text-foreground">{goal.name}</p>
                     <p className="text-xs text-muted-foreground">
                       {PRIORITY_LABEL_IT[goal.priority]} priorità
-                      {!item.deadlineFeasible && (
-                        <span className="ml-1 text-amber-600 dark:text-amber-400">
-                          — deadline non fattibile
-                        </span>
-                      )}
                     </p>
+                    {!item.deadlineFeasible && (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setEditingGoal(goal.tempId);
+                          setAddGoalModalOpen(true);
+                          prevStep();
+                        }}
+                        className="mt-1 inline-flex items-center gap-1 rounded-full bg-amber-100 dark:bg-amber-900/40 px-2 py-0.5 text-xs font-medium text-amber-700 dark:text-amber-300 hover:bg-amber-200 dark:hover:bg-amber-900/60 transition-colors"
+                        aria-label={`Aggiusta goal ${goal.name}`}
+                      >
+                        <span aria-hidden="true">⚠️</span>
+                        Aggiusta goal
+                      </button>
+                    )}
                   </div>
                   <p className="text-sm font-bold text-blue-600 dark:text-blue-400">
                     €{item.monthlyAmount.toFixed(0)}/mese

--- a/apps/web/src/store/onboarding-plan.store.ts
+++ b/apps/web/src/store/onboarding-plan.store.ts
@@ -93,6 +93,8 @@ interface Actions {
   // Modal state for "Aggiungi obiettivo" Dialog (issue #463)
   setAddGoalModalOpen: (open: boolean) => void;
   setEditingPresetId: (id: string | null) => void;
+  // Edit-in-place goal modal (issue #460)
+  setEditingGoal: (tempId: string | null) => void;
 }
 
 type WizardStore = WizardState & Actions;
@@ -108,6 +110,7 @@ const initialState: WizardState = {
   persistedPlanId: null,
   isAddGoalModalOpen: false,
   editingPresetId: null,
+  editingGoalId: null,
 };
 
 export const useOnboardingPlanStore = create<WizardStore>((set) => ({
@@ -222,4 +225,5 @@ export const useOnboardingPlanStore = create<WizardStore>((set) => ({
   reset: () => set(initialState),
   setAddGoalModalOpen: (open) => set({ isAddGoalModalOpen: open }),
   setEditingPresetId: (id) => set({ editingPresetId: id }),
+  setEditingGoal: (tempId) => set({ editingGoalId: tempId }),
 }));

--- a/apps/web/src/types/onboarding-plan.ts
+++ b/apps/web/src/types/onboarding-plan.ts
@@ -173,6 +173,12 @@ export interface WizardState {
   isAddGoalModalOpen: boolean;
   /** Preset id currently being edited in the modal; null for manual entry. */
   editingPresetId: string | null;
+  /**
+   * tempId of the goal being edited in-place (issue #460).
+   * Non-null triggers the modal in edit mode, pre-populated from existing goal.
+   * null = add mode (default).
+   */
+  editingGoalId: string | null;
 }
 
 // ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Store**: adds `editingGoalId: string | null` state + `setEditingGoal(id)` action, orthogonal to the existing `editingPresetId` (preset-add flow untouched)
- **StepGoals**: `AddGoalModal` gains edit mode — when `editingGoalId` is non-null the modal title becomes "Modifica obiettivo", form pre-populates from existing goal, submit calls `updateGoal` instead of `addGoal`. Each goal card gains a "Modifica" (Pencil) button. Scroll-into-view fires on the edited card when returning from Step 4.
- **StepPlanReview**: goals with `deadlineFeasible === false` now show a clickable "⚠️ Aggiusta goal" chip. Click fires `setEditingGoal(tempId)` + `setAddGoalModalOpen(true)` + `prevStep()` — navigates back to Step 3 and opens the edit modal focused on that goal.
- **Allocation re-trigger**: free — existing `useEffect` in `StepPlanReview` depends on `step3.goals`, so any `updateGoal` call automatically re-computes the allocation preview.

## Implementation note

Modal approach chosen over inline-card editing. Issue body suggested inline, but task scope spec says modal-based (extends the Radix Dialog from HIGH-08 / #475). Noted here for visibility.

## Test plan

- [x] `StepGoals.test.tsx`: extended with 5 new tests — "Modifica" button render, click wires `setEditingGoal` + `setEditingPresetId(null)` + `setAddGoalModalOpen(true)`, edit modal title "Modifica obiettivo", form pre-fill, `updateGoal` dispatch (not `addGoal`)
- [x] `StepPlanReview.test.tsx`: new file — chip renders for `deadlineFeasible=false`, no chip for `true`, click fires `prevStep` + `setEditingGoal` + `setAddGoalModalOpen`, multi-goal isolation
- [x] All 82 test files green (1647 tests pass)
- [x] `validate-ci.sh 8` passed

## Dependencies

Built on top of PR #475 (add goal Radix Dialog modal, already merged). No conflicts expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)