### PR TITLE
feat(onboarding): welcome step with feature chips (Sprint 1.5.2 WP-B)

### DIFF
--- a/apps/web/__tests__/components/onboarding/StepWelcome.test.tsx
+++ b/apps/web/__tests__/components/onboarding/StepWelcome.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * Tests for StepWelcome — Sprint 1.5.2 WP-B (Step 1 Benvenuto).
+ *
+ * Covers:
+ *  - Renders with firstName → "Ciao, {name}! 👋"
+ *  - Renders without firstName (null) → fallback "Ciao! 👋"
+ *  - Subtitle text present
+ *  - 3 feature chips rendered with correct labels
+ *  - Icons accessible (aria-hidden on decorative icons)
+ */
+
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '../../utils/test-utils';
+import { StepWelcome } from '@/components/onboarding/steps/StepWelcome';
+
+// ---------------------------------------------------------------------------
+// Framer-motion stub — props-forwarding passthrough
+// ---------------------------------------------------------------------------
+vi.mock('framer-motion', () => ({
+  motion: new Proxy(
+    {},
+    {
+      get: (_target: unknown, prop: string | symbol) => {
+        if (prop === '__esModule') return false;
+        return ({
+          children,
+          initial: _initial,
+          animate: _animate,
+          exit: _exit,
+          transition: _transition,
+          whileHover: _whileHover,
+          whileTap: _whileTap,
+          whileInView: _whileInView,
+          variants: _variants,
+          ...rest
+        }: Record<string, unknown>) => {
+          const Tag = typeof prop === 'string' ? prop : 'div';
+          return React.createElement(Tag as string, rest, children as React.ReactNode);
+        };
+      },
+    }
+  ),
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+// =============================================================================
+// Tests
+// =============================================================================
+describe('StepWelcome (Sprint 1.5.2 WP-B)', () => {
+  // ---- 1. Greeting with firstName -------------------------------------------
+  describe('greeting text', () => {
+    it('shows personalized greeting when firstName provided', () => {
+      render(<StepWelcome firstName="Marco" />);
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Ciao, Marco! 👋');
+    });
+
+    it('shows fallback greeting when firstName is null', () => {
+      render(<StepWelcome firstName={null} />);
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Ciao! 👋');
+    });
+
+    it('shows fallback greeting when firstName is empty string', () => {
+      render(<StepWelcome firstName="" />);
+      // empty string is falsy — falls back to generic
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Ciao! 👋');
+    });
+  });
+
+  // ---- 2. Subtitle -----------------------------------------------------------
+  describe('subtitle', () => {
+    it('renders Zecca onboarding subtitle', () => {
+      render(<StepWelcome firstName="Giulia" />);
+      expect(
+        screen.getByText(/Benvenuto su Zecca/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  // ---- 3. Feature chips ------------------------------------------------------
+  describe('feature chips', () => {
+    it('renders exactly 3 feature chips', () => {
+      render(<StepWelcome firstName={null} />);
+      // role="list" wraps the chips
+      const list = screen.getByRole('list', { name: /funzionalita principali/i });
+      expect(list.querySelectorAll('[role="listitem"]').length).toBe(3);
+    });
+
+    it('renders "5 Agenti AI" chip', () => {
+      render(<StepWelcome firstName={null} />);
+      expect(screen.getByText('5 Agenti AI')).toBeInTheDocument();
+    });
+
+    it('renders "Gamification" chip', () => {
+      render(<StepWelcome firstName={null} />);
+      expect(screen.getByText('Gamification')).toBeInTheDocument();
+    });
+
+    it('renders "Analisi Smart" chip', () => {
+      render(<StepWelcome firstName={null} />);
+      expect(screen.getByText('Analisi Smart')).toBeInTheDocument();
+    });
+  });
+
+  // ---- 4. Accessibility -------------------------------------------------------
+  describe('accessibility', () => {
+    it('heading has correct level (h1)', () => {
+      render(<StepWelcome firstName="Test" />);
+      const h1 = screen.getByRole('heading', { level: 1 });
+      expect(h1).toBeInTheDocument();
+    });
+
+    it('chip list has accessible label', () => {
+      render(<StepWelcome firstName={null} />);
+      expect(
+        screen.getByRole('list', { name: /funzionalita principali/i })
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/__tests__/components/onboarding/WizardPianoGenerato.test.tsx
+++ b/apps/web/__tests__/components/onboarding/WizardPianoGenerato.test.tsx
@@ -25,22 +25,25 @@ import * as Dialog from '@radix-ui/react-dialog';
 import type { AllocationResult, PriorityRank, WizardState } from '@/types/onboarding-plan';
 
 // --------------------------------------------------------------------------
-// Child step stubs
+// Child step stubs (6 steps post Sprint 1.5.2 WP-B renumber)
 // --------------------------------------------------------------------------
+vi.mock('@/components/onboarding/steps/StepWelcome', () => ({
+  StepWelcome: () => <div data-testid="step-1-stub">StepWelcome</div>,
+}));
 vi.mock('@/components/onboarding/steps/StepIncome', () => ({
-  StepIncome: () => <div data-testid="step-1-stub">StepIncome</div>,
+  StepIncome: () => <div data-testid="step-2-stub">StepIncome</div>,
 }));
 vi.mock('@/components/onboarding/steps/StepSavingsTarget', () => ({
-  StepSavingsTarget: () => <div data-testid="step-2-stub">StepSavingsTarget</div>,
+  StepSavingsTarget: () => <div data-testid="step-3-stub">StepSavingsTarget</div>,
 }));
 vi.mock('@/components/onboarding/steps/StepGoals', () => ({
-  StepGoals: () => <div data-testid="step-3-stub">StepGoals</div>,
+  StepGoals: () => <div data-testid="step-4-stub">StepGoals</div>,
 }));
 vi.mock('@/components/onboarding/steps/StepPlanReview', () => ({
-  StepPlanReview: () => <div data-testid="step-4-stub">StepPlanReview</div>,
+  StepPlanReview: () => <div data-testid="step-5-stub">StepPlanReview</div>,
 }));
 vi.mock('@/components/onboarding/steps/StepAiPrefs', () => ({
-  StepAiPrefs: () => <div data-testid="step-5-stub">StepAiPrefs</div>,
+  StepAiPrefs: () => <div data-testid="step-6-stub">StepAiPrefs</div>,
 }));
 
 // Framer-motion: props-forwarding passthrough
@@ -185,7 +188,8 @@ function makeState(
     invokerRoute: '/dashboard',
     skipState: null,
   };
-  return { ...base, ...overrides, ...actions };
+  // WizardStep is now 1|2|3|4|5|6 (Sprint 1.5.2 WP-B)
+  return { ...base, ...overrides, ...actions } as WizardState & StoreActionSpies;
 }
 
 const GOAL_TEMP_ID = 'goal-temp-1';
@@ -249,11 +253,11 @@ describe('WizardPianoGenerato — Dialog (Sprint 1.5.2 WP-A)', () => {
       expect(screen.getByRole('button', { name: 'Chiudi wizard' })).toBeInTheDocument();
     });
 
-    it('renders X close button with aria-label "Chiudi wizard" on Step 5 (last step)', () => {
+    it('renders X close button with aria-label "Chiudi wizard" on Step 6 (last step)', () => {
       mockAuthStore.mockReturnValue({ user: { id: 'u1', onboarded: false }, setUser: mockSetUser });
       mockPlanStore.mockReturnValue(
         makeState({
-          currentStep: 5,
+          currentStep: 6,
           step3: { goals: GOALS_ONE },
           step4: { allocationPreview: makeAllocation([GOAL_TEMP_ID]), userOverrides: {} },
         })
@@ -294,11 +298,11 @@ describe('WizardPianoGenerato — Dialog (Sprint 1.5.2 WP-A)', () => {
       expect(screen.queryByRole('button', { name: 'Salta' })).not.toBeInTheDocument();
     });
 
-    it('is NOT visible on Step 5', () => {
+    it('is NOT visible on Step 6 (last step)', () => {
       mockAuthStore.mockReturnValue({ user: { id: 'u1', onboarded: false }, setUser: mockSetUser });
       mockPlanStore.mockReturnValue(
         makeState({
-          currentStep: 5,
+          currentStep: 6,
           step3: { goals: GOALS_ONE },
           step4: { allocationPreview: makeAllocation([GOAL_TEMP_ID]), userOverrides: {} },
         })
@@ -332,7 +336,7 @@ describe('WizardPianoGenerato — Dialog (Sprint 1.5.2 WP-A)', () => {
 
   // ---- 3. Step indicator (lines, no icon circles) --------------------------
   describe('Step indicator — line segments', () => {
-    it('renders progressbar with aria attributes', () => {
+    it('renders progressbar with aria attributes (6 steps)', () => {
       mockAuthStore.mockReturnValue({ user: { id: 'u1', onboarded: false }, setUser: mockSetUser });
       mockPlanStore.mockReturnValue(makeState({ currentStep: 3 }));
 
@@ -340,25 +344,26 @@ describe('WizardPianoGenerato — Dialog (Sprint 1.5.2 WP-A)', () => {
       const progressbar = screen.getByRole('progressbar');
       expect(progressbar).toHaveAttribute('aria-valuenow', '3');
       expect(progressbar).toHaveAttribute('aria-valuemin', '1');
-      expect(progressbar).toHaveAttribute('aria-valuemax', '5');
-      expect(progressbar.children.length).toBe(5);
+      expect(progressbar).toHaveAttribute('aria-valuemax', '6');
+      expect(progressbar.children.length).toBe(6);
     });
 
-    it('renders 5 line segments (not icon circles) inside progressbar', () => {
+    it('renders 6 line segments (not icon circles) inside progressbar', () => {
       mockAuthStore.mockReturnValue({ user: { id: 'u1', onboarded: false }, setUser: mockSetUser });
       mockPlanStore.mockReturnValue(makeState({ currentStep: 1 }));
 
       renderWizard();
       const progressbar = screen.getByRole('progressbar');
       // Each child is a flex column div wrapping a line div + a label span
-      expect(progressbar.children.length).toBe(5);
+      expect(progressbar.children.length).toBe(6);
     });
 
-    it('shows step labels below lines', () => {
+    it('shows all 6 step labels below lines', () => {
       mockAuthStore.mockReturnValue({ user: { id: 'u1', onboarded: false }, setUser: mockSetUser });
       mockPlanStore.mockReturnValue(makeState({ currentStep: 1 }));
 
       renderWizard();
+      expect(screen.getByText('Benvenuto')).toBeInTheDocument();
       expect(screen.getByText('Reddito')).toBeInTheDocument();
       expect(screen.getByText('Risparmio')).toBeInTheDocument();
       expect(screen.getByText('I tuoi goal')).toBeInTheDocument();
@@ -366,26 +371,27 @@ describe('WizardPianoGenerato — Dialog (Sprint 1.5.2 WP-A)', () => {
       expect(screen.getByText('Preferenze AI')).toBeInTheDocument();
     });
 
-    it('shows step description text', () => {
+    it('shows step description text for Step 1 (Benvenuto)', () => {
       mockAuthStore.mockReturnValue({ user: { id: 'u1', onboarded: false }, setUser: mockSetUser });
       mockPlanStore.mockReturnValue(makeState({ currentStep: 1 }));
 
       renderWizard();
-      expect(screen.getByText(/Passo 1 di 5 — Reddito/)).toBeInTheDocument();
+      expect(screen.getByText(/Passo 1 di 6 — Benvenuto/)).toBeInTheDocument();
     });
   });
 
   // ---- 4. Step rendering ---------------------------------------------------
   describe('Step rendering', () => {
     it.each([
-      [1, 'step-1-stub'],
-      [2, 'step-2-stub'],
-      [3, 'step-3-stub'],
-      [4, 'step-4-stub'],
-      [5, 'step-5-stub'],
+      [1, 'step-1-stub'],  // Step 1 = Benvenuto (NEW)
+      [2, 'step-2-stub'],  // Step 2 = Reddito
+      [3, 'step-3-stub'],  // Step 3 = Risparmio
+      [4, 'step-4-stub'],  // Step 4 = Obiettivi
+      [5, 'step-5-stub'],  // Step 5 = Piano proposto
+      [6, 'step-6-stub'],  // Step 6 = Preferenze AI
     ])('renders step-%i component when currentStep=%i', (step, testId) => {
       mockAuthStore.mockReturnValue({ user: { id: 'u1', onboarded: false }, setUser: mockSetUser });
-      mockPlanStore.mockReturnValue(makeState({ currentStep: step as 1 | 2 | 3 | 4 | 5 }));
+      mockPlanStore.mockReturnValue(makeState({ currentStep: step as 1 | 2 | 3 | 4 | 5 | 6 }));
 
       renderWizard();
       expect(screen.getByTestId(testId)).toBeInTheDocument();
@@ -439,13 +445,13 @@ describe('WizardPianoGenerato — Dialog (Sprint 1.5.2 WP-A)', () => {
     });
   });
 
-  // ---- 6. Step 5 canSubmit=true -------------------------------------------
-  describe('Step 5 — Conferma e crea piano (canSubmit=true)', () => {
+  // ---- 6. Step 6 canSubmit=true (last step, Preferenze AI) ------------------
+  describe('Step 6 — Conferma e crea piano (canSubmit=true)', () => {
     it('renders enabled button when all conditions hold', () => {
       mockAuthStore.mockReturnValue({ user: { id: 'u1', onboarded: false }, setUser: mockSetUser });
       mockPlanStore.mockReturnValue(
         makeState({
-          currentStep: 5,
+          currentStep: 6,
           step3: { goals: GOALS_ONE },
           step4: { allocationPreview: makeAllocation([GOAL_TEMP_ID]), userOverrides: {} },
           isPersisting: false,
@@ -459,13 +465,13 @@ describe('WizardPianoGenerato — Dialog (Sprint 1.5.2 WP-A)', () => {
     });
   });
 
-  // ---- 7. Step 5 disabled reasons ------------------------------------------
-  describe('Step 5 — disabled reasons', () => {
+  // ---- 7. Step 6 disabled reasons ------------------------------------------
+  describe('Step 6 — disabled reasons', () => {
     it('disables button + shows amber banner when userId is null', () => {
       mockAuthStore.mockReturnValue({ user: null, setUser: mockSetUser });
       mockPlanStore.mockReturnValue(
         makeState({
-          currentStep: 5,
+          currentStep: 6,
           step3: { goals: GOALS_ONE },
           step4: { allocationPreview: makeAllocation([GOAL_TEMP_ID]), userOverrides: {} },
         })
@@ -480,7 +486,7 @@ describe('WizardPianoGenerato — Dialog (Sprint 1.5.2 WP-A)', () => {
       mockAuthStore.mockReturnValue({ user: { id: 'u1', onboarded: false }, setUser: mockSetUser });
       mockPlanStore.mockReturnValue(
         makeState({
-          currentStep: 5,
+          currentStep: 6,
           step3: { goals: [] },
           step4: { allocationPreview: makeAllocation([]), userOverrides: {} },
         })
@@ -495,7 +501,7 @@ describe('WizardPianoGenerato — Dialog (Sprint 1.5.2 WP-A)', () => {
       mockAuthStore.mockReturnValue({ user: { id: 'u1', onboarded: false }, setUser: mockSetUser });
       mockPlanStore.mockReturnValue(
         makeState({
-          currentStep: 5,
+          currentStep: 6,
           step3: { goals: GOALS_ONE },
           step4: { allocationPreview: null, userOverrides: {} },
         })
@@ -510,7 +516,7 @@ describe('WizardPianoGenerato — Dialog (Sprint 1.5.2 WP-A)', () => {
       mockAuthStore.mockReturnValue({ user: { id: 'u1', onboarded: false }, setUser: mockSetUser });
       mockPlanStore.mockReturnValue(
         makeState({
-          currentStep: 5,
+          currentStep: 6,
           step3: { goals: GOALS_ONE },
           step4: { allocationPreview: makeAllocation([GOAL_TEMP_ID]), userOverrides: {} },
           isPersisting: true,
@@ -536,7 +542,7 @@ describe('WizardPianoGenerato — Dialog (Sprint 1.5.2 WP-A)', () => {
       mockAuthStore.mockReturnValue({ user: { id: 'u1', onboarded: false }, setUser: mockSetUser });
       mockPlanStore.mockReturnValue(
         makeState({
-          currentStep: 5,
+          currentStep: 6,
           step3: { goals: GOALS_ONE },
           step4: { allocationPreview: makeAllocation([GOAL_TEMP_ID]), userOverrides: {} },
           step5: { enableAiCategorization: true, enableAiInsights: false },
@@ -566,11 +572,11 @@ describe('WizardPianoGenerato — Dialog (Sprint 1.5.2 WP-A)', () => {
 
   // ---- 9. Edit mode -------------------------------------------------------
   describe('Edit mode (mode="edit")', () => {
-    it('renders "Modifica il tuo piano" title and "Salva modifiche" button on step 5', () => {
+    it('renders "Modifica il tuo piano" title and "Salva modifiche" button on step 6 (last)', () => {
       mockAuthStore.mockReturnValue({ user: { id: 'u1', onboarded: true }, setUser: mockSetUser });
       mockPlanStore.mockReturnValue(
         makeState({
-          currentStep: 5,
+          currentStep: 6,
           step3: { goals: GOALS_ONE },
           step4: { allocationPreview: makeAllocation([GOAL_TEMP_ID]), userOverrides: {} },
         })
@@ -586,7 +592,7 @@ describe('WizardPianoGenerato — Dialog (Sprint 1.5.2 WP-A)', () => {
       mockAuthStore.mockReturnValue({ user: { id: 'u1', onboarded: false }, setUser: mockSetUser });
       mockPlanStore.mockReturnValue(
         makeState({
-          currentStep: 5,
+          currentStep: 6,
           step3: { goals: GOALS_ONE },
           step4: { allocationPreview: makeAllocation([GOAL_TEMP_ID]), userOverrides: {} },
         })
@@ -601,7 +607,7 @@ describe('WizardPianoGenerato — Dialog (Sprint 1.5.2 WP-A)', () => {
       mockAuthStore.mockReturnValue({ user: { id: 'u1', onboarded: true }, setUser: mockSetUser });
       mockPlanStore.mockReturnValue(
         makeState({
-          currentStep: 5,
+          currentStep: 6,
           step3: { goals: GOALS_ONE },
           step4: { allocationPreview: makeAllocation([GOAL_TEMP_ID]), userOverrides: {} },
           isPersisting: true,
@@ -626,7 +632,7 @@ describe('WizardPianoGenerato — Dialog (Sprint 1.5.2 WP-A)', () => {
       mockAuthStore.mockReturnValue({ user: { id: 'u1', onboarded: false }, setUser: mockSetUser });
       mockPlanStore.mockReturnValue(
         makeState({
-          currentStep: 5,
+          currentStep: 6,
           step3: { goals: GOALS_ONE },
           step4: { allocationPreview: makeAllocation([GOAL_TEMP_ID]), userOverrides: {} },
           _actions: actions,

--- a/apps/web/src/components/onboarding/WizardPianoGenerato.tsx
+++ b/apps/web/src/components/onboarding/WizardPianoGenerato.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/store/onboarding-plan.store';
 import { useAuthStore } from '@/store/auth.store';
 import { onboardingPlanClient, OnboardingPlanApiError } from '@/services/onboarding-plan.client';
+import { StepWelcome } from './steps/StepWelcome';
 import { StepIncome } from './steps/StepIncome';
 import { StepSavingsTarget } from './steps/StepSavingsTarget';
 import { StepGoals } from './steps/StepGoals';
@@ -20,15 +21,19 @@ import { Button } from '@/components/ui/button';
 import { ChevronLeft, ChevronRight, Check, Loader2 } from 'lucide-react';
 
 // ---------------------------------------------------------------------------
-// Step indicator configuration — clean lines + labels (no icon circles)
+// Step indicator configuration — 6 steps (Sprint 1.5.2 WP-B)
+// Step 1 = Benvenuto (NEW), Steps 2-6 renumbered from previous 1-5
 // ---------------------------------------------------------------------------
 const STEP_CONFIG = [
+  { label: 'Benvenuto' },
   { label: 'Reddito' },
   { label: 'Risparmio' },
   { label: 'I tuoi goal' },
   { label: 'Piano proposto' },
   { label: 'Preferenze AI' },
 ] as const;
+
+const TOTAL_STEPS = STEP_CONFIG.length; // 6
 
 interface WizardPianoGeneratoProps {
   /** 'create' (default) = first-time onboarding. 'edit' = pre-populated from existing plan. */
@@ -58,18 +63,18 @@ export function WizardPianoGenerato({ mode = 'create', onClose }: WizardPianoGen
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [prevStepRef, setPrevStepRef] = useState(currentStep);
 
-  // Step 1 gate: income must be within bounds to advance
-  const canAdvanceStep1 = useOnboardingPlanStore(selectCanAdvanceFromStep1);
+  // Income gate now applies to Step 2 (Reddito) post WP-B renumber
+  const canAdvanceIncomeStep = useOnboardingPlanStore(selectCanAdvanceFromStep1);
 
-  const isLastStep = currentStep === 5;
+  const isLastStep = currentStep === TOTAL_STEPS;
   const canSubmit = !!userId && !!allocationPreview && step3.goals.length > 0 && !isPersisting;
 
   const disabledReason = !userId
     ? 'Sessione utente non rilevata — ricarica la pagina.'
     : step3.goals.length === 0
-      ? 'Aggiungi almeno un obiettivo allo Step 3.'
+      ? 'Aggiungi almeno un obiettivo allo Step 4.'
       : !allocationPreview
-        ? 'Piano non ancora calcolato — torna allo Step 4 per rigenerarlo.'
+        ? 'Piano non ancora calcolato — torna allo Step 5 per rigenerarlo.'
         : null;
 
   // Direction for slide animation: forward (+1) or backward (-1)
@@ -145,7 +150,11 @@ export function WizardPianoGenerato({ mode = 'create', onClose }: WizardPianoGen
     }
   };
 
-  const canAdvance = currentStep === 1 ? canAdvanceStep1 : true;
+  // Step 1 (Welcome) always allows advancing.
+  // Step 2 (Income) requires valid income bounds.
+  // All other steps allow free navigation.
+  const canAdvance =
+    currentStep === 2 ? canAdvanceIncomeStep : true;
 
   return (
     <Dialog.Portal>
@@ -173,12 +182,12 @@ export function WizardPianoGenerato({ mode = 'create', onClose }: WizardPianoGen
 
         {/* Step indicator — clean lines + labels, no circle icons */}
         <div
-          className="flex gap-3 mt-4"
+          className="flex gap-2 mt-4"
           role="progressbar"
           aria-valuemin={1}
-          aria-valuemax={5}
+          aria-valuemax={TOTAL_STEPS}
           aria-valuenow={currentStep}
-          aria-label={`Passo ${currentStep} di 5`}
+          aria-label={`Passo ${currentStep} di ${TOTAL_STEPS}`}
         >
           {STEP_CONFIG.map((step, idx) => {
             const stepNum = idx + 1;
@@ -217,7 +226,7 @@ export function WizardPianoGenerato({ mode = 'create', onClose }: WizardPianoGen
           id="wizard-step-description"
           className="text-sm text-muted-foreground mt-2"
         >
-          Passo {currentStep} di 5 — {STEP_CONFIG[currentStep - 1]!.label}
+          Passo {currentStep} di {TOTAL_STEPS} — {STEP_CONFIG[currentStep - 1]!.label}
         </p>
 
         {/* Step content with framer-motion slide transitions */}
@@ -230,11 +239,18 @@ export function WizardPianoGenerato({ mode = 'create', onClose }: WizardPianoGen
               exit={{ x: direction * -40, opacity: 0 }}
               transition={{ duration: 0.2, ease: 'easeInOut' }}
             >
-              {currentStep === 1 && <StepIncome />}
-              {currentStep === 2 && <StepSavingsTarget />}
-              {currentStep === 3 && <StepGoals />}
-              {currentStep === 4 && <StepPlanReview />}
-              {currentStep === 5 && <StepAiPrefs />}
+              {/* Step 1 — Benvenuto (NEW, Sprint 1.5.2 WP-B) */}
+              {currentStep === 1 && <StepWelcome firstName={user?.firstName ?? null} />}
+              {/* Step 2 — Reddito (previously Step 1) */}
+              {currentStep === 2 && <StepIncome />}
+              {/* Step 3 — Risparmio (previously Step 2) */}
+              {currentStep === 3 && <StepSavingsTarget />}
+              {/* Step 4 — Obiettivi (previously Step 3) */}
+              {currentStep === 4 && <StepGoals />}
+              {/* Step 5 — Piano proposto (previously Step 4) */}
+              {currentStep === 5 && <StepPlanReview />}
+              {/* Step 6 — Preferenze AI (previously Step 5) */}
+              {currentStep === 6 && <StepAiPrefs />}
             </motion.div>
           </AnimatePresence>
         </main>
@@ -264,7 +280,7 @@ export function WizardPianoGenerato({ mode = 'create', onClose }: WizardPianoGen
         {/* Footer: Salta (Step 1 only), Indietro, Avanti/Conferma */}
         <footer className="flex justify-between pt-6 border-t border-border mt-6">
           <div className="flex items-center gap-2">
-            {/* Salta: visible ONLY on Step 1 */}
+            {/* Salta: visible ONLY on Step 1 (Benvenuto) */}
             {currentStep === 1 && (
               <Button
                 variant="ghost"
@@ -274,7 +290,7 @@ export function WizardPianoGenerato({ mode = 'create', onClose }: WizardPianoGen
                 Salta
               </Button>
             )}
-            {/* Indietro: visible on steps 2-5 */}
+            {/* Indietro: visible on steps 2-6 */}
             {currentStep > 1 && (
               <Button
                 variant="outline"

--- a/apps/web/src/components/onboarding/steps/StepWelcome.tsx
+++ b/apps/web/src/components/onboarding/steps/StepWelcome.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { Sparkles, Brain, Diamond, TrendingUp } from 'lucide-react';
+
+interface StepWelcomeProps {
+  /** User's first name from auth store. Null = fallback to generic greeting. */
+  firstName: string | null;
+}
+
+export function StepWelcome({ firstName }: StepWelcomeProps) {
+  const greeting = firstName ? `Ciao, ${firstName}! 👋` : 'Ciao! 👋';
+
+  return (
+    <div className="flex flex-col items-center text-center gap-6 py-4">
+      {/* Animated hero icon with purple-to-blue gradient */}
+      <motion.div
+        initial={{ scale: 0.7, opacity: 0 }}
+        animate={{ scale: 1, opacity: 1 }}
+        transition={{ duration: 0.5, ease: 'easeOut' }}
+        className="flex items-center justify-center w-20 h-20 rounded-2xl bg-gradient-to-br from-purple-500 to-blue-500 shadow-lg"
+        aria-hidden="true"
+      >
+        <motion.div
+          animate={{ rotate: [0, 10, -8, 5, 0] }}
+          transition={{ duration: 2, repeat: Infinity, repeatDelay: 3, ease: 'easeInOut' }}
+        >
+          <Sparkles className="w-10 h-10 text-white" />
+        </motion.div>
+      </motion.div>
+
+      {/* Greeting */}
+      <div className="space-y-3">
+        <h1 className="text-3xl font-bold text-foreground">{greeting}</h1>
+        <p className="text-base text-muted-foreground max-w-md leading-relaxed">
+          Benvenuto su Zecca. In pochi step configureremo il tuo hub finanziario personalizzato con AI.
+        </p>
+      </div>
+
+      {/* Feature chips */}
+      <div
+        className="flex flex-wrap justify-center gap-3"
+        role="list"
+        aria-label="Funzionalita principali"
+      >
+        {/* Chip 1: 5 Agenti AI */}
+        <div
+          role="listitem"
+          className="flex items-center gap-2 px-4 py-2 rounded-full bg-purple-100 dark:bg-purple-900/40"
+        >
+          <Brain
+            className="w-4 h-4 text-purple-500 flex-shrink-0"
+            aria-hidden="true"
+          />
+          <span className="text-sm font-medium text-purple-700 dark:text-purple-300">
+            5 Agenti AI
+          </span>
+        </div>
+
+        {/* Chip 2: Gamification */}
+        <div
+          role="listitem"
+          className="flex items-center gap-2 px-4 py-2 rounded-full bg-blue-100 dark:bg-blue-900/40"
+        >
+          <Diamond
+            className="w-4 h-4 text-blue-500 flex-shrink-0"
+            aria-hidden="true"
+          />
+          <span className="text-sm font-medium text-blue-700 dark:text-blue-300">
+            Gamification
+          </span>
+        </div>
+
+        {/* Chip 3: Analisi Smart */}
+        <div
+          role="listitem"
+          className="flex items-center gap-2 px-4 py-2 rounded-full bg-green-100 dark:bg-green-900/40"
+        >
+          <TrendingUp
+            className="w-4 h-4 text-green-500 flex-shrink-0"
+            aria-hidden="true"
+          />
+          <span className="text-sm font-medium text-green-700 dark:text-green-300">
+            Analisi Smart
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/store/onboarding-plan.store.ts
+++ b/apps/web/src/store/onboarding-plan.store.ts
@@ -1,7 +1,8 @@
 /**
- * Onboarding Plan Store — Sprint 1.5
+ * Onboarding Plan Store — Sprint 1.5 / Sprint 1.5.2 WP-B
  *
- * Zustand store for 5-step "Piano Generato" wizard state.
+ * Zustand store for 6-step "Piano Generato" wizard state.
+ * Step layout: 1=Benvenuto, 2=Reddito, 3=Risparmio, 4=Obiettivi, 5=Piano, 6=Preferenze AI
  * Consumes WizardState contract from types/onboarding-plan.ts.
  *
  * @module store/onboarding-plan.store
@@ -26,8 +27,9 @@ export const INCOME_MIN = 100;
 export const INCOME_MAX = 100_000;
 
 /**
- * Returns true when Step 1 income value is within accepted bounds.
+ * Returns true when the income step value (Step 2 after WP-B renumber) is within accepted bounds.
  * 0 = not yet entered (initial state) or skipped -> false.
+ * @deprecated name kept for backwards-compat; semantically "canAdvanceFromIncomeStep" post WP-B
  */
 export const selectCanAdvanceFromStep1 = (s: WizardState): boolean => {
   const income = s.step1.monthlyIncome;
@@ -122,7 +124,7 @@ export const useOnboardingPlanStore = create<WizardStore>((set) => ({
   setStep: (step) => set({ currentStep: step }),
   nextStep: () =>
     set((s) => ({
-      currentStep: (s.currentStep < 5 ? s.currentStep + 1 : s.currentStep) as WizardStep,
+      currentStep: (s.currentStep < 6 ? s.currentStep + 1 : s.currentStep) as WizardStep,
     })),
   prevStep: () =>
     set((s) => ({

--- a/apps/web/src/types/onboarding-plan.ts
+++ b/apps/web/src/types/onboarding-plan.ts
@@ -121,7 +121,11 @@ export interface AllocationResult {
 // Wizard state (Stream A owns, used in Zustand store)
 // ─────────────────────────────────────────────────────────────────────────
 
-export type WizardStep = 1 | 2 | 3 | 4 | 5;
+/**
+ * 6-step wizard (Sprint 1.5.2 WP-B):
+ * 1=Benvenuto, 2=Reddito, 3=Risparmio, 4=Obiettivi, 5=Piano proposto, 6=Preferenze AI
+ */
+export type WizardStep = 1 | 2 | 3 | 4 | 5 | 6;
 
 export interface WizardStepIncome {
   monthlyIncome: number;


### PR DESCRIPTION
## Summary

- New `StepWelcome.tsx` (Step 1): animated Sparkles hero icon (purple-to-blue gradient), personalized greeting `"Ciao, {firstName}! 👋"` with null fallback, subtitle, and 3 feature chips (5 Agenti AI / Gamification / Analisi Smart)
- `WizardPianoGenerato.tsx`: Welcome inserted as Step 1, existing Steps 1-5 renumbered to 2-6; income gate moved from `currentStep === 1` to `currentStep === 2`; `STEP_CONFIG` now 6 entries; `aria-valuemax` updated to 6
- `WizardStep` type extended: `1|2|3|4|5` → `1|2|3|4|5|6`
- Store `nextStep` cap updated from `< 5` to `< 6`

## Test plan

- [x] `StepWelcome.test.tsx` (10 tests): firstName/null/empty fallback, subtitle, 3 chips, h1 level, aria list label — all green
- [x] `WizardPianoGenerato.test.tsx` (32 tests): aria-valuemax=6, 6 step labels, step-1 through step-6 stubs, all last-step references updated to step 6 — all green
- [x] Lint: 0 new errors (3 pre-existing warnings in unrelated files)
- [x] TypeScript: clean (pre-existing `@money-wise/ui` resolution warning in app-sidebar unrelated to WP-B)
- [x] Pre-commit hook passed (lint + typecheck + full test suite)

## Notes

- Wave 2 WP with expected merge conflict on `WizardPianoGenerato.tsx` and store after WP-C (Profilo merge) — expected per spec risk register
- `selectCanAdvanceFromStep1` name kept for backwards-compat, annotated `@deprecated` in JSDoc

🤖 Generated with [Claude Code](https://claude.com/claude-code)