### PR TITLE
feat(dashboard): goals CRUD page (Sprint 1.5.2 WP-G)

### DIFF
--- a/apps/web/__tests__/components/goals/GoalCard.test.tsx
+++ b/apps/web/__tests__/components/goals/GoalCard.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * Tests for GoalCard component (Sprint 1.5.2 WP-G)
+ */
+
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '../../utils/test-utils';
+import userEvent from '@testing-library/user-event';
+import { GoalCard, inferGoalType } from '../../../src/components/goals/GoalCard';
+import type { Goal } from '../../../src/services/goals.client';
+
+const makeGoal = (overrides: Partial<Goal> = {}): Goal => ({
+  id: 'goal-1',
+  name: 'Test Goal',
+  target: 5000,
+  current: 1000,
+  deadline: '2027-12-31',
+  priority: 2,
+  monthlyAllocation: 200,
+  status: 'ACTIVE',
+  ...overrides,
+});
+
+describe('GoalCard', () => {
+  it('renders goal name', () => {
+    render(
+      <GoalCard
+        goal={makeGoal({ name: 'Fondo Emergenza' })}
+        onEditClick={vi.fn()}
+        onDeleteClick={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('goal-card-name')).toHaveTextContent('Fondo Emergenza');
+  });
+
+  it('renders goal target amount', () => {
+    render(
+      <GoalCard
+        goal={makeGoal({ target: 10000 })}
+        onEditClick={vi.fn()}
+        onDeleteClick={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('goal-card-target')).toHaveTextContent('10.000');
+  });
+
+  it('renders card with data-testid including goal id', () => {
+    render(
+      <GoalCard
+        goal={makeGoal({ id: 'abc-123' })}
+        onEditClick={vi.fn()}
+        onDeleteClick={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('goal-card-abc-123')).toBeInTheDocument();
+  });
+
+  it('calls onEditClick when card is clicked', async () => {
+    const user = userEvent.setup({ delay: null });
+    const onEditClick = vi.fn();
+    const goal = makeGoal();
+    render(
+      <GoalCard goal={goal} onEditClick={onEditClick} onDeleteClick={vi.fn()} />,
+    );
+
+    await user.click(screen.getByTestId('goal-card-goal-1'));
+    expect(onEditClick).toHaveBeenCalledWith(goal);
+  });
+
+  it('calls onDeleteClick when delete button clicked (does not trigger edit)', async () => {
+    const user = userEvent.setup({ delay: null });
+    const onEditClick = vi.fn();
+    const onDeleteClick = vi.fn();
+    const goal = makeGoal();
+    render(
+      <GoalCard goal={goal} onEditClick={onEditClick} onDeleteClick={onDeleteClick} />,
+    );
+
+    await user.click(screen.getByTestId('goal-delete-goal-1'));
+    expect(onDeleteClick).toHaveBeenCalledWith('goal-1');
+    expect(onEditClick).not.toHaveBeenCalled();
+  });
+
+  it('shows "Nessuna" when no deadline', () => {
+    render(
+      <GoalCard
+        goal={makeGoal({ deadline: null })}
+        onEditClick={vi.fn()}
+        onDeleteClick={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('goal-card-deadline')).toHaveTextContent('Nessuna');
+  });
+});
+
+describe('inferGoalType', () => {
+  it('infers emergency from "Fondo Emergenza"', () => {
+    expect(inferGoalType('Fondo Emergenza')).toBe('emergency');
+  });
+
+  it('infers debt from "Eliminare Debiti"', () => {
+    expect(inferGoalType('Eliminare Debiti')).toBe('debt');
+  });
+
+  it('infers investment from "Iniziare a Investire"', () => {
+    expect(inferGoalType('Iniziare a Investire')).toBe('investment');
+  });
+
+  it('infers savings by default for unknown names', () => {
+    expect(inferGoalType('Comprare Casa')).toBe('savings');
+  });
+});

--- a/apps/web/__tests__/components/goals/GoalEditModal.test.tsx
+++ b/apps/web/__tests__/components/goals/GoalEditModal.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * Tests for GoalEditModal component (Sprint 1.5.2 WP-G)
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '../../utils/test-utils';
+import userEvent from '@testing-library/user-event';
+import { GoalEditModal } from '../../../src/components/goals/GoalEditModal';
+import type { Goal } from '../../../src/services/goals.client';
+
+const mockGoal: Goal = {
+  id: 'goal-42',
+  name: 'Fondo Emergenza',
+  target: 5000,
+  current: 0,
+  deadline: '2027-06-01',
+  priority: 1,
+  monthlyAllocation: 300,
+  status: 'ACTIVE',
+};
+
+describe('GoalEditModal', () => {
+  it('renders "Nuovo obiettivo" title in add mode', () => {
+    render(
+      <GoalEditModal
+        open={true}
+        mode="add"
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('goal-modal-title')).toHaveTextContent('Nuovo obiettivo');
+  });
+
+  it('renders "Modifica obiettivo" title in edit mode', () => {
+    render(
+      <GoalEditModal
+        open={true}
+        mode="edit"
+        goal={mockGoal}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('goal-modal-title')).toHaveTextContent('Modifica obiettivo');
+  });
+
+  it('pre-fills form fields in edit mode', () => {
+    render(
+      <GoalEditModal
+        open={true}
+        mode="edit"
+        goal={mockGoal}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('goal-modal-name')).toHaveValue('Fondo Emergenza');
+    expect(screen.getByTestId('goal-modal-target')).toHaveValue(5000);
+  });
+
+  it('shows empty name field in add mode', () => {
+    render(
+      <GoalEditModal
+        open={true}
+        mode="add"
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('goal-modal-name')).toHaveValue('');
+  });
+
+  it('calls onSave with form data when save button clicked', async () => {
+    const user = userEvent.setup({ delay: null });
+    const onSave = vi.fn();
+    render(
+      <GoalEditModal
+        open={true}
+        mode="add"
+        onSave={onSave}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    await user.clear(screen.getByTestId('goal-modal-name'));
+    await user.type(screen.getByTestId('goal-modal-name'), 'Nuovo Goal');
+
+    const targetInput = screen.getByTestId('goal-modal-target');
+    await user.clear(targetInput);
+    await user.type(targetInput, '3000');
+
+    await user.click(screen.getByTestId('goal-modal-save'));
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Nuovo Goal',
+        target: 3000,
+      }),
+    );
+  });
+
+  it('shows validation error when name is empty', async () => {
+    const user = userEvent.setup({ delay: null });
+    const onSave = vi.fn();
+    render(
+      <GoalEditModal
+        open={true}
+        mode="add"
+        onSave={onSave}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    // target > 0 but name empty
+    await user.clear(screen.getByTestId('goal-modal-target'));
+    await user.type(screen.getByTestId('goal-modal-target'), '1000');
+
+    await user.click(screen.getByTestId('goal-modal-save'));
+
+    expect(screen.getByTestId('goal-modal-name-error')).toBeInTheDocument();
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('shows validation error when target is 0', async () => {
+    const user = userEvent.setup({ delay: null });
+    const onSave = vi.fn();
+    render(
+      <GoalEditModal
+        open={true}
+        mode="add"
+        onSave={onSave}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    await user.type(screen.getByTestId('goal-modal-name'), 'My Goal');
+    // target stays 0
+
+    await user.click(screen.getByTestId('goal-modal-save'));
+
+    expect(screen.getByTestId('goal-modal-target-error')).toBeInTheDocument();
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('calls onCancel when cancel button clicked', async () => {
+    const user = userEvent.setup({ delay: null });
+    const onCancel = vi.fn();
+    render(
+      <GoalEditModal
+        open={true}
+        mode="add"
+        onSave={vi.fn()}
+        onCancel={onCancel}
+      />,
+    );
+
+    await user.click(screen.getByTestId('goal-modal-cancel'));
+    // onCancel is triggered via onOpenChange(false)
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('does not render modal content when closed', () => {
+    render(
+      <GoalEditModal
+        open={false}
+        mode="add"
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId('goal-edit-modal')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/__tests__/components/goals/GoalTypeFilter.test.tsx
+++ b/apps/web/__tests__/components/goals/GoalTypeFilter.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * Tests for GoalTypeFilter component (Sprint 1.5.2 WP-G)
+ */
+
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '../../utils/test-utils';
+import userEvent from '@testing-library/user-event';
+import { GoalTypeFilter } from '../../../src/components/goals/GoalTypeFilter';
+import type { GoalType } from '../../../src/components/goals/GoalTypeFilter';
+
+describe('GoalTypeFilter', () => {
+  it('renders all 6 chips', () => {
+    const onTypeSelect = vi.fn();
+    render(<GoalTypeFilter selected="all" onTypeSelect={onTypeSelect} />);
+
+    expect(screen.getByTestId('filter-chip-all')).toBeInTheDocument();
+    expect(screen.getByTestId('filter-chip-emergency')).toBeInTheDocument();
+    expect(screen.getByTestId('filter-chip-savings')).toBeInTheDocument();
+    expect(screen.getByTestId('filter-chip-investment')).toBeInTheDocument();
+    expect(screen.getByTestId('filter-chip-debt')).toBeInTheDocument();
+    expect(screen.getByTestId('filter-chip-lifestyle')).toBeInTheDocument();
+  });
+
+  it('marks selected chip with aria-pressed=true', () => {
+    render(<GoalTypeFilter selected="savings" onTypeSelect={vi.fn()} />);
+
+    expect(screen.getByTestId('filter-chip-savings')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('filter-chip-all')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('calls onTypeSelect with the correct type when a chip is clicked', async () => {
+    const user = userEvent.setup({ delay: null });
+    const onTypeSelect = vi.fn();
+    render(<GoalTypeFilter selected="all" onTypeSelect={onTypeSelect} />);
+
+    await user.click(screen.getByTestId('filter-chip-emergency'));
+    expect(onTypeSelect).toHaveBeenCalledWith('emergency');
+  });
+
+  it('calls onTypeSelect with "all" when Tutti chip clicked', async () => {
+    const user = userEvent.setup({ delay: null });
+    const onTypeSelect = vi.fn();
+    render(<GoalTypeFilter selected="debt" onTypeSelect={onTypeSelect} />);
+
+    await user.click(screen.getByTestId('filter-chip-all'));
+    expect(onTypeSelect).toHaveBeenCalledWith('all');
+  });
+});

--- a/apps/web/__tests__/pages/dashboard/goals.test.tsx
+++ b/apps/web/__tests__/pages/dashboard/goals.test.tsx
@@ -1,46 +1,24 @@
 /**
- * Tests for GoalsPage component (Sprint 1.5 refactor)
+ * Tests for GoalsPage CRUD (Sprint 1.5.2 WP-G)
  *
- * Post-Sprint-1.5: GoalsPage fetches real data via onboardingPlanClient.loadPlan(userId).
- * Legacy hardcoded goalsData mock (Fondo Emergenza/Anticipo Casa/etc.) removed — those
- * assertions belonged to Sprint 1.2 Figma-derived mock.
- *
- * Current tests cover the new states:
- *  - Loading (no user/fetching)
- *  - Empty (no plan yet → CTA "Crea il tuo piano")
- *  - Error and Happy path: covered by `onboarding-plan.spec.ts` e2e (Playwright) +
- *    integration with Supabase, not by component unit tests.
+ * Uses data-testid attributes for robust element matching.
+ * Mocks goalsClient with vi.fn() per method.
  */
 
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '../../utils/test-utils';
+import userEvent from '@testing-library/user-event';
 
-// Mock framer-motion
-vi.mock('framer-motion', () => ({
-  motion: new Proxy({}, {
-    get: (_target: unknown, prop: string | symbol) => {
-      if (prop === '__esModule') return false;
-      return ({ children, initial, animate, exit, transition, whileHover, whileTap, whileInView, variants, ...rest }: Record<string, unknown>) => {
-        const Tag = typeof prop === 'string' ? prop : 'div';
-        return React.createElement(Tag as string, rest, children as React.ReactNode);
-      };
-    },
-  }),
-  AnimatePresence: ({ children }: { children: React.ReactNode }) => children,
-}));
+// Mock Radix dialog portals
+vi.mock('@radix-ui/react-dialog', async () => {
+  const actual = await vi.importActual<typeof import('@radix-ui/react-dialog')>(
+    '@radix-ui/react-dialog',
+  );
+  return actual;
+});
 
-// Mock useRouter (Next.js App Router) — default stub
-vi.mock('next/navigation', () => ({
-  useRouter: () => ({
-    push: vi.fn(),
-    replace: vi.fn(),
-    refresh: vi.fn(),
-    back: vi.fn(),
-  }),
-}));
-
-// Mock auth store — default returns no user
+// Mock auth store
 const mockAuthStore = vi.fn();
 vi.mock('@/store/auth.store', () => ({
   useAuthStore: (selector?: (s: unknown) => unknown) => {
@@ -49,65 +27,260 @@ vi.mock('@/store/auth.store', () => ({
   },
 }));
 
-// Mock onboarding-plan client — default returns null (no plan)
-const mockLoadPlan = vi.fn();
-vi.mock('@/services/onboarding-plan.client', async () => {
-  const actual = await vi.importActual<typeof import('@/services/onboarding-plan.client')>(
-    '@/services/onboarding-plan.client',
+// Mock goalsClient
+const mockLoadGoals = vi.fn();
+const mockAddGoal = vi.fn();
+const mockUpdateGoal = vi.fn();
+const mockDeleteGoal = vi.fn();
+
+vi.mock('@/services/goals.client', async () => {
+  const actual = await vi.importActual<typeof import('@/services/goals.client')>(
+    '@/services/goals.client',
   );
   return {
     ...actual,
-    onboardingPlanClient: {
-      loadPlan: (...args: unknown[]) => mockLoadPlan(...args),
-      persistPlan: vi.fn(),
+    goalsClient: {
+      loadGoals: (...args: unknown[]) => mockLoadGoals(...args),
+      addGoal: (...args: unknown[]) => mockAddGoal(...args),
+      updateGoal: (...args: unknown[]) => mockUpdateGoal(...args),
+      deleteGoal: (...args: unknown[]) => mockDeleteGoal(...args),
     },
   };
 });
 
 import GoalsPage from '../../../app/dashboard/goals/page';
 
-describe('GoalsPage (Sprint 1.5)', () => {
+const MOCK_GOAL = {
+  id: 'goal-1',
+  name: 'Fondo Emergenza',
+  target: 5000,
+  current: 1000,
+  deadline: '2027-12-31',
+  priority: 1 as const,
+  monthlyAllocation: 200,
+  status: 'ACTIVE',
+};
+
+describe('GoalsPage (Sprint 1.5.2 WP-G)', () => {
   beforeEach(() => {
     mockAuthStore.mockReset();
-    mockLoadPlan.mockReset();
+    mockLoadGoals.mockReset();
+    mockAddGoal.mockReset();
+    mockUpdateGoal.mockReset();
+    mockDeleteGoal.mockReset();
+
+    // Default: logged in user
+    mockAuthStore.mockReturnValue({ user: { id: 'user-uuid' } });
   });
 
-  describe('Loading / no-user state', () => {
-    it('renders without crashing when user is null (early return to stop spinner)', () => {
-      mockAuthStore.mockReturnValue({ user: null });
-      mockLoadPlan.mockResolvedValue(null);
+  // ---------------------------------------------------------------------------
+  // Loading state
+  // ---------------------------------------------------------------------------
 
-      render(<GoalsPage />);
+  it('shows loading spinner initially', () => {
+    // loadGoals never resolves during this test
+    mockLoadGoals.mockReturnValue(new Promise(() => {}));
+    render(<GoalsPage />);
+    expect(screen.getByTestId('goals-loading')).toBeInTheDocument();
+  });
 
-      // Either empty-state or loading — both acceptable on initial render.
-      // Primary assertion: page title region OR loading spinner OR empty state CTA.
-      // We just ensure it mounted.
-      expect(document.body).toBeTruthy();
+  // ---------------------------------------------------------------------------
+  // Empty state
+  // ---------------------------------------------------------------------------
+
+  it('shows empty state when no goals', async () => {
+    mockLoadGoals.mockResolvedValue([]);
+    render(<GoalsPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId('goals-empty-state')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('goals-empty-cta')).toBeInTheDocument();
+  });
+
+  it('renders page heading "Obiettivi"', async () => {
+    mockLoadGoals.mockResolvedValue([]);
+    render(<GoalsPage />);
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Obiettivi');
     });
   });
 
-  describe('Empty state (no plan yet)', () => {
-    it('shows CTA "Crea il tuo piano" when loadPlan returns null', async () => {
-      mockAuthStore.mockReturnValue({ user: { id: 'test-user-uuid' } });
-      mockLoadPlan.mockResolvedValue(null);
+  // ---------------------------------------------------------------------------
+  // Happy path — goals loaded
+  // ---------------------------------------------------------------------------
 
-      render(<GoalsPage />);
+  it('renders goal cards when goals exist', async () => {
+    mockLoadGoals.mockResolvedValue([MOCK_GOAL]);
+    render(<GoalsPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId('goals-grid')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('goal-card-goal-1')).toBeInTheDocument();
+  });
 
-      await waitFor(() => {
-        expect(screen.getByText(/Nessun piano finanziario ancora/i)).toBeInTheDocument();
-      });
-      expect(screen.getByRole('button', { name: /Crea il tuo piano/i })).toBeInTheDocument();
+  it('shows filter chips when goals exist', async () => {
+    mockLoadGoals.mockResolvedValue([MOCK_GOAL]);
+    render(<GoalsPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId('goal-type-filter')).toBeInTheDocument();
+    });
+  });
+
+  it('filters goals by type when chip clicked', async () => {
+    const user = userEvent.setup({ delay: null });
+    const investGoal = {
+      ...MOCK_GOAL,
+      id: 'goal-2',
+      name: 'Portafoglio Investimenti',
+    };
+    mockLoadGoals.mockResolvedValue([MOCK_GOAL, investGoal]);
+    render(<GoalsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('goals-grid')).toBeInTheDocument();
     });
 
-    it('renders page heading in Italian', async () => {
-      mockAuthStore.mockReturnValue({ user: { id: 'test-user-uuid' } });
-      mockLoadPlan.mockResolvedValue(null);
+    // Both visible initially
+    expect(screen.getByTestId('goal-card-goal-1')).toBeInTheDocument();
+    expect(screen.getByTestId('goal-card-goal-2')).toBeInTheDocument();
 
-      render(<GoalsPage />);
+    // Filter to investment
+    await user.click(screen.getByTestId('filter-chip-investment'));
 
-      await waitFor(() => {
-        expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Obiettivi');
-      });
+    // Only invest goal visible
+    expect(screen.queryByTestId('goal-card-goal-1')).not.toBeInTheDocument();
+    expect(screen.getByTestId('goal-card-goal-2')).toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Add goal flow
+  // ---------------------------------------------------------------------------
+
+  it('opens add modal when floating add button clicked', async () => {
+    const user = userEvent.setup({ delay: null });
+    mockLoadGoals.mockResolvedValue([]);
+
+    render(<GoalsPage />);
+    await waitFor(() => expect(screen.getByTestId('goals-empty-state')).toBeInTheDocument());
+
+    await user.click(screen.getByTestId('goals-add-btn'));
+    expect(screen.getByTestId('goal-edit-modal')).toBeInTheDocument();
+    expect(screen.getByTestId('goal-modal-title')).toHaveTextContent('Nuovo obiettivo');
+  });
+
+  it('adds goal and shows it in grid after save', async () => {
+    const user = userEvent.setup({ delay: null });
+    mockLoadGoals.mockResolvedValue([]);
+    const newGoal = { ...MOCK_GOAL, id: 'new-1', name: 'Nuovo Test Goal' };
+    mockAddGoal.mockResolvedValue(newGoal);
+
+    render(<GoalsPage />);
+    await waitFor(() => expect(screen.getByTestId('goals-add-btn')).toBeInTheDocument());
+
+    await user.click(screen.getByTestId('goals-add-btn'));
+    await user.type(screen.getByTestId('goal-modal-name'), 'Nuovo Test Goal');
+    await user.clear(screen.getByTestId('goal-modal-target'));
+    await user.type(screen.getByTestId('goal-modal-target'), '3000');
+    await user.click(screen.getByTestId('goal-modal-save'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('goal-card-new-1')).toBeInTheDocument();
     });
+    expect(mockAddGoal).toHaveBeenCalledWith('user-uuid', expect.objectContaining({ name: 'Nuovo Test Goal', target: 3000 }));
+  });
+
+  // ---------------------------------------------------------------------------
+  // Edit goal flow
+  // ---------------------------------------------------------------------------
+
+  it('opens edit modal pre-filled when card clicked', async () => {
+    const user = userEvent.setup({ delay: null });
+    mockLoadGoals.mockResolvedValue([MOCK_GOAL]);
+
+    render(<GoalsPage />);
+    await waitFor(() => expect(screen.getByTestId('goal-card-goal-1')).toBeInTheDocument());
+
+    await user.click(screen.getByTestId('goal-card-goal-1'));
+    expect(screen.getByTestId('goal-modal-title')).toHaveTextContent('Modifica obiettivo');
+    expect(screen.getByTestId('goal-modal-name')).toHaveValue('Fondo Emergenza');
+  });
+
+  it('calls updateGoal and reflects change after edit save', async () => {
+    const user = userEvent.setup({ delay: null });
+    mockLoadGoals.mockResolvedValue([MOCK_GOAL]);
+    const updated = { ...MOCK_GOAL, target: 8000 };
+    mockUpdateGoal.mockResolvedValue(updated);
+
+    render(<GoalsPage />);
+    await waitFor(() => expect(screen.getByTestId('goal-card-goal-1')).toBeInTheDocument());
+
+    await user.click(screen.getByTestId('goal-card-goal-1'));
+    await user.clear(screen.getByTestId('goal-modal-target'));
+    await user.type(screen.getByTestId('goal-modal-target'), '8000');
+    await user.click(screen.getByTestId('goal-modal-save'));
+
+    expect(mockUpdateGoal).toHaveBeenCalledWith('goal-1', expect.objectContaining({ target: 8000 }));
+    await waitFor(() => {
+      expect(screen.getByTestId('goal-card-goal-1')).toBeInTheDocument();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Delete goal flow
+  // ---------------------------------------------------------------------------
+
+  it('shows delete confirm dialog when delete button clicked', async () => {
+    const user = userEvent.setup({ delay: null });
+    mockLoadGoals.mockResolvedValue([MOCK_GOAL]);
+
+    render(<GoalsPage />);
+    await waitFor(() => expect(screen.getByTestId('goal-card-goal-1')).toBeInTheDocument());
+
+    await user.click(screen.getByTestId('goal-delete-goal-1'));
+    expect(screen.getByTestId('delete-confirm-dialog')).toBeInTheDocument();
+  });
+
+  it('removes goal from list after delete confirmed', async () => {
+    const user = userEvent.setup({ delay: null });
+    mockLoadGoals.mockResolvedValue([MOCK_GOAL]);
+    mockDeleteGoal.mockResolvedValue(undefined);
+
+    render(<GoalsPage />);
+    await waitFor(() => expect(screen.getByTestId('goal-card-goal-1')).toBeInTheDocument());
+
+    await user.click(screen.getByTestId('goal-delete-goal-1'));
+    await user.click(screen.getByTestId('delete-confirm-ok'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('goal-card-goal-1')).not.toBeInTheDocument();
+    });
+    expect(mockDeleteGoal).toHaveBeenCalledWith('goal-1');
+  });
+
+  it('cancels delete and keeps goal in list', async () => {
+    const user = userEvent.setup({ delay: null });
+    mockLoadGoals.mockResolvedValue([MOCK_GOAL]);
+
+    render(<GoalsPage />);
+    await waitFor(() => expect(screen.getByTestId('goal-card-goal-1')).toBeInTheDocument());
+
+    await user.click(screen.getByTestId('goal-delete-goal-1'));
+    await user.click(screen.getByTestId('delete-confirm-cancel'));
+
+    expect(screen.getByTestId('goal-card-goal-1')).toBeInTheDocument();
+    expect(mockDeleteGoal).not.toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Error state
+  // ---------------------------------------------------------------------------
+
+  it('shows error message when loadGoals throws', async () => {
+    mockLoadGoals.mockRejectedValue(new Error('Network error'));
+    render(<GoalsPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId('goals-error')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('goals-error-message')).toHaveTextContent('Network error');
   });
 });

--- a/apps/web/app/dashboard/goals/page.tsx
+++ b/apps/web/app/dashboard/goals/page.tsx
@@ -1,64 +1,155 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useEffect, useState, useCallback } from 'react';
+import { Plus, Target, Loader2 } from 'lucide-react';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import { Progress } from '@/components/ui/progress';
-import { motion } from 'framer-motion';
-import { Plus, Sparkles, Calendar, Loader2, Target } from 'lucide-react';
 import { useAuthStore } from '@/store/auth.store';
-import { onboardingPlanClient, OnboardingPlanApiError } from '@/services/onboarding-plan.client';
-import { PRIORITY_LABEL_IT, type PriorityRank } from '@/types/onboarding-plan';
+import { goalsClient, GoalsApiError } from '@/services/goals.client';
+import type { Goal, GoalInput } from '@/services/goals.client';
+import { GoalCard, inferGoalType } from '@/components/goals/GoalCard';
+import { GoalEditModal } from '@/components/goals/GoalEditModal';
+import { GoalTypeFilter } from '@/components/goals/GoalTypeFilter';
+import type { GoalType } from '@/components/goals/GoalTypeFilter';
+import * as Dialog from '@radix-ui/react-dialog';
 
-type PlanBundle = Awaited<ReturnType<typeof onboardingPlanClient.loadPlan>>;
-
-const PRIORITY_COLOR: Record<PriorityRank, { bg: string; text: string; light: string }> = {
-  1: { bg: 'bg-blue-600', text: 'text-blue-600', light: 'bg-blue-50 dark:bg-blue-950/30' },
-  2: { bg: 'bg-orange-600', text: 'text-orange-600', light: 'bg-orange-50 dark:bg-orange-950/30' },
-  3: { bg: 'bg-emerald-600', text: 'text-emerald-600', light: 'bg-emerald-50 dark:bg-emerald-950/30' },
-};
+// =============================================================================
+// GoalsPage
+// =============================================================================
 
 export default function GoalsPage() {
-  const router = useRouter();
   const userId = useAuthStore((s) => s.user?.id);
-  const [bundle, setBundle] = useState<PlanBundle>(null);
+
+  // Goals data
+  const [goals, setGoals] = useState<Goal[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
+  // Filter
+  const [selectedType, setSelectedType] = useState<GoalType>('all');
+
+  // Edit modal
+  const [editModalOpen, setEditModalOpen] = useState(false);
+  const [editMode, setEditMode] = useState<'add' | 'edit'>('add');
+  const [editingGoal, setEditingGoal] = useState<Goal | undefined>(undefined);
+
+  // Delete confirm
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+  const [deletingGoalId, setDeletingGoalId] = useState<string | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  // ---------------------------------------------------------------------------
+  // Load
+  // ---------------------------------------------------------------------------
+
+  const loadGoals = useCallback(async () => {
     if (!userId) {
       setIsLoading(false);
       return;
     }
-    let cancelled = false;
-    (async () => {
-      try {
-        const result = await onboardingPlanClient.loadPlan(userId);
-        if (!cancelled) setBundle(result);
-      } catch (err) {
-        if (!cancelled) {
-          const msg =
-            err instanceof OnboardingPlanApiError
-              ? err.message
-              : err instanceof Error
-                ? err.message
-                : 'Errore caricamento obiettivi';
-          setError(msg);
-        }
-      } finally {
-        if (!cancelled) setIsLoading(false);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await goalsClient.loadGoals(userId);
+      setGoals(data);
+    } catch (err) {
+      setError(
+        err instanceof GoalsApiError || err instanceof Error
+          ? err.message
+          : 'Errore caricamento obiettivi',
+      );
+    } finally {
+      setIsLoading(false);
+    }
   }, [userId]);
+
+  useEffect(() => {
+    loadGoals();
+  }, [loadGoals]);
+
+  // ---------------------------------------------------------------------------
+  // Filtered goals
+  // ---------------------------------------------------------------------------
+
+  const filteredGoals =
+    selectedType === 'all'
+      ? goals
+      : goals.filter((g) => inferGoalType(g.name) === selectedType);
+
+  // ---------------------------------------------------------------------------
+  // Handlers
+  // ---------------------------------------------------------------------------
+
+  const handleAddClick = () => {
+    setEditMode('add');
+    setEditingGoal(undefined);
+    setEditModalOpen(true);
+  };
+
+  const handleEditClick = (goal: Goal) => {
+    setEditMode('edit');
+    setEditingGoal(goal);
+    setEditModalOpen(true);
+  };
+
+  const handleModalSave = async (data: GoalInput) => {
+    if (!userId) return;
+    setEditModalOpen(false);
+    try {
+      if (editMode === 'add') {
+        const newGoal = await goalsClient.addGoal(userId, data);
+        setGoals((prev) => [...prev, newGoal]);
+      } else if (editingGoal) {
+        const updated = await goalsClient.updateGoal(editingGoal.id, data);
+        setGoals((prev) => prev.map((g) => (g.id === updated.id ? updated : g)));
+      }
+    } catch (err) {
+      setError(
+        err instanceof GoalsApiError || err instanceof Error
+          ? err.message
+          : 'Errore durante il salvataggio',
+      );
+    }
+  };
+
+  const handleModalCancel = () => {
+    setEditModalOpen(false);
+    setEditingGoal(undefined);
+  };
+
+  const handleDeleteClick = (goalId: string) => {
+    setDeletingGoalId(goalId);
+    setDeleteConfirmOpen(true);
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!deletingGoalId) return;
+    setIsDeleting(true);
+    try {
+      await goalsClient.deleteGoal(deletingGoalId);
+      setGoals((prev) => prev.filter((g) => g.id !== deletingGoalId));
+    } catch (err) {
+      setError(
+        err instanceof GoalsApiError || err instanceof Error
+          ? err.message
+          : 'Errore durante l\'eliminazione',
+      );
+    } finally {
+      setIsDeleting(false);
+      setDeleteConfirmOpen(false);
+      setDeletingGoalId(null);
+    }
+  };
+
+  const deletingGoalName = goals.find((g) => g.id === deletingGoalId)?.name ?? 'questo obiettivo';
+
+  // ---------------------------------------------------------------------------
+  // Render states
+  // ---------------------------------------------------------------------------
 
   if (isLoading) {
     return (
-      <div className="p-6 max-w-7xl mx-auto">
+      <div className="p-6 max-w-7xl mx-auto" data-testid="goals-loading">
         <div className="flex items-center justify-center py-20">
           <Loader2 className="w-8 h-8 animate-spin text-muted-foreground" />
         </div>
@@ -68,217 +159,157 @@ export default function GoalsPage() {
 
   if (error) {
     return (
-      <div className="p-6 max-w-7xl mx-auto">
+      <div className="p-6 max-w-7xl mx-auto" data-testid="goals-error">
         <Card className="p-6 border-l-4 border-l-red-500">
           <p className="text-sm font-semibold text-foreground">Errore caricamento obiettivi</p>
-          <p className="text-sm text-muted-foreground mt-1">{error}</p>
-        </Card>
-      </div>
-    );
-  }
-
-  // Empty state: no plan yet → CTA to onboarding wizard
-  if (!bundle) {
-    return (
-      <div className="p-6 max-w-7xl mx-auto">
-        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
-          <div>
-            <h1 className="text-3xl font-bold text-foreground">Obiettivi</h1>
-            <p className="text-muted-foreground mt-1">Crea il tuo piano finanziario personalizzato</p>
-          </div>
-        </div>
-        <Card className="p-12 text-center border-dashed">
-          <Target className="w-12 h-12 mx-auto text-muted-foreground mb-4" />
-          <h2 className="text-lg font-semibold text-foreground">Nessun piano finanziario ancora</h2>
-          <p className="text-sm text-muted-foreground mt-2 max-w-md mx-auto">
-            Inizia l&apos;onboarding &quot;Piano Generato&quot; per costruire il tuo primo piano in 5 passi:
-            reddito, obiettivi di risparmio, goal, allocazione automatica.
+          <p className="text-sm text-muted-foreground mt-1" data-testid="goals-error-message">
+            {error}
           </p>
           <Button
-            onClick={() => router.push('/onboarding/plan')}
-            className="mt-6 bg-blue-600 hover:bg-blue-700 text-white"
+            variant="outline"
+            className="mt-3"
+            onClick={() => { setError(null); loadGoals(); }}
           >
-            <Plus className="w-4 h-4 mr-2" />
-            Crea il tuo piano
+            Riprova
           </Button>
         </Card>
       </div>
     );
   }
 
-  const { plan, goals, allocations } = bundle;
-  const totalTarget = goals.reduce((s, g) => s + g.target, 0);
-  const totalCurrent = goals.reduce((s, g) => s + g.current, 0);
-  const totalPct = totalTarget > 0 ? (totalCurrent / totalTarget) * 100 : 0;
-  const allocationByGoalId = new Map(allocations.map((a) => [a.goalId, a]));
-
   return (
-    <div className="p-6 max-w-7xl mx-auto space-y-6">
-      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+    <div className="p-6 max-w-7xl mx-auto space-y-6" data-testid="goals-page">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
         <div>
           <h1 className="text-3xl font-bold text-foreground">Obiettivi</h1>
-          <p className="text-muted-foreground mt-1">Piano finanziario attivo</p>
+          <p className="text-muted-foreground mt-1">
+            {goals.length > 0
+              ? `${goals.length} obiettiv${goals.length === 1 ? 'o attivo' : 'i attivi'}`
+              : 'Crea il tuo primo obiettivo finanziario'}
+          </p>
         </div>
-        <Button
-          variant="outline"
-          onClick={() => router.push('/onboarding/plan?mode=edit')}
+      </div>
+
+      {/* Filter chips */}
+      {goals.length > 0 && (
+        <GoalTypeFilter selected={selectedType} onTypeSelect={setSelectedType} />
+      )}
+
+      {/* Empty state */}
+      {goals.length === 0 ? (
+        <Card
+          data-testid="goals-empty-state"
+          className="p-12 text-center border-dashed"
         >
-          <Plus className="w-4 h-4 mr-2" />
-          Modifica piano
-        </Button>
-      </div>
-
-      {/* Plan summary */}
-      <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }}>
-        <Card className="p-6 bg-gradient-to-r from-blue-600 to-purple-600 text-white overflow-hidden relative">
-          <div className="absolute top-0 right-0 w-40 h-40 bg-white/10 rounded-full -translate-y-1/2 translate-x-1/2" />
-          <div className="relative z-10">
-            <div className="flex items-center justify-between mb-4">
-              <div>
-                <p className="text-blue-100 text-sm">Progresso Complessivo</p>
-                <p className="text-3xl font-bold mt-1">
-                  &euro;{totalCurrent.toLocaleString('it-IT')} / &euro;{totalTarget.toLocaleString('it-IT')}
-                </p>
-              </div>
-              <div className="text-right">
-                <p className="text-4xl font-bold">{totalPct.toFixed(0)}%</p>
-                <p className="text-blue-100 text-sm">{goals.length} obiettivi attivi</p>
-              </div>
-            </div>
-            <div className="h-3 bg-white/20 rounded-full overflow-hidden">
-              <motion.div
-                initial={{ width: 0 }}
-                animate={{ width: `${Math.min(100, totalPct)}%` }}
-                transition={{ delay: 0.5, duration: 1 }}
-                className="h-full bg-white rounded-full"
-              />
-            </div>
-            <div className="grid grid-cols-3 gap-4 mt-4 text-xs text-blue-100">
-              <div>
-                <p>Reddito mensile</p>
-                <p className="text-sm font-semibold text-white mt-1">
-                  &euro;{plan.monthlyIncome.toLocaleString('it-IT')}
-                </p>
-              </div>
-              <div>
-                <p>Risparmio target</p>
-                <p className="text-sm font-semibold text-white mt-1">
-                  &euro;{plan.monthlySavingsTarget.toLocaleString('it-IT')}/mese
-                </p>
-              </div>
-              <div>
-                <p>Essenziali</p>
-                <p className="text-sm font-semibold text-white mt-1">
-                  {plan.essentialsPct.toFixed(0)}%
-                </p>
-              </div>
-            </div>
-          </div>
+          <Target className="w-12 h-12 mx-auto text-muted-foreground mb-4" />
+          <h2 className="text-lg font-semibold text-foreground">
+            Crea il tuo primo obiettivo
+          </h2>
+          <p className="text-sm text-muted-foreground mt-2 max-w-md mx-auto">
+            Definisci i tuoi traguardi finanziari: risparmio, investimenti, fondo
+            emergenza e molto altro.
+          </p>
+          <Button
+            onClick={handleAddClick}
+            data-testid="goals-empty-cta"
+            className="mt-6 bg-blue-600 hover:bg-blue-700 text-white"
+          >
+            <Plus className="w-4 h-4 mr-2" />
+            Aggiungi obiettivo
+          </Button>
         </Card>
-      </motion.div>
-
-      {/* Goals grid */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {goals.map((goal, i) => {
-          const pct = goal.target > 0 ? (goal.current / goal.target) * 100 : 0;
-          const colors = PRIORITY_COLOR[goal.priority];
-          const remaining = Math.max(0, goal.target - goal.current);
-          const allocation = allocationByGoalId.get(goal.id);
-
-          // Days left calculation (null-safe)
-          let daysLeft: number | null = null;
-          if (goal.deadline) {
-            const [dy, dm, dd] = goal.deadline.slice(0, 10).split('-').map(Number);
-            const deadlineLocal = new Date(dy, (dm || 1) - 1, dd || 1).getTime();
-            const todayLocal = new Date(
-              new Date().getFullYear(),
-              new Date().getMonth(),
-              new Date().getDate(),
-            ).getTime();
-            daysLeft = Math.max(0, Math.ceil((deadlineLocal - todayLocal) / (1000 * 60 * 60 * 24)));
-          }
-
-          return (
-            <motion.div
-              key={goal.id}
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.15 + i * 0.08 }}
+      ) : (
+        <>
+          {/* Filtered empty */}
+          {filteredGoals.length === 0 && (
+            <p
+              data-testid="goals-filter-empty"
+              className="text-sm text-muted-foreground py-6 text-center"
             >
-              <Card className={`p-6 hover:shadow-lg transition-shadow ${colors.light}`}>
-                <div className="flex items-start justify-between mb-4">
-                  <div className="flex items-center gap-3">
-                    <div className={`p-2.5 rounded-xl ${colors.bg} text-white`}>
-                      <Target className="w-5 h-5" />
-                    </div>
-                    <div>
-                      <h3 className="font-bold text-foreground">{goal.name}</h3>
-                      <Badge variant="outline" className="text-xs mt-0.5">
-                        {PRIORITY_LABEL_IT[goal.priority]} priorit&agrave;
-                      </Badge>
-                    </div>
-                  </div>
-                </div>
+              Nessun obiettivo per questo filtro.
+            </p>
+          )}
 
-                <div className="mb-3">
-                  <div className="flex justify-between text-sm mb-1.5">
-                    <span className="text-muted-foreground">
-                      &euro;{goal.current.toLocaleString('it-IT')}
-                    </span>
-                    <span className="font-semibold text-foreground">
-                      &euro;{goal.target.toLocaleString('it-IT')}
-                    </span>
-                  </div>
-                  <Progress value={pct} className="h-2.5" />
-                  <p className={`text-sm font-bold mt-1 ${colors.text}`}>{pct.toFixed(0)}%</p>
-                </div>
+          {/* Goals grid */}
+          <div
+            className="grid grid-cols-1 md:grid-cols-2 gap-4"
+            data-testid="goals-grid"
+          >
+            {filteredGoals.map((goal) => (
+              <GoalCard
+                key={goal.id}
+                goal={goal}
+                onEditClick={handleEditClick}
+                onDeleteClick={handleDeleteClick}
+              />
+            ))}
+          </div>
+        </>
+      )}
 
-                <div className="grid grid-cols-2 gap-3 mt-4 pt-4 border-t border-border/50">
-                  <div>
-                    <p className="text-xs text-muted-foreground">Scadenza</p>
-                    <div className="flex items-center gap-1 mt-0.5">
-                      <Calendar className="w-3 h-3 text-muted-foreground" />
-                      <p className="text-sm font-medium text-foreground">
-                        {daysLeft !== null ? `${daysLeft}g` : 'Nessuna'}
-                      </p>
-                    </div>
-                  </div>
-                  <div>
-                    <p className="text-xs text-muted-foreground">Piano mensile</p>
-                    <p className="text-sm font-medium text-foreground mt-0.5">
-                      &euro;{(allocation?.monthlyAmount ?? goal.monthlyAllocation).toFixed(0)}
-                    </p>
-                  </div>
-                </div>
+      {/* Floating add button */}
+      <button
+        type="button"
+        onClick={handleAddClick}
+        data-testid="goals-add-btn"
+        className="fixed bottom-6 right-6 flex items-center gap-2 bg-blue-600 hover:bg-blue-700 text-white px-4 py-3 rounded-full shadow-lg transition-colors z-40"
+        aria-label="Aggiungi obiettivo"
+      >
+        <Plus className="w-5 h-5" />
+        <span className="text-sm font-medium">Aggiungi</span>
+      </button>
 
-                {allocation && !allocation.deadlineFeasible && (
-                  <div className="mt-3 p-2 rounded-lg bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800">
-                    <p className="text-xs text-amber-700 dark:text-amber-400">
-                      &#9888; La scadenza potrebbe non essere fattibile con l&apos;allocation corrente
-                    </p>
-                  </div>
-                )}
+      {/* Edit/Add Modal */}
+      <GoalEditModal
+        open={editModalOpen}
+        mode={editMode}
+        goal={editingGoal}
+        onSave={handleModalSave}
+        onCancel={handleModalCancel}
+      />
 
-                {allocation?.reasoning && (
-                  <details className="mt-3 text-xs">
-                    <summary className="cursor-pointer text-muted-foreground hover:text-foreground">
-                      <Sparkles className="w-3 h-3 inline mr-1" />
-                      Perch&eacute; questo importo?
-                    </summary>
-                    <p className="mt-2 text-muted-foreground">{allocation.reasoning}</p>
-                  </details>
-                )}
-
-                {remaining > 0 && (
-                  <p className="text-xs text-muted-foreground mt-3">
-                    Mancano &euro;{remaining.toLocaleString('it-IT')} al target
-                  </p>
-                )}
-              </Card>
-            </motion.div>
-          );
-        })}
-      </div>
+      {/* Delete Confirm Dialog */}
+      <Dialog.Root open={deleteConfirmOpen} onOpenChange={setDeleteConfirmOpen}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+          <Dialog.Content
+            data-testid="delete-confirm-dialog"
+            className="fixed left-1/2 top-1/2 z-50 w-full max-w-sm -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-border bg-background p-6 shadow-xl focus:outline-none data-[state=open]:animate-in data-[state=closed]:animate-out"
+            aria-describedby={undefined}
+          >
+            <Dialog.Title className="text-base font-semibold text-foreground mb-2">
+              Elimina obiettivo
+            </Dialog.Title>
+            <p className="text-sm text-muted-foreground mb-5">
+              Vuoi eliminare &ldquo;{deletingGoalName}&rdquo;? Le allocazioni associate
+              verranno perse.
+            </p>
+            <div className="flex justify-end gap-2">
+              <Dialog.Close asChild>
+                <Button
+                  variant="outline"
+                  data-testid="delete-confirm-cancel"
+                  disabled={isDeleting}
+                >
+                  Annulla
+                </Button>
+              </Dialog.Close>
+              <Button
+                onClick={handleDeleteConfirm}
+                data-testid="delete-confirm-ok"
+                className="bg-red-600 hover:bg-red-700 text-white"
+                disabled={isDeleting}
+              >
+                {isDeleting ? (
+                  <Loader2 className="w-4 h-4 animate-spin mr-2" />
+                ) : null}
+                Elimina
+              </Button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
     </div>
   );
 }

--- a/apps/web/src/components/goals/GoalCard.tsx
+++ b/apps/web/src/components/goals/GoalCard.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import {
+  PiggyBank,
+  TrendingUp,
+  CreditCard,
+  Star,
+  Target,
+  Trash2,
+  Calendar,
+} from 'lucide-react';
+import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Progress } from '@/components/ui/progress';
+import { PRIORITY_LABEL_IT, type PriorityRank } from '@/types/onboarding-plan';
+import type { GoalType } from './GoalTypeFilter';
+import type { Goal } from '@/services/goals.client';
+
+// =============================================================================
+// Type inference helper (pre-MED-11: heuristic from name)
+// =============================================================================
+
+export function inferGoalType(name: string): GoalType {
+  const lower = name.toLowerCase();
+  if (lower.includes('emergenza') || lower.includes('fondo')) return 'emergency';
+  if (lower.includes('debito') || lower.includes('debiti') || lower.includes('prestito')) return 'debt';
+  if (lower.includes('invest') || lower.includes('crypto') || lower.includes('portafoglio') || lower.includes('patrimonio')) return 'investment';
+  if (lower.includes('viaggio') || lower.includes('vacanza') || lower.includes('lifestyle') || lower.includes('spesa')) return 'lifestyle';
+  return 'savings';
+}
+
+// =============================================================================
+// Icon per type
+// =============================================================================
+
+const TYPE_ICON: Record<GoalType, React.ComponentType<{ className?: string }>> = {
+  all: Target,
+  emergency: PiggyBank,
+  savings: Star,
+  investment: TrendingUp,
+  debt: CreditCard,
+  lifestyle: Star,
+};
+
+const TYPE_COLOR: Record<GoalType, { bg: string; text: string; light: string }> = {
+  all: { bg: 'bg-blue-600', text: 'text-blue-600', light: 'bg-blue-50 dark:bg-blue-950/30' },
+  emergency: { bg: 'bg-blue-600', text: 'text-blue-600', light: 'bg-blue-50 dark:bg-blue-950/30' },
+  savings: { bg: 'bg-emerald-600', text: 'text-emerald-600', light: 'bg-emerald-50 dark:bg-emerald-950/30' },
+  investment: { bg: 'bg-purple-600', text: 'text-purple-600', light: 'bg-purple-50 dark:bg-purple-950/30' },
+  debt: { bg: 'bg-red-600', text: 'text-red-600', light: 'bg-red-50 dark:bg-red-950/30' },
+  lifestyle: { bg: 'bg-orange-600', text: 'text-orange-600', light: 'bg-orange-50 dark:bg-orange-950/30' },
+};
+
+const PRIORITY_COLOR: Record<PriorityRank, { bg: string }> = {
+  1: { bg: 'bg-blue-600' },
+  2: { bg: 'bg-orange-500' },
+  3: { bg: 'bg-emerald-600' },
+};
+
+// =============================================================================
+// GoalCard
+// =============================================================================
+
+interface GoalCardProps {
+  goal: Goal;
+  onEditClick: (goal: Goal) => void;
+  onDeleteClick: (goalId: string) => void;
+}
+
+export function GoalCard({ goal, onEditClick, onDeleteClick }: GoalCardProps) {
+  const type = inferGoalType(goal.name);
+  const Icon = TYPE_ICON[type];
+  const colors = TYPE_COLOR[type];
+  const priorityColor = PRIORITY_COLOR[goal.priority];
+
+  const pct = goal.target > 0 ? Math.min(100, (goal.current / goal.target) * 100) : 0;
+  const remaining = Math.max(0, goal.target - goal.current);
+
+  let daysLeft: number | null = null;
+  if (goal.deadline) {
+    const [dy, dm, dd] = goal.deadline.slice(0, 10).split('-').map(Number);
+    const deadlineMs = new Date(dy!, (dm! - 1), dd!).getTime();
+    const todayMs = new Date(
+      new Date().getFullYear(),
+      new Date().getMonth(),
+      new Date().getDate(),
+    ).getTime();
+    daysLeft = Math.max(0, Math.ceil((deadlineMs - todayMs) / 86_400_000));
+  }
+
+  return (
+    <Card
+      data-testid={`goal-card-${goal.id}`}
+      className={`p-5 hover:shadow-lg transition-shadow cursor-pointer ${colors.light}`}
+      onClick={() => onEditClick(goal)}
+    >
+      <div className="flex items-start justify-between mb-3">
+        <div className="flex items-center gap-3 flex-1 min-w-0">
+          <div className={`p-2 rounded-xl ${colors.bg} text-white shrink-0`}>
+            <Icon className="w-4 h-4" />
+          </div>
+          <div className="min-w-0">
+            <h3
+              data-testid="goal-card-name"
+              className="font-semibold text-foreground truncate"
+            >
+              {goal.name}
+            </h3>
+            <Badge
+              variant="outline"
+              className="text-xs mt-0.5"
+              data-testid="goal-card-priority"
+            >
+              <span className={`inline-block w-1.5 h-1.5 rounded-full mr-1 ${priorityColor.bg}`} />
+              {PRIORITY_LABEL_IT[goal.priority]}
+            </Badge>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          data-testid={`goal-delete-${goal.id}`}
+          onClick={(e) => {
+            e.stopPropagation();
+            onDeleteClick(goal.id);
+          }}
+          className="shrink-0 p-1.5 rounded-lg hover:bg-red-50 dark:hover:bg-red-950/30 transition-colors ml-2"
+          aria-label={`Elimina ${goal.name}`}
+        >
+          <Trash2 className="w-4 h-4 text-muted-foreground hover:text-red-500 transition-colors" />
+        </button>
+      </div>
+
+      <div className="mb-3">
+        <div className="flex justify-between text-sm mb-1.5">
+          <span className="text-muted-foreground">
+            &euro;{goal.current.toLocaleString('it-IT')}
+          </span>
+          <span
+            data-testid="goal-card-target"
+            className="font-semibold text-foreground"
+          >
+            &euro;{goal.target.toLocaleString('it-IT')}
+          </span>
+        </div>
+        <Progress value={pct} className="h-2" />
+        <p className={`text-xs font-bold mt-1 ${colors.text}`}>{pct.toFixed(0)}%</p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2 pt-3 border-t border-border/40">
+        <div>
+          <p className="text-xs text-muted-foreground">Scadenza</p>
+          <div className="flex items-center gap-1 mt-0.5">
+            <Calendar className="w-3 h-3 text-muted-foreground" />
+            <p
+              data-testid="goal-card-deadline"
+              className="text-xs font-medium text-foreground"
+            >
+              {daysLeft !== null ? `${daysLeft}g` : 'Nessuna'}
+            </p>
+          </div>
+        </div>
+        <div>
+          <p className="text-xs text-muted-foreground">Mensile</p>
+          <p className="text-xs font-medium text-foreground mt-0.5">
+            &euro;{goal.monthlyAllocation.toFixed(0)}
+          </p>
+        </div>
+      </div>
+
+      {remaining > 0 && (
+        <p className="text-xs text-muted-foreground mt-2">
+          Mancano &euro;{remaining.toLocaleString('it-IT')} al target
+        </p>
+      )}
+    </Card>
+  );
+}

--- a/apps/web/src/components/goals/GoalEditModal.tsx
+++ b/apps/web/src/components/goals/GoalEditModal.tsx
@@ -1,0 +1,225 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { PRIORITY_LABEL_IT, type PriorityRank } from '@/types/onboarding-plan';
+import type { Goal, GoalInput } from '@/services/goals.client';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type GoalEditModalMode = 'add' | 'edit';
+
+interface GoalEditModalProps {
+  open: boolean;
+  mode: GoalEditModalMode;
+  goal?: Goal;
+  onSave: (data: GoalInput) => void;
+  onCancel: () => void;
+}
+
+// =============================================================================
+// Initial draft helpers
+// =============================================================================
+
+const EMPTY_DRAFT: GoalInput = {
+  name: '',
+  target: 0,
+  deadline: null,
+  priority: 2,
+  monthlyAllocation: 0,
+};
+
+function goalToInput(goal: Goal): GoalInput {
+  return {
+    name: goal.name,
+    target: goal.target,
+    deadline: goal.deadline,
+    priority: goal.priority,
+    monthlyAllocation: goal.monthlyAllocation,
+  };
+}
+
+// =============================================================================
+// GoalEditModal
+// =============================================================================
+
+export function GoalEditModal({ open, mode, goal, onSave, onCancel }: GoalEditModalProps) {
+  const [draft, setDraft] = useState<GoalInput>(EMPTY_DRAFT);
+  const [errors, setErrors] = useState<{ name?: string; target?: string }>({});
+
+  // Reset draft when modal opens
+  useEffect(() => {
+    if (open) {
+      setDraft(mode === 'edit' && goal ? goalToInput(goal) : EMPTY_DRAFT);
+      setErrors({});
+    }
+  }, [open, mode, goal]);
+
+  const validate = (): boolean => {
+    const next: typeof errors = {};
+    if (!draft.name.trim()) next.name = 'Il nome è obbligatorio';
+    if (draft.target <= 0) next.target = 'Il target deve essere > 0';
+    setErrors(next);
+    return Object.keys(next).length === 0;
+  };
+
+  const handleSave = () => {
+    if (!validate()) return;
+    onSave(draft);
+  };
+
+  const title = mode === 'add' ? 'Nuovo obiettivo' : 'Modifica obiettivo';
+
+  return (
+    <Dialog.Root open={open} onOpenChange={(o) => { if (!o) onCancel(); }}>
+      <Dialog.Portal>
+        <Dialog.Overlay
+          data-testid="goal-modal-overlay"
+          className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
+        />
+        <Dialog.Content
+          data-testid="goal-edit-modal"
+          className="fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-border bg-background p-6 shadow-xl focus:outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95"
+          aria-describedby={undefined}
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between mb-5">
+            <Dialog.Title
+              data-testid="goal-modal-title"
+              className="text-base font-semibold text-foreground"
+            >
+              {title}
+            </Dialog.Title>
+            <Dialog.Close asChild>
+              <button
+                className="rounded-lg p-1.5 hover:bg-muted transition-colors"
+                aria-label="Chiudi"
+                data-testid="goal-modal-close"
+              >
+                <X className="w-4 h-4 text-muted-foreground" />
+              </button>
+            </Dialog.Close>
+          </div>
+
+          {/* Form */}
+          <div className="space-y-4">
+            {/* Name */}
+            <div>
+              <label
+                htmlFor="goal-edit-name"
+                className="text-sm font-medium text-foreground block mb-1"
+              >
+                Nome
+              </label>
+              <input
+                id="goal-edit-name"
+                type="text"
+                data-testid="goal-modal-name"
+                value={draft.name}
+                onChange={(e) => setDraft({ ...draft, name: e.target.value })}
+                className="w-full bg-muted/50 border border-border rounded-xl px-3 py-2 text-sm text-foreground"
+                placeholder="es. Fondo Emergenza"
+                autoFocus
+              />
+              {errors.name && (
+                <p data-testid="goal-modal-name-error" className="text-xs text-red-500 mt-1">
+                  {errors.name}
+                </p>
+              )}
+            </div>
+
+            {/* Target + Deadline */}
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label
+                  htmlFor="goal-edit-target"
+                  className="text-sm font-medium text-foreground block mb-1"
+                >
+                  Target (€)
+                </label>
+                <input
+                  id="goal-edit-target"
+                  type="number"
+                  min={0}
+                  data-testid="goal-modal-target"
+                  value={draft.target || ''}
+                  onChange={(e) => setDraft({ ...draft, target: Number(e.target.value) })}
+                  className="w-full bg-muted/50 border border-border rounded-xl px-3 py-2 text-sm text-foreground"
+                  placeholder="5000"
+                />
+                {errors.target && (
+                  <p data-testid="goal-modal-target-error" className="text-xs text-red-500 mt-1">
+                    {errors.target}
+                  </p>
+                )}
+              </div>
+              <div>
+                <label
+                  htmlFor="goal-edit-deadline"
+                  className="text-sm font-medium text-foreground block mb-1"
+                >
+                  Scadenza
+                </label>
+                <input
+                  id="goal-edit-deadline"
+                  type="date"
+                  data-testid="goal-modal-deadline"
+                  value={draft.deadline ?? ''}
+                  onChange={(e) =>
+                    setDraft({ ...draft, deadline: e.target.value || null })
+                  }
+                  className="w-full bg-muted/50 border border-border rounded-xl px-3 py-2 text-sm text-foreground"
+                />
+              </div>
+            </div>
+
+            {/* Priority */}
+            <div>
+              <label
+                htmlFor="goal-edit-priority"
+                className="text-sm font-medium text-foreground block mb-1"
+              >
+                Priorità
+              </label>
+              <select
+                id="goal-edit-priority"
+                data-testid="goal-modal-priority"
+                value={draft.priority}
+                onChange={(e) =>
+                  setDraft({ ...draft, priority: Number(e.target.value) as PriorityRank })
+                }
+                className="w-full bg-muted/50 border border-border rounded-xl px-3 py-2 text-sm text-foreground"
+              >
+                {([1, 2, 3] as PriorityRank[]).map((p) => (
+                  <option key={p} value={p}>
+                    {PRIORITY_LABEL_IT[p]}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          {/* Footer */}
+          <div className="flex justify-end gap-2 mt-6">
+            <Dialog.Close asChild>
+              <Button variant="outline" data-testid="goal-modal-cancel">
+                Annulla
+              </Button>
+            </Dialog.Close>
+            <Button
+              onClick={handleSave}
+              data-testid="goal-modal-save"
+              className="bg-blue-600 hover:bg-blue-700 text-white"
+            >
+              {mode === 'add' ? 'Aggiungi' : 'Salva'}
+            </Button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/apps/web/src/components/goals/GoalTypeFilter.tsx
+++ b/apps/web/src/components/goals/GoalTypeFilter.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+/**
+ * GoalTypeFilter — horizontal chip row for filtering by goal type.
+ * Since MED-11 migration (adds `type` column) is not yet applied, type is
+ * inferred from goal names via heuristics in the parent page.
+ */
+
+export type GoalType = 'all' | 'emergency' | 'savings' | 'investment' | 'debt' | 'lifestyle';
+
+interface GoalTypeFilterProps {
+  selected: GoalType;
+  onTypeSelect: (type: GoalType) => void;
+}
+
+const CHIPS: { type: GoalType; label: string }[] = [
+  { type: 'all', label: 'Tutti' },
+  { type: 'emergency', label: 'Emergenza' },
+  { type: 'savings', label: 'Risparmio' },
+  { type: 'investment', label: 'Investimento' },
+  { type: 'debt', label: 'Debiti' },
+  { type: 'lifestyle', label: 'Lifestyle' },
+];
+
+export function GoalTypeFilter({ selected, onTypeSelect }: GoalTypeFilterProps) {
+  return (
+    <div
+      className="flex flex-wrap gap-2"
+      role="group"
+      aria-label="Filtro per tipo di obiettivo"
+      data-testid="goal-type-filter"
+    >
+      {CHIPS.map(({ type, label }) => (
+        <button
+          key={type}
+          type="button"
+          data-testid={`filter-chip-${type}`}
+          onClick={() => onTypeSelect(type)}
+          className={[
+            'px-3 py-1.5 rounded-full text-sm font-medium transition-colors',
+            selected === type
+              ? 'bg-blue-600 text-white'
+              : 'bg-muted text-muted-foreground hover:bg-muted/80',
+          ].join(' ')}
+          aria-pressed={selected === type}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/services/goals.client.ts
+++ b/apps/web/src/services/goals.client.ts
@@ -1,0 +1,165 @@
+/**
+ * Goals Client — Supabase CRUD (Sprint 1.5.2 WP-G)
+ *
+ * Thin CRUD layer for the `goals` table. Independent from the onboarding-plan
+ * client which handles the full plan+goals+allocations batch insert.
+ * Used by /dashboard/goals page for inline add/edit/delete.
+ */
+
+import { createClient } from '@/utils/supabase/client';
+import type { PriorityRank } from '@/types/onboarding-plan';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface Goal {
+  id: string;
+  name: string;
+  target: number;
+  current: number;
+  deadline: string | null;
+  priority: PriorityRank;
+  monthlyAllocation: number;
+  status: string;
+}
+
+export interface GoalInput {
+  name: string;
+  target: number;
+  deadline: string | null;
+  priority: PriorityRank;
+  monthlyAllocation?: number;
+}
+
+export class GoalsApiError extends Error {
+  constructor(
+    message: string,
+    public statusCode: number,
+    public details?: unknown,
+  ) {
+    super(message);
+    this.name = 'GoalsApiError';
+  }
+}
+
+// =============================================================================
+// Client
+// =============================================================================
+
+export const goalsClient = {
+  /**
+   * Load all ACTIVE goals for a user.
+   */
+  async loadGoals(userId: string): Promise<Goal[]> {
+    if (!userId) throw new GoalsApiError('userId is required', 400);
+
+    const supabase = createClient();
+    const { data, error } = await supabase
+      .from('goals')
+      .select('id, name, target, current, deadline, priority, monthly_allocation, status')
+      .eq('user_id', userId)
+      .eq('status', 'ACTIVE')
+      .order('priority', { ascending: true });
+
+    if (error) throw new GoalsApiError(error.message, 500, error);
+
+    return (data ?? []).map((g) => ({
+      id: g.id,
+      name: g.name,
+      target: Number(g.target),
+      current: Number(g.current),
+      deadline: g.deadline,
+      priority: g.priority as PriorityRank,
+      monthlyAllocation: Number(g.monthly_allocation),
+      status: g.status,
+    }));
+  },
+
+  /**
+   * Add a new goal for a user.
+   */
+  async addGoal(userId: string, goal: GoalInput): Promise<Goal> {
+    if (!userId) throw new GoalsApiError('userId is required', 400);
+    if (!goal.name?.trim()) throw new GoalsApiError('Goal name is required', 400);
+
+    const supabase = createClient();
+    const { data, error } = await supabase
+      .from('goals')
+      .insert({
+        user_id: userId,
+        name: goal.name.trim(),
+        target: goal.target,
+        current: 0,
+        deadline: goal.deadline,
+        priority: goal.priority,
+        monthly_allocation: goal.monthlyAllocation ?? 0,
+        status: 'ACTIVE' as const,
+      })
+      .select('id, name, target, current, deadline, priority, monthly_allocation, status')
+      .single();
+
+    if (error || !data) throw new GoalsApiError(error?.message ?? 'Failed to add goal', 500, error);
+
+    return {
+      id: data.id,
+      name: data.name,
+      target: Number(data.target),
+      current: Number(data.current),
+      deadline: data.deadline,
+      priority: data.priority as PriorityRank,
+      monthlyAllocation: Number(data.monthly_allocation),
+      status: data.status,
+    };
+  },
+
+  /**
+   * Update fields on an existing goal.
+   */
+  async updateGoal(goalId: string, patch: Partial<GoalInput>): Promise<Goal> {
+    if (!goalId) throw new GoalsApiError('goalId is required', 400);
+
+    const supabase = createClient();
+
+    const { data, error } = await supabase
+      .from('goals')
+      .update({
+        ...(patch.name !== undefined ? { name: patch.name.trim() } : {}),
+        ...(patch.target !== undefined ? { target: patch.target } : {}),
+        ...(patch.deadline !== undefined ? { deadline: patch.deadline } : {}),
+        ...(patch.priority !== undefined ? { priority: patch.priority } : {}),
+        ...(patch.monthlyAllocation !== undefined ? { monthly_allocation: patch.monthlyAllocation } : {}),
+      })
+      .eq('id', goalId)
+      .select('id, name, target, current, deadline, priority, monthly_allocation, status')
+      .single();
+
+    if (error || !data) throw new GoalsApiError(error?.message ?? 'Failed to update goal', 500, error);
+
+    return {
+      id: data.id,
+      name: data.name,
+      target: Number(data.target),
+      current: Number(data.current),
+      deadline: data.deadline,
+      priority: data.priority as PriorityRank,
+      monthlyAllocation: Number(data.monthly_allocation),
+      status: data.status,
+    };
+  },
+
+  /**
+   * Soft-delete: set status to ARCHIVED.
+   */
+  async deleteGoal(goalId: string): Promise<void> {
+    if (!goalId) throw new GoalsApiError('goalId is required', 400);
+
+    const supabase = createClient();
+    const { error } = await supabase
+      .from('goals')
+      .update({ status: 'ARCHIVED' as const })
+      .eq('id', goalId);
+
+    if (error) throw new GoalsApiError(error.message, 500, error);
+  },
+};


### PR DESCRIPTION
## Summary

- **goals.client.ts** (new): `addGoal` / `updateGoal` / `deleteGoal` / `loadGoals` via Supabase with soft-delete (ARCHIVED status)
- **GoalCard** (new): type-icon card with progress bar, deadline countdown, priority badge; click to edit, delete button with stopPropagation
- **GoalEditModal** (new): Radix Dialog (reuses `@radix-ui/react-dialog`) for add/edit; validates name required + target > 0
- **GoalTypeFilter** (new): 6 chip row (Tutti/Emergenza/Risparmio/Investimento/Debiti/Lifestyle) using name-heuristic inference (pre-MED-11 — `type` column not yet in DB schema)
- **page.tsx rewrite**: floating add button, 2-col grid, delete confirm Dialog, filter state, error/loading/empty states; uses `goalsClient` directly (no `onboardingPlanClient`)

## Notes

- Goal type is inferred from name patterns (`inferGoalType` in GoalCard) since MED-11 migration (`type` column) has not been applied yet. Once MED-11 merges, replace heuristic with `goal.type` field.
- Pre-existing typecheck error on `app-sidebar.tsx` (`@money-wise/ui` module) is unrelated and pre-dates this PR.
- 3 pre-existing lint warnings (all in accounts components) are unchanged.

## Test plan

- [x] GoalTypeFilter: 4 tests (chip rendering, aria-pressed, click callbacks)
- [x] GoalCard: 10 tests (name/target/testid, edit click, delete click no-propagation, null deadline)
- [x] GoalEditModal: 9 tests (title by mode, pre-fill, save callback, validation errors, cancel, closed state)
- [x] page integration: 14 tests (loading, empty, grid render, filter, add flow, edit flow, delete flow, cancel delete, error state)
- [x] Full suite: 84 test files / 1674 tests green, 0 regressions
- [x] Typecheck: 0 new errors
- [x] Lint: 0 new errors (3 pre-existing warnings unchanged)
- [x] Build: production build successful (`/dashboard/goals` 8.36 kB)
- [x] Pre-commit hooks: all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)