### PR TITLE
fix(onboarding): hotfix CRIT-03 reasoning + warning

### DIFF
--- a/apps/web/__tests__/lib/onboarding/allocation.test.ts
+++ b/apps/web/__tests__/lib/onboarding/allocation.test.ts
@@ -367,3 +367,74 @@ describe('computeAllocation -- beta+gamma waterfall (issue #458)', () => {
     expect(result.totalAllocated).toBeCloseTo(300, 2);
   });
 });
+
+describe('CRIT-03 hotfix regression (user screenshot bug)', () => {
+  beforeEach(() => {
+    _goalIdCounter = 0;
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-19T22:00:00Z'));
+  });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('non-emergency goal with priority=1 and short deadline is NOT treated as emergency', () => {
+    const input = makeInput({
+      monthlyIncome: 2250,
+      monthlySavingsTarget: 450,
+      essentialsPct: 78,
+      goals: [makeGoal({
+        id: 'debt-1',
+        name: 'Eliminare Debiti',
+        target: 3500,
+        current: 0,
+        deadline: '2026-05-19',
+        priority: 1,
+      })],
+    });
+    const result = computeAllocation(input);
+    expect(result.items[0].reasoning).not.toContain('Fondo di emergenza');
+    expect(result.items[0].reasoning).not.toContain('40%');
+    expect(result.items[0].reasoning.toLowerCase()).toMatch(/priorit\u00e0 alta/);
+  });
+
+  it('global warning reflects infeasible items correctly (non contradictory)', () => {
+    const input = makeInput({
+      monthlyIncome: 2250,
+      monthlySavingsTarget: 450,
+      essentialsPct: 78,
+      goals: [makeGoal({
+        id: 'debt-1',
+        name: 'Eliminare Debiti',
+        target: 3500,
+        current: 0,
+        deadline: '2026-05-19',
+        priority: 1,
+      })],
+    });
+    const result = computeAllocation(input);
+    const hasInfeasible = result.items.some((it) => !it.deadlineFeasible);
+    if (hasInfeasible && result.unallocated > 0) {
+      const residuoWarning = result.warnings.find((w) => w.includes('Budget residuo'));
+      expect(residuoWarning).toBeDefined();
+      expect(residuoWarning).not.toContain('finanziati per intero');
+      expect(residuoWarning).toMatch(/deadline non raggiungibile|considera/i);
+    }
+  });
+
+  it('emergency goal by name pattern IS detected correctly', () => {
+    const input = makeInput({
+      monthlyIncome: 3000,
+      monthlySavingsTarget: 500,
+      essentialsPct: 50,
+      goals: [makeGoal({
+        id: 'emergency-1',
+        name: 'Fondo Emergenza',
+        target: 5000,
+        current: 0,
+        deadline: '2027-04-19',
+        priority: 1,
+      })],
+    });
+    const result = computeAllocation(input);
+    expect(result.items[0].reasoning).toContain('Fondo di emergenza');
+  });
+});

--- a/apps/web/src/lib/onboarding/allocation.ts
+++ b/apps/web/src/lib/onboarding/allocation.ts
@@ -23,8 +23,6 @@ import type {
 
 const _EMERGENCY_NAME_PATTERN = /emergenza|emergency/i;
 const _EMERGENCY_OVERRIDE_FRACTION = 0.4;
-/** Maximum months-to-deadline for a priority=1 goal to be treated as emergency. */
-const _EMERGENCY_DEADLINE_MONTHS = 12;
 
 function _fmtEur(amount: number): string {
   return `€${amount.toLocaleString('it-IT', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
@@ -53,16 +51,8 @@ function _parseDeadline(deadline: string | null): Date | null {
   return new Date(year, month - 1, day);
 }
 
-function _isEmergencyGoal(goal: AllocationGoalInput, now: Date): boolean {
-  if (_EMERGENCY_NAME_PATTERN.test(goal.name)) return true;
-  if (goal.priority === 1) {
-    const deadlineDate = _parseDeadline(goal.deadline);
-    if (deadlineDate !== null) {
-      const months = _monthsDiff(now, deadlineDate);
-      if (months >= 0 && months <= _EMERGENCY_DEADLINE_MONTHS) return true;
-    }
-  }
-  return false;
+function _isEmergencyGoal(goal: AllocationGoalInput, _now: Date): boolean {
+  return _EMERGENCY_NAME_PATTERN.test(goal.name);
 }
 
 function _round2(n: number): number {
@@ -183,14 +173,6 @@ export function computeAllocation(input: AllocationInput): AllocationResult {
     }
   }
 
-  const waterfallConsumed = _round2(waterfallResults.reduce((sum, e) => sum + e.amount, 0));
-  const postWaterfallResidual = _round2(remainingPool - waterfallConsumed);
-  if (postWaterfallResidual > 0) {
-    globalWarnings.push(
-      `Budget residuo di ${_fmtEur(postWaterfallResidual)} non allocato (tutti gli obiettivi sono stati finanziati per intero).`,
-    );
-  }
-
   const waterfallAmountMap = new Map<number, _WaterfallEntry>();
   for (const entry of waterfallResults) {
     waterfallAmountMap.set(entry.originalIndex, entry);
@@ -292,5 +274,19 @@ export function computeAllocation(input: AllocationInput): AllocationResult {
 
   const totalAllocated = _round2(items.reduce((sum, it) => sum + it.monthlyAmount, 0));
   const unallocated = _round2(savingsPool - totalAllocated);
+
+  if (unallocated > 0) {
+    const hasInfeasibleItem = items.some((it) => it.deadlineFeasible === false);
+    if (hasInfeasibleItem) {
+      globalWarnings.push(
+        `Budget residuo di ${_fmtEur(unallocated)} non allocato. Alcuni obiettivi hanno deadline non raggiungibile con l'allocation corrente — considera di estendere deadline o ridurre target.`,
+      );
+    } else {
+      globalWarnings.push(
+        `Budget residuo di ${_fmtEur(unallocated)} non allocato (tutti gli obiettivi sono stati finanziati per intero).`,
+      );
+    }
+  }
+
   return { items, incomeAfterEssentials, totalAllocated, unallocated, warnings: globalWarnings };
 }


### PR DESCRIPTION
## Summary

- **Bug 1 (reasoning attribution)**: `_isEmergencyGoal` was matching non-emergency goals via `priority === 1 AND deadline <= 12 months` branch — causing "Fondo di emergenza 40%" reasoning text to be emitted for goals like "Eliminare Debiti". Fixed by removing the priority+deadline branch; emergency detection is now name-pattern-only (`/emergenza|emergency/i`).
- **Bug 2 (contradictory warning)**: The global "Budget residuo non allocato (tutti gli obiettivi finanziati per intero)" message was emitted before `items[]` was built, so it could not check `deadlineFeasible`. Moved the warning emission to post-items and added an `hasInfeasibleItem` guard that switches to a non-contradictory message when any item has `deadlineFeasible === false`.
- **Cleanup**: Removed unused `_EMERGENCY_DEADLINE_MONTHS` constant.

## Before / After

**User scenario**: income €2250, essentials 78%, savingsTarget €450, 1 goal "Eliminare Debiti" priority ALTA deadline 1 month.

| | Before | After |
|---|---|---|
| Reasoning | "Fondo di emergenza: allocazione prioritaria del 40%…" | "Priorità alta — waterfall: consumato €495,00 su €495,00 disponibili — importo mensile: €495,00" |
| Global warning | "€270 non allocato (tutti gli obiettivi finanziati per intero)" | Deadline non raggiungibile message (or absent if fully allocated) |

## Files changed

- `apps/web/src/lib/onboarding/allocation.ts` — 3 surgical fixes
- `apps/web/__tests__/lib/onboarding/allocation.test.ts` — +3 regression tests (24 total, all passing)

## Test plan

- [x] `pnpm vitest run __tests__/lib/onboarding/allocation.test.ts` — 24/24 passing
- [x] `pnpm lint` — 0 errors (3 pre-existing warnings unrelated to this PR)
- [x] `validate-ci.sh 8` — all 8 levels green
- [x] Pre-commit hooks passed (lint + typecheck + unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)