### PR TITLE
feat(goals): goal type openended — target/deadline opzionali (closes #464)

### DIFF
--- a/apps/web/__tests__/components/onboarding/StepGoals.test.tsx
+++ b/apps/web/__tests__/components/onboarding/StepGoals.test.tsx
@@ -13,7 +13,7 @@ import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '../../utils/test-utils';
 import userEvent from '@testing-library/user-event';
-import type { PriorityRank } from '@/types/onboarding-plan';
+import type { PriorityRank, GoalType } from '@/types/onboarding-plan';
 
 // --------------------------------------------------------------------------
 // Store mock — selector pattern
@@ -22,7 +22,8 @@ import type { PriorityRank } from '@/types/onboarding-plan';
 type Goal = {
   tempId: string;
   name: string;
-  target: number;
+  type: GoalType;
+  target: number | null;
   deadline: string | null;
   priority: PriorityRank;
 };
@@ -85,7 +86,9 @@ describe('StepGoals', () => {
 
   // ---- 2. Preset card click -------------------------------------------------
 
-  it('preset card click opens form pre-filled with preset defaults', async () => {
+  it('preset card click (Fondo Emergenza) opens form in openended mode — no target input', async () => {
+    // Issue #464: Fondo Emergenza preset defaults to openended type.
+    // Target input should NOT be visible when type='openended'.
     render(<StepGoals />);
     await userEvent.click(screen.getByLabelText(/Aggiungi preset: Fondo Emergenza/i));
 
@@ -93,12 +96,15 @@ describe('StepGoals', () => {
     const nameInput = screen.getByLabelText(/Nome/i);
     expect(nameInput).toHaveValue('Fondo Emergenza');
 
-    // Target pre-filled with 5000
-    const targetInput = screen.getByLabelText(/Target \(€\)/i);
-    expect(targetInput).toHaveValue(5000);
+    // Target input NOT visible for openended goals
+    expect(screen.queryByLabelText(/Target \(€\)/i)).not.toBeInTheDocument();
+
+    // "Goal aperto" button should be pressed
+    const openendedBtn = screen.getByRole('button', { name: /Goal aperto/i });
+    expect(openendedBtn).toHaveAttribute('aria-pressed', 'true');
   });
 
-  it('preset "Comprare Casa" pre-fills with 50000 target', async () => {
+  it('preset "Comprare Casa" pre-fills with 50000 target (fixed type)', async () => {
     render(<StepGoals />);
     await userEvent.click(screen.getByLabelText(/Aggiungi preset: Comprare Casa/i));
 
@@ -106,11 +112,11 @@ describe('StepGoals', () => {
     expect(targetInput).toHaveValue(50000);
   });
 
-  it('after preset click, user can submit the form and addGoal is called', async () => {
+  it('after preset click (Fondo Emergenza openended), submitting calls addGoal with type=openended', async () => {
     render(<StepGoals />);
     await userEvent.click(screen.getByLabelText(/Aggiungi preset: Fondo Emergenza/i));
 
-    // Form is open with pre-filled values — click Aggiungi
+    // Form is open in openended mode — click Aggiungi
     const addButton = screen.getByRole('button', { name: /^Aggiungi$/ });
     await userEvent.click(addButton);
 
@@ -118,7 +124,8 @@ describe('StepGoals', () => {
       expect(mockAddGoal).toHaveBeenCalledWith(
         expect.objectContaining({
           name: 'Fondo Emergenza',
-          target: 5000,
+          type: 'openended',
+          target: null,
           priority: 1,
         })
       );
@@ -138,7 +145,7 @@ describe('StepGoals', () => {
     expect(targetInput).toHaveValue(null); // empty number input = null
   });
 
-  it('submitting a manual goal with valid data calls addGoal', async () => {
+  it('submitting a manual goal with valid data calls addGoal with type=fixed', async () => {
     render(<StepGoals />);
     await userEvent.click(screen.getByRole('button', { name: /Aggiungi manualmente/i }));
 
@@ -150,7 +157,7 @@ describe('StepGoals', () => {
 
     await waitFor(() => {
       expect(mockAddGoal).toHaveBeenCalledWith(
-        expect.objectContaining({ name: 'Università', target: 8000 })
+        expect.objectContaining({ name: 'Università', type: 'fixed', target: 8000 })
       );
     });
   });
@@ -165,12 +172,46 @@ describe('StepGoals', () => {
     expect(screen.getByRole('button', { name: /Aggiungi manualmente/i })).toBeInTheDocument();
   });
 
+  it('#464 toggle to openended hides target/deadline, shows description', async () => {
+    render(<StepGoals />);
+    await userEvent.click(screen.getByRole('button', { name: /Aggiungi manualmente/i }));
+
+    // Initially fixed — target should be visible
+    expect(screen.getByLabelText(/Target \(€\)/i)).toBeInTheDocument();
+
+    // Switch to openended
+    await userEvent.click(screen.getByRole('button', { name: /Goal aperto/i }));
+
+    // Target input should disappear
+    expect(screen.queryByLabelText(/Target \(€\)/i)).not.toBeInTheDocument();
+    // Deadline input should disappear
+    expect(screen.queryByLabelText(/Scadenza/i)).not.toBeInTheDocument();
+    // Description explaining openended should appear
+    expect(screen.getByText(/riceve qualsiasi risparmio residuo/i)).toBeInTheDocument();
+  });
+
+  it('#464 openended goal in list displays "Goal aperto" label and remove button', () => {
+    mockStore.mockReturnValue(
+      makeStoreState([
+        { tempId: 'g-open', name: 'Mio Fondo Aperto', type: 'openended', target: null, deadline: null, priority: 1 },
+      ])
+    );
+    render(<StepGoals />);
+    // Goal name appears in the list (use heading-level query to avoid preset card collision)
+    const listItem = screen.getByLabelText(/Rimuovi Mio Fondo Aperto/i).closest('li')!;
+    expect(listItem).toBeInTheDocument();
+    // "Goal aperto" subtitle text is present in the list item
+    expect(listItem).toHaveTextContent(/Goal aperto/i);
+    // Remove button present
+    expect(screen.getByLabelText(/Rimuovi Mio Fondo Aperto/i)).toBeInTheDocument();
+  });
+
   // ---- 4. Goals list --------------------------------------------------------
 
   it('renders existing goals from store', () => {
     mockStore.mockReturnValue(
       makeStoreState([
-        { tempId: 'g1', name: 'Obiettivo Personalizzato', target: 7500, deadline: null, priority: 2 },
+        { tempId: 'g1', name: 'Obiettivo Personalizzato', type: 'fixed', target: 7500, deadline: null, priority: 2 },
       ])
     );
     render(<StepGoals />);
@@ -183,7 +224,7 @@ describe('StepGoals', () => {
   it('remove button calls removeGoal with correct tempId', async () => {
     mockStore.mockReturnValue(
       makeStoreState([
-        { tempId: 'g-remove', name: 'Obiettivo Da Rimuovere', target: 1000, deadline: null, priority: 2 },
+        { tempId: 'g-remove', name: 'Obiettivo Da Rimuovere', type: 'fixed', target: 1000, deadline: null, priority: 2 },
       ])
     );
     render(<StepGoals />);

--- a/apps/web/__tests__/lib/onboarding/allocation.test.ts
+++ b/apps/web/__tests__/lib/onboarding/allocation.test.ts
@@ -39,7 +39,8 @@ function makeGoal(partial: Partial<AllocationGoalInput>): AllocationGoalInput {
   return {
     id: partial.id ?? `goal-${++_goalIdCounter}`,
     name: partial.name ?? 'Generic Goal',
-    target: partial.target ?? 1000,
+    type: partial.type ?? 'fixed',
+    target: partial.target !== undefined ? partial.target : 1000,
     current: partial.current ?? 0,
     deadline: partial.deadline ?? null,
     priority: (partial.priority ?? 2) as PriorityRank,
@@ -335,7 +336,7 @@ describe('computeAllocation -- beta+gamma waterfall (issue #458)', () => {
     expect(result.items[2].goalId).toBe('alta');
   });
 
-  it('open-ended goal with 0 allocation -> deadlineFeasible=true + exhausted warning', () => {
+  it('fixed goals with no deadline: deadlineFeasible=true; exhausted pool causes warning', () => {
     const input = makeInput({
       monthlyIncome: 2000, essentialsPct: 50, monthlySavingsTarget: 100,
       goals: [
@@ -365,5 +366,127 @@ describe('computeAllocation -- beta+gamma waterfall (issue #458)', () => {
     expect(result.items.find((it) => it.goalId === 'g-casa')!.monthlyAmount).toBeCloseTo(300, 2);
     expect(result.items.find((it) => it.goalId === 'g-viaggio')!.monthlyAmount).toBeCloseTo(0, 2);
     expect(result.totalAllocated).toBeCloseTo(300, 2);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Issue #464 — Openended goal scenarios
+  // ──────────────────────────────────────────────────────────────────────
+
+  it('#464 single openended goal, no fixed goals → receives 100% of pool', () => {
+    const input = makeInput({
+      monthlyIncome: 2000, essentialsPct: 50, monthlySavingsTarget: 400,
+      goals: [
+        makeGoal({ id: 'g-open', name: 'Fondo Emergenza', type: 'openended', target: null, priority: 1 }),
+      ],
+    });
+    const result = computeAllocation(input);
+    expect(result.items).toHaveLength(1);
+    const item = result.items[0]!;
+    expect(item.goalId).toBe('g-open');
+    expect(item.monthlyAmount).toBeCloseTo(400, 2);
+    expect(item.deadlineFeasible).toBe(true);
+    expect(item.reasoning).toMatch(/fondo aperto|residuo/i);
+    expect(result.totalAllocated).toBeCloseTo(400, 2);
+    expect(result.unallocated).toBeCloseTo(0, 2);
+  });
+
+  it('#464 two openended goals → equal split of pool', () => {
+    const input = makeInput({
+      monthlyIncome: 2000, essentialsPct: 50, monthlySavingsTarget: 400,
+      goals: [
+        makeGoal({ id: 'g-open1', name: 'Fondo Emergenza', type: 'openended', target: null, priority: 1 }),
+        makeGoal({ id: 'g-open2', name: 'Risparmio Libero', type: 'openended', target: null, priority: 3 }),
+      ],
+    });
+    const result = computeAllocation(input);
+    expect(result.items).toHaveLength(2);
+    const item1 = result.items.find((it) => it.goalId === 'g-open1')!;
+    const item2 = result.items.find((it) => it.goalId === 'g-open2')!;
+    expect(item1.monthlyAmount).toBeCloseTo(200, 2);
+    expect(item2.monthlyAmount).toBeCloseTo(200, 2);
+    expect(item1.deadlineFeasible).toBe(true);
+    expect(item2.deadlineFeasible).toBe(true);
+    expect(result.totalAllocated).toBeCloseTo(400, 2);
+    expect(result.unallocated).toBeCloseTo(0, 2);
+  });
+
+  it('#464 fixed + openended: fixed waterfall first, openended gets residual', () => {
+    // Pool = 500. Fixed goal needs 300/mo → openended gets 200.
+    const input = makeInput({
+      monthlyIncome: 2500, essentialsPct: 50, monthlySavingsTarget: 500,
+      goals: [
+        makeGoal({ id: 'g-fixed', name: 'Acconto Casa', type: 'fixed', target: 6000, current: 0, deadline: monthsFromToday(20), priority: 1 }),
+        makeGoal({ id: 'g-open', name: 'Fondo Emergenza', type: 'openended', target: null, priority: 2 }),
+      ],
+    });
+    const result = computeAllocation(input);
+    const fixed = result.items.find((it) => it.goalId === 'g-fixed')!;
+    const open = result.items.find((it) => it.goalId === 'g-open')!;
+    expect(fixed.monthlyAmount).toBeCloseTo(300, 2);
+    expect(open.monthlyAmount).toBeCloseTo(200, 2);
+    expect(open.deadlineFeasible).toBe(true);
+    expect(result.totalAllocated).toBeCloseTo(500, 2);
+    expect(result.unallocated).toBeCloseTo(0, 2);
+  });
+
+  it('#464 emergency floor (fixed) + fixed waterfall + openended: correct residual chain', () => {
+    // Pool = 500. Emergency floor = min(500*0.4, need) = 200.
+    // Remaining = 300 → waterfall fixed goal needs 500/mo, gets 300.
+    // Residual after waterfall = 0 → openended gets 0.
+    const input = makeInput({
+      monthlyIncome: 2500, essentialsPct: 50, monthlySavingsTarget: 500,
+      goals: [
+        makeGoal({ id: 'g-debt', name: 'Debito Auto', type: 'fixed', target: 9000, current: 0, deadline: monthsFromToday(18), priority: 1 }),
+        makeGoal({ id: 'g-emerg', name: 'Fondo Emergenza', type: 'fixed', target: 3000, current: 0, deadline: null, priority: 2 }),
+        makeGoal({ id: 'g-open', name: 'Risparmio Libero', type: 'openended', target: null, priority: 3 }),
+      ],
+    });
+    const result = computeAllocation(input);
+    const emerg = result.items.find((it) => it.goalId === 'g-emerg')!;
+    const debt = result.items.find((it) => it.goalId === 'g-debt')!;
+    const open = result.items.find((it) => it.goalId === 'g-open')!;
+    // Emergency gets min(500*0.4=200, 3000) = 200
+    expect(emerg.monthlyAmount).toBeCloseTo(200, 2);
+    // Debt gets min(300, 500) = 300
+    expect(debt.monthlyAmount).toBeCloseTo(300, 2);
+    // Residual after waterfall = 0
+    expect(open.monthlyAmount).toBeCloseTo(0, 2);
+    expect(open.deadlineFeasible).toBe(true);
+    expect(open.warnings.some((w) => /esaurit|budget|residuo/i.test(w))).toBe(true);
+    expect(result.totalAllocated).toBeCloseTo(500, 2);
+  });
+
+  it('#464 openended goal with type=openended and target=null → deadlineFeasible true, no target warning', () => {
+    const input = makeInput({
+      monthlySavingsTarget: 300,
+      goals: [makeGoal({ id: 'g-open', name: 'Fondo Aperto', type: 'openended', target: null, priority: 2 })],
+    });
+    const result = computeAllocation(input);
+    const item = result.items[0]!;
+    expect(item.deadlineFeasible).toBe(true);
+    expect(item.warnings.filter((w) => /target non specificato/i.test(w))).toHaveLength(0);
+    expect(item.reasoning).toMatch(/fondo aperto|residuo/i);
+  });
+
+  it('#464 openended Fondo Emergenza (type=openended) does NOT receive the 40% floor', () => {
+    // If Fondo Emergenza is openended, it should NOT be treated as emergency (no 40% floor).
+    // It receives only the residual after fixed goals waterfall.
+    const input = makeInput({
+      monthlyIncome: 2500, essentialsPct: 50, monthlySavingsTarget: 500,
+      goals: [
+        makeGoal({ id: 'g-casa', name: 'Acconto Casa', type: 'fixed', target: 10000, current: 0, deadline: monthsFromToday(20), priority: 1 }),
+        makeGoal({ id: 'g-emerg-open', name: 'Fondo Emergenza', type: 'openended', target: null, priority: 2 }),
+      ],
+    });
+    const result = computeAllocation(input);
+    const casa = result.items.find((it) => it.goalId === 'g-casa')!;
+    const emergOpen = result.items.find((it) => it.goalId === 'g-emerg-open')!;
+    // casa gets full 500 (waterfall), no emergency floor intercepted
+    expect(casa.monthlyAmount).toBeCloseTo(500, 2);
+    // emergOpen gets residual = 0
+    expect(emergOpen.monthlyAmount).toBeCloseTo(0, 2);
+    expect(emergOpen.deadlineFeasible).toBe(true);
+    // No gamma warning since no emergency floor was applied
+    expect(result.warnings.some((w) => /waterfall puro|senza protezione/i.test(w))).toBe(false);
   });
 });

--- a/apps/web/src/components/onboarding/WizardPianoGenerato.tsx
+++ b/apps/web/src/components/onboarding/WizardPianoGenerato.tsx
@@ -102,6 +102,7 @@ export function WizardPianoGenerato() {
           const item = allocationPreview.items.find((it) => it.goalId === g.tempId);
           return {
             name: g.name,
+            type: g.type,
             target: g.target,
             deadline: g.deadline,
             priority: g.priority,

--- a/apps/web/src/components/onboarding/steps/StepGoals.tsx
+++ b/apps/web/src/components/onboarding/steps/StepGoals.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { useOnboardingPlanStore } from '@/store/onboarding-plan.store';
-import { PRIORITY_LABEL_IT, type PriorityRank } from '@/types/onboarding-plan';
+import { PRIORITY_LABEL_IT, type PriorityRank, type GoalType } from '@/types/onboarding-plan';
 import { Button } from '@/components/ui/button';
 import {
   Plus,
@@ -14,6 +14,8 @@ import {
   Banknote,
   Plane,
   BarChart3,
+  Infinity as InfinityIcon,
+  Target,
 } from 'lucide-react';
 
 // ---------------------------------------------------------------------------
@@ -25,8 +27,9 @@ interface PresetGoal {
   icon: React.ComponentType<{ className?: string }>;
   color: string;
   bg: string;
-  defaultTarget: number;
-  defaultDeadlineMonths: number;
+  defaultType: GoalType;
+  defaultTarget: number | null;
+  defaultDeadlineMonths: number | null;
   priority: PriorityRank;
 }
 
@@ -36,8 +39,10 @@ const PRESET_GOALS: PresetGoal[] = [
     icon: PiggyBank,
     color: 'text-blue-600',
     bg: 'bg-blue-50 dark:bg-blue-950/30 border-blue-200 dark:border-blue-800',
-    defaultTarget: 5000,
-    defaultDeadlineMonths: 12,
+    // Issue #464: Fondo Emergenza defaults to openended — receives surplus
+    defaultType: 'openended',
+    defaultTarget: null,
+    defaultDeadlineMonths: null,
     priority: 1,
   },
   {
@@ -45,6 +50,7 @@ const PRESET_GOALS: PresetGoal[] = [
     icon: Landmark,
     color: 'text-green-600',
     bg: 'bg-green-50 dark:bg-green-950/30 border-green-200 dark:border-green-800',
+    defaultType: 'fixed',
     defaultTarget: 50000,
     defaultDeadlineMonths: 60,
     priority: 2,
@@ -54,6 +60,7 @@ const PRESET_GOALS: PresetGoal[] = [
     icon: TrendingUp,
     color: 'text-purple-600',
     bg: 'bg-purple-50 dark:bg-purple-950/30 border-purple-200 dark:border-purple-800',
+    defaultType: 'fixed',
     defaultTarget: 10000,
     defaultDeadlineMonths: 24,
     priority: 2,
@@ -63,6 +70,7 @@ const PRESET_GOALS: PresetGoal[] = [
     icon: CreditCard,
     color: 'text-red-600',
     bg: 'bg-red-50 dark:bg-red-950/30 border-red-200 dark:border-red-800',
+    defaultType: 'fixed',
     defaultTarget: 3000,
     defaultDeadlineMonths: 12,
     priority: 1,
@@ -72,6 +80,7 @@ const PRESET_GOALS: PresetGoal[] = [
     icon: Banknote,
     color: 'text-orange-600',
     bg: 'bg-orange-50 dark:bg-orange-950/30 border-orange-200 dark:border-orange-800',
+    defaultType: 'fixed',
     defaultTarget: 5000,
     defaultDeadlineMonths: 12,
     priority: 3,
@@ -81,6 +90,7 @@ const PRESET_GOALS: PresetGoal[] = [
     icon: Plane,
     color: 'text-cyan-600',
     bg: 'bg-cyan-50 dark:bg-cyan-950/30 border-cyan-200 dark:border-cyan-800',
+    defaultType: 'fixed',
     defaultTarget: 2000,
     defaultDeadlineMonths: 6,
     priority: 3,
@@ -90,6 +100,7 @@ const PRESET_GOALS: PresetGoal[] = [
     icon: BarChart3,
     color: 'text-emerald-600',
     bg: 'bg-emerald-50 dark:bg-emerald-950/30 border-emerald-200 dark:border-emerald-800',
+    defaultType: 'fixed',
     defaultTarget: 20000,
     defaultDeadlineMonths: 36,
     priority: 2,
@@ -110,37 +121,58 @@ function addMonthsToToday(months: number): string {
 // Component
 // ---------------------------------------------------------------------------
 
+const EMPTY_DRAFT = {
+  name: '',
+  type: 'fixed' as GoalType,
+  target: '',
+  deadline: '',
+  priority: 2 as PriorityRank,
+};
+
 export function StepGoals() {
   const goals = useOnboardingPlanStore((s) => s.step3.goals);
   const addGoal = useOnboardingPlanStore((s) => s.addGoal);
   const removeGoal = useOnboardingPlanStore((s) => s.removeGoal);
 
   const [showAdd, setShowAdd] = useState(false);
-  const [draft, setDraft] = useState({
-    name: '',
-    target: '',
-    deadline: '',
-    priority: 2 as PriorityRank,
-  });
+  const [draft, setDraft] = useState(EMPTY_DRAFT);
+
+  const isOpenended = draft.type === 'openended';
 
   const handleAdd = () => {
-    const target = Number(draft.target);
-    if (!draft.name || target <= 0) return;
-    addGoal({
-      name: draft.name,
-      target,
-      deadline: draft.deadline || null,
-      priority: draft.priority,
-    });
-    setDraft({ name: '', target: '', deadline: '', priority: 2 });
+    if (!draft.name) return;
+    if (draft.type === 'fixed') {
+      const target = Number(draft.target);
+      if (target <= 0) return;
+      addGoal({
+        name: draft.name,
+        type: 'fixed',
+        target,
+        deadline: draft.deadline || null,
+        priority: draft.priority,
+      });
+    } else {
+      // openended: no target or deadline required
+      addGoal({
+        name: draft.name,
+        type: 'openended',
+        target: null,
+        deadline: null,
+        priority: draft.priority,
+      });
+    }
+    setDraft(EMPTY_DRAFT);
     setShowAdd(false);
   };
 
   const handlePresetClick = (preset: PresetGoal) => {
     setDraft({
       name: preset.name,
-      target: String(preset.defaultTarget),
-      deadline: addMonthsToToday(preset.defaultDeadlineMonths),
+      type: preset.defaultType,
+      target: preset.defaultTarget !== null ? String(preset.defaultTarget) : '',
+      deadline: preset.defaultDeadlineMonths !== null
+        ? addMonthsToToday(preset.defaultDeadlineMonths)
+        : '',
       priority: preset.priority,
     });
     setShowAdd(true);
@@ -175,7 +207,9 @@ export function StepGoals() {
                   {preset.name}
                 </span>
                 <span className="text-xs text-muted-foreground">
-                  €{preset.defaultTarget.toLocaleString('it-IT')}
+                  {preset.defaultTarget !== null
+                    ? `€${preset.defaultTarget.toLocaleString('it-IT')}`
+                    : 'Surplus'}
                 </span>
               </button>
             );
@@ -191,12 +225,20 @@ export function StepGoals() {
               key={g.tempId}
               className="flex items-center justify-between p-3 rounded-xl border border-border bg-card"
             >
-              <div>
-                <p className="text-sm font-medium text-foreground">{g.name}</p>
-                <p className="text-xs text-muted-foreground">
-                  €{g.target.toLocaleString('it-IT')} — {PRIORITY_LABEL_IT[g.priority]} priorità
-                  {g.deadline ? ` — entro ${g.deadline}` : ''}
-                </p>
+              <div className="flex items-center gap-2">
+                {g.type === 'openended'
+                  ? <InfinityIcon className="w-3.5 h-3.5 text-blue-500 flex-shrink-0" aria-hidden="true" />
+                  : <Target className="w-3.5 h-3.5 text-muted-foreground flex-shrink-0" aria-hidden="true" />
+                }
+                <div>
+                  <p className="text-sm font-medium text-foreground">{g.name}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {g.type === 'openended'
+                      ? `Goal aperto — ${PRIORITY_LABEL_IT[g.priority]} priorità — riceve surplus`
+                      : `€${(g.target ?? 0).toLocaleString('it-IT')} — ${PRIORITY_LABEL_IT[g.priority]} priorità${g.deadline ? ` — entro ${g.deadline}` : ''}`
+                    }
+                  </p>
+                </div>
               </div>
               <button
                 onClick={() => removeGoal(g.tempId)}
@@ -246,36 +288,79 @@ export function StepGoals() {
               suppressHydrationWarning
             />
           </div>
-          <div className="grid grid-cols-2 gap-3">
-            <div suppressHydrationWarning>
-              <label htmlFor="goal-target" className="text-sm font-medium text-foreground block mb-1">
-                Target (€)
-              </label>
-              <input
-                id="goal-target"
-                type="number"
-                min={0}
-                value={draft.target}
-                onChange={(e) => setDraft({ ...draft, target: e.target.value })}
-                className="w-full bg-muted/50 border border-border rounded-xl px-3 py-2 text-sm text-foreground"
-                placeholder="15000"
-                suppressHydrationWarning
-              />
+
+          {/* Goal type toggle (issue #464) */}
+          <div suppressHydrationWarning>
+            <p className="text-sm font-medium text-foreground mb-1">Tipo di goal</p>
+            <div className="flex gap-2" role="group" aria-label="Tipo di goal">
+              <button
+                type="button"
+                onClick={() => setDraft({ ...draft, type: 'fixed' })}
+                className={`flex-1 flex items-center justify-center gap-1.5 px-3 py-2 rounded-xl border text-xs font-medium transition-colors ${
+                  !isOpenended
+                    ? 'bg-primary text-primary-foreground border-primary'
+                    : 'bg-muted/50 text-muted-foreground border-border hover:bg-muted'
+                }`}
+                aria-pressed={!isOpenended}
+              >
+                <Target className="w-3.5 h-3.5" aria-hidden="true" />
+                Con target fisso
+              </button>
+              <button
+                type="button"
+                onClick={() => setDraft({ ...draft, type: 'openended', target: '', deadline: '' })}
+                className={`flex-1 flex items-center justify-center gap-1.5 px-3 py-2 rounded-xl border text-xs font-medium transition-colors ${
+                  isOpenended
+                    ? 'bg-blue-600 text-white border-blue-600'
+                    : 'bg-muted/50 text-muted-foreground border-border hover:bg-muted'
+                }`}
+                aria-pressed={isOpenended}
+              >
+                <InfinityIcon className="w-3.5 h-3.5" aria-hidden="true" />
+                Goal aperto
+              </button>
             </div>
-            <div suppressHydrationWarning>
-              <label htmlFor="goal-deadline" className="text-sm font-medium text-foreground block mb-1">
-                Scadenza (opzionale)
-              </label>
-              <input
-                id="goal-deadline"
-                type="date"
-                value={draft.deadline}
-                onChange={(e) => setDraft({ ...draft, deadline: e.target.value })}
-                className="w-full bg-muted/50 border border-border rounded-xl px-3 py-2 text-sm text-foreground"
-                suppressHydrationWarning
-              />
-            </div>
+            {isOpenended && (
+              <p className="text-xs text-muted-foreground mt-1.5">
+                Il goal aperto riceve qualsiasi risparmio residuo dopo gli obiettivi con target fisso. Non richiede importo ne scadenza.
+              </p>
+            )}
           </div>
+
+          {/* Target + deadline: only shown for fixed goals */}
+          {!isOpenended && (
+            <div className="grid grid-cols-2 gap-3">
+              <div suppressHydrationWarning>
+                <label htmlFor="goal-target" className="text-sm font-medium text-foreground block mb-1">
+                  Target (€)
+                </label>
+                <input
+                  id="goal-target"
+                  type="number"
+                  min={0}
+                  value={draft.target}
+                  onChange={(e) => setDraft({ ...draft, target: e.target.value })}
+                  className="w-full bg-muted/50 border border-border rounded-xl px-3 py-2 text-sm text-foreground"
+                  placeholder="15000"
+                  suppressHydrationWarning
+                />
+              </div>
+              <div suppressHydrationWarning>
+                <label htmlFor="goal-deadline" className="text-sm font-medium text-foreground block mb-1">
+                  Scadenza (opzionale)
+                </label>
+                <input
+                  id="goal-deadline"
+                  type="date"
+                  value={draft.deadline}
+                  onChange={(e) => setDraft({ ...draft, deadline: e.target.value })}
+                  className="w-full bg-muted/50 border border-border rounded-xl px-3 py-2 text-sm text-foreground"
+                  suppressHydrationWarning
+                />
+              </div>
+            </div>
+          )}
+
           <div suppressHydrationWarning>
             <label htmlFor="goal-priority" className="text-sm font-medium text-foreground block mb-1">
               Priorità
@@ -299,7 +384,7 @@ export function StepGoals() {
               variant="outline"
               onClick={() => {
                 setShowAdd(false);
-                setDraft({ name: '', target: '', deadline: '', priority: 2 });
+                setDraft(EMPTY_DRAFT);
               }}
             >
               Annulla

--- a/apps/web/src/components/onboarding/steps/StepPlanReview.tsx
+++ b/apps/web/src/components/onboarding/steps/StepPlanReview.tsx
@@ -47,6 +47,7 @@ export function StepPlanReview() {
       goals: step3.goals.map((g) => ({
         id: g.tempId,
         name: g.name,
+        type: g.type,
         target: g.target,
         current: 0,
         deadline: g.deadline,

--- a/apps/web/src/lib/onboarding/allocation.ts
+++ b/apps/web/src/lib/onboarding/allocation.ts
@@ -54,6 +54,10 @@ function _parseDeadline(deadline: string | null): Date | null {
 }
 
 function _isEmergencyGoal(goal: AllocationGoalInput, now: Date): boolean {
+  // Openended goals never act as the emergency floor — they already receive
+  // the residual pool. Requiring type='fixed' prevents a null target from
+  // crashing emergencyNeed = goal.target - goal.current (issue #464).
+  if (goal.type === 'openended') return false;
   if (_EMERGENCY_NAME_PATTERN.test(goal.name)) return true;
   if (goal.priority === 1) {
     const deadlineDate = _parseDeadline(goal.deadline);
@@ -77,7 +81,10 @@ function _buildReasoning(
   requiredMonthly: number,
   remainingPoolBefore: number,
 ): string {
-  if (goal.target === 0) return 'Target non specificato';
+  if (goal.type === 'openended') {
+    return `Fondo aperto: riceve il residuo del pool mensile ${_fmtEur(monthlyAmount)} dopo allocazione degli obiettivi con target fisso.`;
+  }
+  if (goal.target === 0 || goal.target === null) return 'Target non specificato';
   if (isEmergency) {
     return `Fondo di emergenza: allocazione prioritaria del ${Math.round(_EMERGENCY_OVERRIDE_FRACTION * 100)}% del budget mensile disponibile come protezione finanziaria.`;
   }
@@ -111,7 +118,11 @@ function _runWaterfall(
   let remainingPool = pool;
   const results: _WaterfallEntry[] = [];
   for (const { goal, originalIndex } of sorted) {
-    const need = Math.max(0, goal.target - goal.current);
+    // Openended goals must not enter waterfall — callers are responsible for
+    // filtering them out. This guard is a safety-net against divergence.
+    if (goal.type === 'openended') continue;
+    const target = goal.target ?? 0;
+    const need = Math.max(0, target - goal.current);
     const deadlineDate = _parseDeadline(goal.deadline);
     const monthsLeft = deadlineDate ? _monthsDiff(now, deadlineDate) : null;
     const requiredMonthly =
@@ -143,33 +154,52 @@ export function computeAllocation(input: AllocationInput): AllocationResult {
     return { items: [], incomeAfterEssentials, totalAllocated: 0, unallocated: savingsPool, warnings: globalWarnings };
   }
 
+  // Separate fixed vs openended goals upfront.
+  // Openended goals (issue #464) receive the residual pool AFTER emergency floor
+  // + waterfall on fixed goals. Emergency detection is gated to fixed goals only
+  // (an openended "Fondo Emergenza" collects surplus — no 40% floor applied).
+  const openendedGoalIndices = new Set<number>(
+    goals.map((g, i) => ({ g, i }))
+      .filter(({ g }) => g.type === 'openended')
+      .map(({ i }) => i),
+  );
+
   const emergencyIndex = goals.findIndex((g) => _isEmergencyGoal(g, now));
 
   let emergencyAmount = 0;
   let remainingPool = savingsPool;
 
-  if (emergencyIndex >= 0 && goals[emergencyIndex]!.target > 0) {
+  if (emergencyIndex >= 0) {
     const emergencyGoal = goals[emergencyIndex]!;
-    const emergencyNeed = Math.max(0, emergencyGoal.target - emergencyGoal.current);
-    emergencyAmount = _round2(Math.min(savingsPool * _EMERGENCY_OVERRIDE_FRACTION, emergencyNeed));
-    remainingPool = _round2(savingsPool - emergencyAmount);
+    // emergencyGoal.target is non-null here because _isEmergencyGoal gates on type='fixed'
+    const emergencyTarget = emergencyGoal.target ?? 0;
+    if (emergencyTarget > 0) {
+      const emergencyNeed = Math.max(0, emergencyTarget - emergencyGoal.current);
+      emergencyAmount = _round2(Math.min(savingsPool * _EMERGENCY_OVERRIDE_FRACTION, emergencyNeed));
+      remainingPool = _round2(savingsPool - emergencyAmount);
+    }
   }
 
-  const otherGoals: Array<{ goal: AllocationGoalInput; originalIndex: number }> = goals
+  const otherFixedGoals: Array<{ goal: AllocationGoalInput; originalIndex: number }> = goals
     .map((goal, originalIndex) => ({ goal, originalIndex }))
-    .filter(({ originalIndex, goal }) => originalIndex !== emergencyIndex && goal.target > 0)
+    .filter(({ originalIndex, goal }) =>
+      originalIndex !== emergencyIndex &&
+      !openendedGoalIndices.has(originalIndex) &&
+      (goal.target ?? 0) > 0,
+    )
     .sort((a, b) => (a.goal.priority as number) - (b.goal.priority as number));
 
-  const waterfallResults = _runWaterfall(otherGoals, remainingPool, now);
+  const waterfallResults = _runWaterfall(otherFixedGoals, remainingPool, now);
 
-  if (emergencyAmount > 0 && otherGoals.length > 0 && savingsPool > 0) {
-    const allNonZeroGoals: Array<{ goal: AllocationGoalInput; originalIndex: number }> = goals
+  // Gamma warning: when emergency floor shifts ≥5% of pool from top non-emergency fixed goal.
+  if (emergencyAmount > 0 && otherFixedGoals.length > 0 && savingsPool > 0) {
+    const allNonZeroFixedGoals: Array<{ goal: AllocationGoalInput; originalIndex: number }> = goals
       .map((goal, originalIndex) => ({ goal, originalIndex }))
-      .filter(({ goal }) => goal.target > 0)
+      .filter(({ goal }) => goal.type !== 'openended' && (goal.target ?? 0) > 0)
       .sort((a, b) => (a.goal.priority as number) - (b.goal.priority as number));
 
-    const pureWaterfallResults = _runWaterfall(allNonZeroGoals, savingsPool, now);
-    const topGoalId = otherGoals[0]!.goal.id;
+    const pureWaterfallResults = _runWaterfall(allNonZeroFixedGoals, savingsPool, now);
+    const topGoalId = otherFixedGoals[0]!.goal.id;
     const actualTopAmount = waterfallResults[0]?.amount ?? 0;
     const pureTopEntry = pureWaterfallResults.find((e) => e.goal.id === topGoalId);
     const pureTopAmount = pureTopEntry?.amount ?? 0;
@@ -185,7 +215,15 @@ export function computeAllocation(input: AllocationInput): AllocationResult {
 
   const waterfallConsumed = _round2(waterfallResults.reduce((sum, e) => sum + e.amount, 0));
   const postWaterfallResidual = _round2(remainingPool - waterfallConsumed);
-  if (postWaterfallResidual > 0) {
+
+  // Distribute residual equally among openended goals.
+  const openendedGoalCount = openendedGoalIndices.size;
+  const openendedShare = openendedGoalCount > 0
+    ? _round2(postWaterfallResidual / openendedGoalCount)
+    : 0;
+
+  // If residual remains AND there are no openended goals to absorb it, surface warning.
+  if (postWaterfallResidual > 0 && openendedGoalCount === 0) {
     globalWarnings.push(
       `Budget residuo di ${_fmtEur(postWaterfallResidual)} non allocato (tutti gli obiettivi sono stati finanziati per intero).`,
     );
@@ -201,9 +239,25 @@ export function computeAllocation(input: AllocationInput): AllocationResult {
   for (let i = 0; i < goals.length; i++) {
     const goal = goals[i]!;
     const isEmergency = i === emergencyIndex;
+    const isOpenended = openendedGoalIndices.has(i);
     const itemWarnings: string[] = [];
 
-    if (goal.target === 0) {
+    // ── Openended goal: receives equal share of post-waterfall residual (issue #464)
+    if (isOpenended) {
+      items.push({
+        goalId: goal.id,
+        monthlyAmount: openendedShare,
+        deadlineFeasible: true, // vacuously true — no deadline/target constraint
+        reasoning: _buildReasoning(goal, openendedShare, false, false, 0, postWaterfallResidual),
+        warnings: openendedShare === 0
+          ? ['Budget esaurito dagli obiettivi con target fisso: nessun residuo disponibile questo mese.']
+          : [],
+      });
+      continue;
+    }
+
+    // ── Fixed goal: target=0 or null (legacy guard)
+    if ((goal.target ?? 0) === 0) {
       items.push({
         goalId: goal.id, monthlyAmount: 0, deadlineFeasible: true,
         reasoning: 'Target non specificato',
@@ -212,7 +266,9 @@ export function computeAllocation(input: AllocationInput): AllocationResult {
       continue;
     }
 
+    // ── Emergency fixed goal
     if (isEmergency) {
+      const target = goal.target!; // non-null: _isEmergencyGoal gates on type='fixed'
       const deadlineDate = _parseDeadline(goal.deadline);
       let deadlineFeasible = true;
       if (deadlineDate !== null) {
@@ -221,14 +277,14 @@ export function computeAllocation(input: AllocationInput): AllocationResult {
           deadlineFeasible = false;
           itemWarnings.push('La scadenza di questo goal è già trascorsa.');
         } else if (emergencyAmount > 0) {
-          const remaining = Math.max(0, goal.target - goal.current);
+          const remaining = Math.max(0, target - goal.current);
           const reqM = monthsLeft > 0 ? remaining / monthsLeft : Infinity;
           if (reqM > emergencyAmount) {
             deadlineFeasible = false;
             itemWarnings.push(`Con ${_fmtEur(emergencyAmount)}/mese non sarà possibile raggiungere l'obiettivo entro la scadenza (necessari ${_fmtEur(reqM)}/mese).`);
           }
         } else {
-          const remaining = Math.max(0, goal.target - goal.current);
+          const remaining = Math.max(0, target - goal.current);
           if (remaining > 0) {
             deadlineFeasible = false;
             itemWarnings.push('Nessun importo allocato: la scadenza non sarà rispettata.');
@@ -243,17 +299,18 @@ export function computeAllocation(input: AllocationInput): AllocationResult {
       continue;
     }
 
+    // ── Standard waterfall fixed goal
     const entry = waterfallAmountMap.get(i);
     if (entry === undefined) {
-      // This branch is an invariant violation: every non-emergency goal with target > 0
-      // is added to otherGoals and must appear in waterfallAmountMap. If reached,
-      // the filter/sort logic has diverged from this loop.
+      // Invariant violation: every non-emergency fixed goal with target > 0 must
+      // appear in waterfallAmountMap. If reached, filter/sort logic has diverged.
       throw new Error(
-        `Invariant violation: missing waterfall allocation for non-emergency goal with target > 0 (goalId: ${goal.id}).`,
+        `Invariant violation: missing waterfall allocation for fixed goal (goalId: ${goal.id}).`,
       );
     }
 
     const { amount, requiredMonthly, remainingPoolBefore } = entry;
+    const target = goal.target!;
 
     const deadlineDate = _parseDeadline(goal.deadline);
     let deadlineFeasible = true;
@@ -270,7 +327,7 @@ export function computeAllocation(input: AllocationInput): AllocationResult {
           itemWarnings.push(`Budget insufficiente per raggiungere questo goal in tempo (necessari ${_fmtEur(requiredMonthly)}/mese, allocati ${_fmtEur(amount)}/mese).`);
         }
       } else {
-        const remaining = Math.max(0, goal.target - goal.current);
+        const remaining = Math.max(0, target - goal.current);
         if (remaining > 0) {
           deadlineFeasible = false;
           itemWarnings.push(`Budget insufficiente per raggiungere questo goal: importo allocato ${_fmtEur(0)}.`);
@@ -278,7 +335,7 @@ export function computeAllocation(input: AllocationInput): AllocationResult {
       }
     } else {
       if (amount === 0) {
-        const remaining = Math.max(0, goal.target - goal.current);
+        const remaining = Math.max(0, target - goal.current);
         if (remaining > 0) itemWarnings.push('Budget esaurito: questo goal non riceverà allocazione in questo mese.');
       }
     }

--- a/apps/web/src/services/onboarding-plan.client.ts
+++ b/apps/web/src/services/onboarding-plan.client.ts
@@ -52,7 +52,10 @@ export interface PersistPlanInput {
   };
   goals: Array<{
     name: string;
-    target: number;
+    /** 'fixed' (has target) | 'openended' (receives surplus). Issue #464. */
+    type: 'fixed' | 'openended';
+    /** null when type='openended'. */
+    target: number | null;
     deadline: string | null;
     priority: PriorityRank;
     monthlyAllocation: number;
@@ -181,6 +184,8 @@ export const onboardingPlanClient = {
         .insert({
           user_id: userId,
           name: g.name,
+          type: g.type,
+          // target: null is valid for openended goals (migration 20260420000000)
           target: g.target,
           current: 0,
           deadline: g.deadline,
@@ -292,7 +297,10 @@ export const onboardingPlanClient = {
     goals: Array<{
       id: string;
       name: string;
-      target: number;
+      /** 'fixed' | 'openended'. Issue #464. */
+      type: 'fixed' | 'openended';
+      /** null when type='openended'. */
+      target: number | null;
       current: number;
       deadline: string | null;
       priority: PriorityRank;
@@ -325,7 +333,7 @@ export const onboardingPlanClient = {
 
     const { data: goalRows, error: goalsErr } = await supabase
       .from('goals')
-      .select('id, name, target, current, deadline, priority, monthly_allocation, status')
+      .select('id, name, type, target, current, deadline, priority, monthly_allocation, status')
       .eq('user_id', userId)
       .eq('status', 'ACTIVE')
       .order('priority', { ascending: true });
@@ -354,7 +362,8 @@ export const onboardingPlanClient = {
       goals: goalRows.map((g) => ({
         id: g.id,
         name: g.name,
-        target: Number(g.target),
+        type: (g.type ?? 'fixed') as 'fixed' | 'openended',
+        target: g.target !== null ? Number(g.target) : null,
         current: Number(g.current),
         deadline: g.deadline,
         priority: g.priority as PriorityRank,

--- a/apps/web/src/types/onboarding-plan.ts
+++ b/apps/web/src/types/onboarding-plan.ts
@@ -29,6 +29,19 @@ export type GoalAllocationInsert = Database['public']['Tables']['goal_allocation
 export type GoalStatus = Database['public']['Enums']['goal_status'];
 
 // ─────────────────────────────────────────────────────────────────────────
+// Goal type (issue #464 — openended goals receive surplus, no target/deadline)
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * 'fixed'     — goal has a specific target amount and optional deadline.
+ *               Receives allocation via waterfall (priority-based).
+ * 'openended' — goal has no fixed target; receives residual pool after all
+ *               fixed goals are funded. Deadline vacuously feasible.
+ *               Typical use: Fondo Emergenza, Risparmio Generico.
+ */
+export type GoalType = 'fixed' | 'openended';
+
+// ─────────────────────────────────────────────────────────────────────────
 // Priority mapping (DB SMALLINT 1-3 <-> UI labels)
 // ─────────────────────────────────────────────────────────────────────────
 
@@ -51,14 +64,23 @@ export const PRIORITY_URGENCY_FACTOR: Record<PriorityRank, number> = {
 /**
  * Goal input to the allocation algorithm.
  * Subset of GoalRow relevant for allocation decisions.
+ *
+ * For openended goals:
+ *   - `type` = 'openended'
+ *   - `target` is null (no fixed target amount)
+ *   - `current` may still be > 0 (existing savings in the fund)
+ *   - `deadline` is null (no deadline for surplus collection)
  */
 export interface AllocationGoalInput {
   id: string;
   name: string;
-  target: number;
+  /** null when type='openended' */
+  target: number | null;
   current: number;
   deadline: string | null;
   priority: PriorityRank;
+  /** Defaults to 'fixed' for backward compat with pre-#464 data. */
+  type: GoalType;
 }
 
 /**
@@ -136,7 +158,10 @@ export interface WizardGoalDraft {
   /** Temp UUID for form state before DB insert. */
   tempId: string;
   name: string;
-  target: number;
+  /** Goal type: 'fixed' requires target > 0; 'openended' receives residual pool. */
+  type: GoalType;
+  /** null when type='openended'. */
+  target: number | null;
   deadline: string | null;
   priority: PriorityRank;
 }

--- a/apps/web/src/utils/supabase/database.types.ts
+++ b/apps/web/src/utils/supabase/database.types.ts
@@ -633,7 +633,10 @@ export type Database = {
           name: string
           priority: number
           status: Database["public"]["Enums"]["goal_status"]
-          target: number
+          /** null when type='openended'. Added in migration 20260420000000. */
+          target: number | null
+          /** 'fixed' | 'openended'. Added in migration 20260420000000. */
+          type: string
           updated_at: string
           user_id: string
         }
@@ -646,7 +649,10 @@ export type Database = {
           name: string
           priority: number
           status?: Database["public"]["Enums"]["goal_status"]
-          target: number
+          /** null when type='openended'. */
+          target?: number | null
+          /** Defaults to 'fixed'. */
+          type?: string
           updated_at?: string
           user_id: string
         }
@@ -659,7 +665,8 @@ export type Database = {
           name?: string
           priority?: number
           status?: Database["public"]["Enums"]["goal_status"]
-          target?: number
+          target?: number | null
+          type?: string
           updated_at?: string
           user_id?: string
         }

--- a/supabase/migrations/20260420000000_add_goal_type_openended.sql
+++ b/supabase/migrations/20260420000000_add_goal_type_openended.sql
@@ -1,0 +1,33 @@
+-- 20260420000000_add_goal_type_openended.sql
+-- Sprint 1.5.1 — Issue #464
+--
+-- Adds goal type (fixed vs openended) for flexible allocation model.
+-- Fondo Emergenza and similar "catch surplus" goals benefit from openended type
+-- where target and deadline are optional.
+--
+-- IMPORTANT: This migration is NOT applied automatically.
+-- Apply manually via: mcp__supabase__apply_migration (tier-1 confirm required).
+
+-- 1. Add type column with default 'fixed' for full backward compatibility.
+ALTER TABLE public.goals
+  ADD COLUMN type TEXT NOT NULL DEFAULT 'fixed' CHECK (type IN ('fixed', 'openended'));
+
+-- 2. Relax NOT NULL on target so openended goals can omit it.
+ALTER TABLE public.goals ALTER COLUMN target DROP NOT NULL;
+
+-- 3. Set default for target so INSERT without target still works for fixed goals
+--    created outside the wizard (back-compat with existing INSERT statements).
+ALTER TABLE public.goals ALTER COLUMN target SET DEFAULT NULL;
+
+-- 4. Enforce: if type='fixed', target must be set and > 0.
+ALTER TABLE public.goals
+  ADD CONSTRAINT goals_fixed_requires_target CHECK (
+    type = 'openended'
+    OR (type = 'fixed' AND target IS NOT NULL AND target > 0)
+  );
+
+-- 5. Index for filtering goals by type (low-cost, useful for allocation queries).
+CREATE INDEX IF NOT EXISTS idx_goals_type_user ON public.goals(user_id, type);
+
+-- Verify: existing rows default to 'fixed', target remains populated.
+-- No data migration required — target is still NOT NULL on all pre-migration rows.


### PR DESCRIPTION
## Summary

- Adds `type: 'fixed' | 'openended'` to goals — openended goals receive the residual savings pool after all fixed goals are funded via waterfall (Sprint 1.5.1 Wave 3, issue #464)
- Preset "Fondo Emergenza" now defaults to `openended` (no target, no deadline required)
- Custom goal form adds type toggle: "Con target fisso" vs "Goal aperto"
- Emergency floor (40%) now gated on `type === 'fixed'` — prevents null-target crash

## Migration required

**WARNING — schema change**: `supabase/migrations/20260420000000_add_goal_type_openended.sql`

This migration is NOT applied automatically. User must apply manually **before merging**:
```
mcp__supabase__apply_migration("20260420000000_add_goal_type_openended")
```

The migration:
1. Adds `goals.type TEXT NOT NULL DEFAULT 'fixed' CHECK (type IN ('fixed', 'openended'))`
2. Drops NOT NULL on `goals.target` (openended goals have null target)
3. Adds CHECK constraint: if type='fixed', target must be set and > 0
4. Adds index `idx_goals_type_user` on `(user_id, type)`

Existing goals default to 'fixed' — fully backward compatible.

## Files changed

- `supabase/migrations/20260420000000_add_goal_type_openended.sql` — NEW (not applied)
- `apps/web/src/types/onboarding-plan.ts` — GoalType, nullable target, type on WizardGoalDraft
- `apps/web/src/utils/supabase/database.types.ts` — manual update for goals.type + nullable target
- `apps/web/src/lib/onboarding/allocation.ts` — openended residual distribution, emergency gate
- `apps/web/src/components/onboarding/steps/StepGoals.tsx` — type toggle, openended form state
- `apps/web/src/components/onboarding/steps/StepPlanReview.tsx` — pass type to algorithm
- `apps/web/src/components/onboarding/WizardPianoGenerato.tsx` — pass type to persistPlan
- `apps/web/src/services/onboarding-plan.client.ts` — type in INSERT + loadPlan SELECT

## Test plan

- [x] 27 allocation tests pass (21 existing + 6 new #464 openended scenarios)
- [x] 13 StepGoals component tests pass (updated + 2 new)
- [x] Full test suite: 1631 passed, 2 skipped (0 failed)
- [x] Typecheck clean
- [ ] Migration: apply + verify via `psql` before merge

## Dependency

Builds on top of waterfall algorithm from #469 (already merged on develop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)