### PR TITLE
fix(types): align database.types.ts con goals.type column (MED-11 pre-WP-K)

### DIFF
--- a/apps/web/src/utils/supabase/database.types.ts
+++ b/apps/web/src/utils/supabase/database.types.ts
@@ -633,7 +633,8 @@ export type Database = {
           name: string
           priority: number
           status: Database["public"]["Enums"]["goal_status"]
-          target: number
+          target: number | null
+          type: string
           updated_at: string
           user_id: string
         }
@@ -646,7 +647,8 @@ export type Database = {
           name: string
           priority: number
           status?: Database["public"]["Enums"]["goal_status"]
-          target: number
+          target?: number | null
+          type?: string
           updated_at?: string
           user_id: string
         }
@@ -659,7 +661,8 @@ export type Database = {
           name?: string
           priority?: number
           status?: Database["public"]["Enums"]["goal_status"]
-          target?: number
+          target?: number | null
+          type?: string
           updated_at?: string
           user_id?: string
         }


### PR DESCRIPTION
Sprint 1.5.2 pre-WP-K types alignment.

## Context
Migration \`20260420000000_add_goal_type_openended\` applicata su Supabase production 2026-04-20, ma \`database.types.ts\` non era stato rigenerato causando code/schema mismatch.

PR #477 che doveva portare l'integrazione TypeScript è stato chiuso per rebase conflict vs Wave 2 (HIGH-08+HIGH-07 merges). La migration è rimasta applicata ma i tipi orfani.

## Changes
- \`goals.Row/Insert/Update\`: aggiunto \`type: string\` (default 'fixed' su DB)
- \`goals.Row/Insert/Update\`: \`target\` → \`number | null\` (nullable post DROP NOT NULL)

Zero logic change — pure type alignment.

## Next
Sprint 1.5.2 Wave 3 WP-K completerà:
- AllocationAdvisor handle openended distribution
- StepGoals type toggle UI
- Replace \`inferGoalType\` name-heuristic (WP-G workaround) con \`goal.type\` reale
- Test openended scenarios

Refs: \`~/vault/moneywise/planning/sprint-1-5-2-overnight-report.md\` P1.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>