### PR TITLE
feat(settings): rifai onboarding tab (Sprint 1.5.2 WP-H)

### DIFF
--- a/apps/web/__tests__/pages/dashboard/settings.test.tsx
+++ b/apps/web/__tests__/pages/dashboard/settings.test.tsx
@@ -54,8 +54,25 @@ vi.mock('../../../src/utils/supabase/client', () => ({
   })),
 }));
 
+// Mock next/navigation for useRouter (App Router)
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: vi.fn(() => ({
+    push: mockPush,
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+  })),
+}));
+
+// Mock onboarding-plan client (exports REDO_ONBOARDING_PATH constant)
+vi.mock('../../../src/services/onboarding-plan.client', () => ({
+  REDO_ONBOARDING_PATH: '/onboarding/plan?mode=edit',
+  default: {},
+}));
+
 import SettingsPage from '../../../app/dashboard/settings/page';
 import { useAuthStore } from '../../../src/store/auth.store';
+import { fireEvent } from '@testing-library/react';
 const mockUseAuthStore = useAuthStore as unknown as ReturnType<typeof vi.fn>;
 
 // Mock user matching the User interface
@@ -109,7 +126,7 @@ describe('SettingsPage', () => {
   });
 
   describe('Tab Navigation', () => {
-    it('renders all 9 tab labels', () => {
+    it('renders all 10 tab labels', () => {
       render(<SettingsPage />);
 
       expect(screen.getByText('Profilo')).toBeInTheDocument();
@@ -118,6 +135,7 @@ describe('SettingsPage', () => {
       expect(screen.getByText('API Keys')).toBeInTheDocument();
       expect(screen.getByText('Piano')).toBeInTheDocument();
       expect(screen.getByText('Notifiche')).toBeInTheDocument();
+      expect(screen.getByText('Onboarding')).toBeInTheDocument();
       expect(screen.getByText('Integrazioni')).toBeInTheDocument();
       expect(screen.getByText('Sicurezza')).toBeInTheDocument();
       expect(screen.getByText('Dati')).toBeInTheDocument();
@@ -165,6 +183,67 @@ describe('SettingsPage', () => {
       render(<SettingsPage />);
 
       expect(screen.getByRole('button', { name: /Cambia Immagine/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('Onboarding Tab', () => {
+    const openOnboardingTab = () => {
+      render(<SettingsPage />);
+      fireEvent.click(screen.getByRole('button', { name: 'Onboarding' }));
+    };
+
+    it('renders the Onboarding tab section title', () => {
+      openOnboardingTab();
+      expect(screen.getByText('Rivedi il tuo piano finanziario')).toBeInTheDocument();
+    });
+
+    it('renders the description text', () => {
+      openOnboardingTab();
+      expect(screen.getByText(/Rifai il wizard di onboarding/)).toBeInTheDocument();
+      expect(screen.getByText(/I goal esistenti restano nello storico/)).toBeInTheDocument();
+    });
+
+    it('renders "Rivedi piano" primary button', () => {
+      openOnboardingTab();
+      expect(screen.getByRole('button', { name: /Rivedi piano/i })).toBeInTheDocument();
+    });
+
+    it('shows confirm dialog when "Rivedi piano" is clicked', () => {
+      openOnboardingTab();
+      fireEvent.click(screen.getByRole('button', { name: /Rivedi piano/i }));
+      expect(screen.getByText(/Sei sicuro\?/)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Procedi/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Annulla/i })).toBeInTheDocument();
+    });
+
+    it('hides confirm dialog when Annulla is clicked', () => {
+      openOnboardingTab();
+      fireEvent.click(screen.getByRole('button', { name: /Rivedi piano/i }));
+      fireEvent.click(screen.getByRole('button', { name: /Annulla/i }));
+      expect(screen.queryByText(/Sei sicuro\?/)).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Rivedi piano/i })).toBeInTheDocument();
+    });
+
+    it('navigates to onboarding edit path when Procedi is clicked', () => {
+      openOnboardingTab();
+      fireEvent.click(screen.getByRole('button', { name: /Rivedi piano/i }));
+      fireEvent.click(screen.getByRole('button', { name: /Procedi/i }));
+      expect(mockPush).toHaveBeenCalledWith('/onboarding/plan?mode=edit');
+    });
+
+    it('renders the "Reset completo" expandable section with "In arrivo" badge', () => {
+      openOnboardingTab();
+      expect(screen.getByText('Reset completo')).toBeInTheDocument();
+      expect(screen.getByText('In arrivo')).toBeInTheDocument();
+    });
+
+    it('expands the Reset completo section on click', () => {
+      openOnboardingTab();
+      expect(screen.queryByText(/eliminerà tutti i dati/)).not.toBeInTheDocument();
+      // The expand button is the one with aria-expanded attribute
+      const expandBtn = screen.getByRole('button', { name: /Reset completo/i });
+      fireEvent.click(expandBtn);
+      expect(screen.getByText(/eliminerà tutti i dati/)).toBeInTheDocument();
     });
   });
 

--- a/apps/web/app/dashboard/settings/page.tsx
+++ b/apps/web/app/dashboard/settings/page.tsx
@@ -10,6 +10,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 import { motion } from 'framer-motion';
 import { createClient } from '@/utils/supabase/client';
 import { CategoryManager } from '@/components/categories/CategoryManager';
@@ -27,6 +28,9 @@ import {
   Key,
   Monitor,
   Loader2,
+  RefreshCw,
+  ChevronDown,
+  ChevronRight,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -35,6 +39,7 @@ import { Card } from '@/components/ui/card';
 import { useAuthStore } from '@/store/auth.store';
 import { useTheme, type Theme } from '@/hooks/useTheme';
 import { userPreferencesClient } from '@/services/user-preferences.client';
+import { REDO_ONBOARDING_PATH } from '@/services/onboarding-plan.client';
 import type { UserPreferences } from '@/types/user-preferences';
 
 // =============================================================================
@@ -48,6 +53,7 @@ type TabKey =
   | 'apikeys'
   | 'plan'
   | 'notifications'
+  | 'onboarding'
   | 'integrations'
   | 'security'
   | 'data';
@@ -78,6 +84,7 @@ const TABS: { key: TabKey; label: string }[] = [
   { key: 'apikeys', label: 'API Keys' },
   { key: 'plan', label: 'Piano' },
   { key: 'notifications', label: 'Notifiche' },
+  { key: 'onboarding', label: 'Onboarding' },
   { key: 'integrations', label: 'Integrazioni' },
   { key: 'security', label: 'Sicurezza' },
   { key: 'data', label: 'Dati' },
@@ -98,7 +105,12 @@ const TOGGLE_CLASS =
 export default function SettingsPage() {
   const { user, setUser } = useAuthStore();
   const { theme, setTheme } = useTheme();
+  const router = useRouter();
   const [activeTab, setActiveTab] = useState<TabKey>('profile');
+
+  // Onboarding redo state
+  const [showRedoConfirm, setShowRedoConfirm] = useState(false);
+  const [showResetSection, setShowResetSection] = useState(false);
 
   // Profile state
   const [isSaving, setIsSaving] = useState(false);
@@ -528,6 +540,92 @@ export default function SettingsPage() {
       {/* Notifications Tab — real persistence to profiles.preferences.notifications */}
       {/* ================================================================= */}
       {activeTab === 'notifications' && <NotificationsTab />}
+
+      {/* ================================================================= */}
+      {/* Onboarding Tab — Rifai piano finanziario */}
+      {/* ================================================================= */}
+      {activeTab === 'onboarding' && (
+        <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} className="space-y-6">
+          <Card className="p-6 rounded-2xl border-0 shadow-sm">
+            <div className="flex items-start gap-4 mb-6">
+              <div className="w-12 h-12 rounded-2xl bg-gradient-to-br from-emerald-500 to-teal-500 flex items-center justify-center flex-shrink-0">
+                <RefreshCw className="w-6 h-6 text-white" />
+              </div>
+              <div>
+                <h3 className="text-lg font-semibold text-foreground">Rivedi il tuo piano finanziario</h3>
+                <p className="text-sm text-muted-foreground mt-1">
+                  Rifai il wizard di onboarding per aggiornare reddito, budget o obiettivi.
+                  Il piano corrente sarà sostituito con quello nuovo.
+                  I goal esistenti restano nello storico.
+                </p>
+              </div>
+            </div>
+
+            {!showRedoConfirm ? (
+              <Button
+                onClick={() => setShowRedoConfirm(true)}
+                className="bg-gradient-to-r from-emerald-500 to-teal-500 hover:from-emerald-600 hover:to-teal-600 text-white shadow-lg shadow-emerald-500/20 border-0"
+              >
+                <RefreshCw className="w-4 h-4 mr-2" />
+                Rivedi piano
+              </Button>
+            ) : (
+              <div className="rounded-2xl border border-amber-500/20 bg-amber-500/5 p-4 space-y-3">
+                <div className="flex items-center gap-2">
+                  <AlertCircle className="w-4 h-4 text-amber-500 flex-shrink-0" />
+                  <p className="text-sm font-medium text-amber-700 dark:text-amber-400">
+                    Sei sicuro? Il wizard si aprirà pre-popolato con i tuoi valori attuali.
+                  </p>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  Il piano corrente verrà sostituito al completamento. Puoi annullare in qualsiasi momento durante il wizard.
+                </p>
+                <div className="flex gap-2 pt-1">
+                  <Button
+                    onClick={() => router.push(REDO_ONBOARDING_PATH)}
+                    className="bg-gradient-to-r from-emerald-500 to-teal-500 hover:from-emerald-600 hover:to-teal-600 text-white border-0"
+                  >
+                    Procedi
+                  </Button>
+                  <Button
+                    variant="outline"
+                    onClick={() => setShowRedoConfirm(false)}
+                  >
+                    Annulla
+                  </Button>
+                </div>
+              </div>
+            )}
+          </Card>
+
+          {/* Reset completo — future work placeholder */}
+          <Card className="p-6 rounded-2xl border-0 shadow-sm">
+            <button
+              onClick={() => setShowResetSection((v) => !v)}
+              className="flex items-center justify-between w-full text-left group"
+              aria-expanded={showResetSection}
+            >
+              <div className="flex items-center gap-2">
+                <h3 className="text-base font-semibold text-foreground">Reset completo</h3>
+                <span className="text-[11px] font-medium px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
+                  In arrivo
+                </span>
+              </div>
+              {showResetSection ? (
+                <ChevronDown className="w-4 h-4 text-muted-foreground" />
+              ) : (
+                <ChevronRight className="w-4 h-4 text-muted-foreground" />
+              )}
+            </button>
+            {showResetSection && (
+              <p className="text-sm text-muted-foreground mt-3">
+                Il reset completo eliminerà tutti i dati dell&apos;account (transazioni, goal, piano)
+                e ricomincerai da zero. Questa funzionalità sarà disponibile in una prossima versione.
+              </p>
+            )}
+          </Card>
+        </motion.div>
+      )}
 
       {/* ================================================================= */}
       {/* Integrations Tab */}

--- a/apps/web/src/services/onboarding-plan.client.ts
+++ b/apps/web/src/services/onboarding-plan.client.ts
@@ -371,4 +371,16 @@ export const onboardingPlanClient = {
   },
 };
 
+// =============================================================================
+// Redo onboarding navigation helper
+// =============================================================================
+
+/**
+ * The path used by the "Rivedi piano" Settings flow to re-enter the onboarding
+ * wizard in edit mode (preserves existing goals in history, replaces plan on submit).
+ *
+ * Used by: Settings Onboarding tab (WP-H, Sprint 1.5.2)
+ */
+export const REDO_ONBOARDING_PATH = '/onboarding/plan?mode=edit' as const;
+
 export default onboardingPlanClient;


### PR DESCRIPTION
## Summary

- Adds new **Onboarding** tab to Settings page (between Notifiche and Integrazioni)
- Section title "Rivedi il tuo piano finanziario" with description preserving goals in history
- "Rivedi piano" primary button triggers inline confirm dialog; on confirm navigates to `/onboarding/plan?mode=edit`
- "Reset completo" expandable section with "In arrivo" badge (future work placeholder)
- Exports `REDO_ONBOARDING_PATH` constant from `onboarding-plan.client.ts` (consumed by settings page)

## Test plan

- [x] Unit: Onboarding tab renders section title + description
- [x] Unit: "Rivedi piano" button present
- [x] Unit: click "Rivedi piano" → confirm dialog appears (Sei sicuro?)
- [x] Unit: click "Annulla" → dialog dismisses, button returns
- [x] Unit: click "Procedi" → `router.push` called with `/onboarding/plan?mode=edit`
- [x] Unit: "Reset completo" + "In arrivo" badge visible
- [x] Unit: "Reset completo" expand reveals body text
- [x] Updated 9→10 tab count assertion in existing test
- [x] All 81 test files pass (1648 tests)
- [x] No new TypeScript errors (pre-existing `@money-wise/ui` unresolved is pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)