### PR TITLE
feat(goals): goal type integration cleanup (Sprint 1.5.2 WP-K)

### DIFF
--- a/apps/web/__tests__/components/goals/GoalCard.test.tsx
+++ b/apps/web/__tests__/components/goals/GoalCard.test.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '../../utils/test-utils';
 import userEvent from '@testing-library/user-event';
-import { GoalCard, inferGoalType } from '../../../src/components/goals/GoalCard';
+import { GoalCard, inferGoalType, inferGoalCategory } from '../../../src/components/goals/GoalCard';
 import type { Goal } from '../../../src/services/goals.client';
 
 const makeGoal = (overrides: Partial<Goal> = {}): Goal => ({
@@ -18,6 +18,7 @@ const makeGoal = (overrides: Partial<Goal> = {}): Goal => ({
   priority: 2,
   monthlyAllocation: 200,
   status: 'ACTIVE',
+  type: 'fixed',
   ...overrides,
 });
 
@@ -93,7 +94,7 @@ describe('GoalCard', () => {
   });
 });
 
-describe('inferGoalType', () => {
+describe('inferGoalType (deprecated alias)', () => {
   it('infers emergency from "Fondo Emergenza"', () => {
     expect(inferGoalType('Fondo Emergenza')).toBe('emergency');
   });
@@ -108,5 +109,82 @@ describe('inferGoalType', () => {
 
   it('infers savings by default for unknown names', () => {
     expect(inferGoalType('Comprare Casa')).toBe('savings');
+  });
+});
+
+describe('inferGoalCategory (WP-K renamed)', () => {
+  it('returns emergency for "Fondo Emergenza"', () => {
+    expect(inferGoalCategory('Fondo Emergenza')).toBe('emergency');
+  });
+
+  it('returns investment for "Portafoglio Crypto"', () => {
+    expect(inferGoalCategory('Portafoglio Crypto')).toBe('investment');
+  });
+
+  it('returns lifestyle for "Viaggio a Parigi"', () => {
+    expect(inferGoalCategory('Viaggio a Parigi')).toBe('lifestyle');
+  });
+});
+
+describe('GoalCard — WP-K openended display', () => {
+  it('shows "Aperto" badge for openended goals', () => {
+    render(
+      <GoalCard
+        goal={makeGoal({ type: 'openended', target: null, name: 'Fondo Emergenza' })}
+        onEditClick={vi.fn()}
+        onDeleteClick={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('goal-card-type-badge')).toBeInTheDocument();
+    expect(screen.getByTestId('goal-card-type-badge')).toHaveTextContent('Aperto');
+  });
+
+  it('does not show "Aperto" badge for fixed goals', () => {
+    render(
+      <GoalCard
+        goal={makeGoal({ type: 'fixed', target: 10000 })}
+        onEditClick={vi.fn()}
+        onDeleteClick={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId('goal-card-type-badge')).not.toBeInTheDocument();
+  });
+
+  it('hides progress bar for openended goals', () => {
+    render(
+      <GoalCard
+        goal={makeGoal({ type: 'openended', target: null, name: 'Fondo Emergenza' })}
+        onEditClick={vi.fn()}
+        onDeleteClick={vi.fn()}
+      />,
+    );
+    // Target element not rendered for openended
+    expect(screen.queryByTestId('goal-card-target')).not.toBeInTheDocument();
+    // Shows accumulated amount instead
+    expect(screen.getByText(/accumulati/i)).toBeInTheDocument();
+  });
+
+  it('shows target for fixed goals', () => {
+    render(
+      <GoalCard
+        goal={makeGoal({ type: 'fixed', target: 10000 })}
+        onEditClick={vi.fn()}
+        onDeleteClick={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('goal-card-target')).toBeInTheDocument();
+  });
+
+  it('goal.type drives openended display, not name heuristic', () => {
+    // A goal named "Risparmio" with type=openended should show as openended
+    render(
+      <GoalCard
+        goal={makeGoal({ type: 'openended', target: null, name: 'Risparmio Libero' })}
+        onEditClick={vi.fn()}
+        onDeleteClick={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('goal-card-type-badge')).toHaveTextContent('Aperto');
+    expect(screen.queryByTestId('goal-card-target')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/__tests__/components/onboarding/StepGoals.test.tsx
+++ b/apps/web/__tests__/components/onboarding/StepGoals.test.tsx
@@ -30,12 +30,15 @@ import type { PriorityRank } from '@/types/onboarding-plan';
 // Store mock — selector pattern
 // --------------------------------------------------------------------------
 
+import type { GoalType } from '@/types/onboarding-plan';
+
 type Goal = {
   tempId: string;
   name: string;
-  target: number;
+  target: number | null;
   deadline: string | null;
   priority: PriorityRank;
+  type?: GoalType;
 };
 
 const mockAddGoal = vi.fn();
@@ -125,15 +128,17 @@ describe('StepGoals', () => {
     expect(mockSetEditingGoal).toHaveBeenCalledWith(null);
   });
 
-  it('modal renders with pre-filled values when open with fondo-emergenza preset', () => {
+  it('modal renders with pre-filled values when open with fondo-emergenza preset (openended)', () => {
     mockStore.mockReturnValue(makeStoreState([], true, 'fondo-emergenza', null));
     render(<StepGoals />);
 
     const nameInput = screen.getByLabelText(/Nome/i);
     expect(nameInput).toHaveValue('Fondo Emergenza');
 
-    const targetInput = screen.getByLabelText(/Target \(€\)/i);
-    expect(targetInput).toHaveValue(5000);
+    // Fondo Emergenza is openended — target/deadline inputs are hidden
+    expect(screen.queryByLabelText(/Target \(€\)/i)).not.toBeInTheDocument();
+    // Openended hint should be visible
+    expect(screen.getByText(/Obiettivo aperto/i)).toBeInTheDocument();
   });
 
   it('modal renders with pre-filled values for comprare-casa preset', () => {
@@ -144,7 +149,7 @@ describe('StepGoals', () => {
     expect(targetInput).toHaveValue(50000);
   });
 
-  it('submitting preset-prefilled form calls addGoal + closes modal', async () => {
+  it('submitting preset-prefilled form (fondo-emergenza, openended) calls addGoal with type=openended + target=null', async () => {
     mockStore.mockReturnValue(makeStoreState([], true, 'fondo-emergenza', null));
     render(<StepGoals />);
 
@@ -155,8 +160,9 @@ describe('StepGoals', () => {
       expect(mockAddGoal).toHaveBeenCalledWith(
         expect.objectContaining({
           name: 'Fondo Emergenza',
-          target: 5000,
+          target: null,
           priority: 1,
+          type: 'openended',
         })
       );
       expect(mockSetAddGoalModalOpen).toHaveBeenCalledWith(false);
@@ -476,7 +482,77 @@ describe('StepGoals', () => {
     expect(mockSetAddGoalModalOpen).toHaveBeenCalledWith(false);
   });
 
-  // ---- 12. WP-D: Pencil button shows on goal cards -------------------------
+  // ---- 12. WP-K: Type toggle —————————————————————————————————————————————
+
+  it('type toggle renders two buttons: "Importo fisso" and "Aperto"', () => {
+    mockStore.mockReturnValue(makeStoreState([], true, null, null));
+    render(<StepGoals />);
+
+    expect(screen.getByTestId('goal-type-fixed')).toBeInTheDocument();
+    expect(screen.getByTestId('goal-type-openended')).toBeInTheDocument();
+  });
+
+  it('clicking "Aperto" hides Target/Scadenza inputs', async () => {
+    mockStore.mockReturnValue(makeStoreState([], true, null, null));
+    render(<StepGoals />);
+
+    // Initially fixed mode — Target visible
+    expect(screen.getByLabelText(/Target \(€\)/i)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByTestId('goal-type-openended'));
+
+    expect(screen.queryByLabelText(/Target \(€\)/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/Scadenza/i)).not.toBeInTheDocument();
+  });
+
+  it('openended mode shows hint text', async () => {
+    mockStore.mockReturnValue(makeStoreState([], true, null, null));
+    render(<StepGoals />);
+
+    await userEvent.click(screen.getByTestId('goal-type-openended'));
+
+    expect(screen.getByText(/Obiettivo aperto/i)).toBeInTheDocument();
+  });
+
+  it('submitting in openended mode calls addGoal with type=openended + target=null', async () => {
+    mockStore.mockReturnValue(makeStoreState([], true, null, null));
+    render(<StepGoals />);
+
+    await userEvent.click(screen.getByTestId('goal-type-openended'));
+    await userEvent.type(screen.getByLabelText(/Nome/i), 'Riserva Libera');
+
+    await userEvent.click(screen.getByRole('button', { name: /^Aggiungi$/ }));
+
+    await waitFor(() => {
+      expect(mockAddGoal).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Riserva Libera',
+          target: null,
+          type: 'openended',
+        })
+      );
+    });
+  });
+
+  it('submitting comprare-casa (fixed) preset calls addGoal with type=fixed', async () => {
+    mockStore.mockReturnValue(makeStoreState([], true, 'comprare-casa', null));
+    render(<StepGoals />);
+
+    const addButton = screen.getByRole('button', { name: /^Aggiungi$/ });
+    await userEvent.click(addButton);
+
+    await waitFor(() => {
+      expect(mockAddGoal).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Comprare Casa',
+          target: 50000,
+          type: 'fixed',
+        })
+      );
+    });
+  });
+
+  // ---- 13. WP-D: Pencil button shows on goal cards -------------------------
 
   it('each goal card shows a Pencil edit button', () => {
     mockStore.mockReturnValue(

--- a/apps/web/__tests__/lib/onboarding/allocation.test.ts
+++ b/apps/web/__tests__/lib/onboarding/allocation.test.ts
@@ -425,6 +425,26 @@ describe('WP-K: openended goal allocation', () => {
     expect(result.unallocated).toBeCloseTo(0, 2);
   });
 
+  it('rounding remainder distributed to last openended goal (€100/3 split)', () => {
+    // 100 / 3 = 33.33 each with _round2 → last goal absorbs remainder so unallocated = 0
+    const input = makeInput({
+      monthlyIncome: 2000, essentialsPct: 50, monthlySavingsTarget: 100,
+      goals: [
+        makeGoal({ id: 'oe-1', name: 'A', type: 'openended', target: null, priority: 1 }),
+        makeGoal({ id: 'oe-2', name: 'B', type: 'openended', target: null, priority: 2 }),
+        makeGoal({ id: 'oe-3', name: 'C', type: 'openended', target: null, priority: 3 }),
+      ],
+    });
+    const result = computeAllocation(input);
+    // Total must exactly equal the pool — no "budget residuo" warning from cent-level rounding
+    expect(result.totalAllocated).toBeCloseTo(100, 2);
+    expect(result.unallocated).toBeCloseTo(0, 2);
+    // Each item gets a positive amount
+    for (const it of result.items) {
+      expect(it.monthlyAmount).toBeGreaterThan(0);
+    }
+  });
+
   it('openended + fixed: waterfall exhausted → openended gets 0 + warning', () => {
     const input = makeInput({
       monthlyIncome: 2000, essentialsPct: 50, monthlySavingsTarget: 300,

--- a/apps/web/__tests__/lib/onboarding/allocation.test.ts
+++ b/apps/web/__tests__/lib/onboarding/allocation.test.ts
@@ -39,10 +39,11 @@ function makeGoal(partial: Partial<AllocationGoalInput>): AllocationGoalInput {
   return {
     id: partial.id ?? `goal-${++_goalIdCounter}`,
     name: partial.name ?? 'Generic Goal',
-    target: partial.target ?? 1000,
+    target: partial.target !== undefined ? partial.target : 1000,
     current: partial.current ?? 0,
     deadline: partial.deadline ?? null,
     priority: (partial.priority ?? 2) as PriorityRank,
+    type: partial.type ?? 'fixed',
   };
 }
 
@@ -365,6 +366,110 @@ describe('computeAllocation -- beta+gamma waterfall (issue #458)', () => {
     expect(result.items.find((it) => it.goalId === 'g-casa')!.monthlyAmount).toBeCloseTo(300, 2);
     expect(result.items.find((it) => it.goalId === 'g-viaggio')!.monthlyAmount).toBeCloseTo(0, 2);
     expect(result.totalAllocated).toBeCloseTo(300, 2);
+  });
+});
+
+describe('WP-K: openended goal allocation', () => {
+  beforeEach(() => {
+    _goalIdCounter = 0;
+    vi.useFakeTimers();
+    vi.setSystemTime(TODAY);
+  });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('single openended goal receives full waterfall remainder (pool after no fixed goals)', () => {
+    const input = makeInput({
+      monthlyIncome: 2500, essentialsPct: 50, monthlySavingsTarget: 500,
+      goals: [makeGoal({ id: 'oe-1', name: 'Risparmio Libero', type: 'openended', target: null })],
+    });
+    const result = computeAllocation(input);
+    expect(result.items[0]!.goalId).toBe('oe-1');
+    expect(result.items[0]!.monthlyAmount).toBeCloseTo(500, 2);
+    expect(result.items[0]!.deadlineFeasible).toBe(true);
+    expect(result.totalAllocated).toBeCloseTo(500, 2);
+    expect(result.unallocated).toBeCloseTo(0, 2);
+  });
+
+  it('fixed + openended: fixed consumes first, openended gets residual', () => {
+    const input = makeInput({
+      monthlyIncome: 2500, essentialsPct: 50, monthlySavingsTarget: 500,
+      goals: [
+        makeGoal({ id: 'fixed-1', name: 'Comprare Casa', type: 'fixed', target: 6000, current: 0, deadline: monthsFromToday(24), priority: 1 }),
+        makeGoal({ id: 'oe-1', name: 'Risparmio Libero', type: 'openended', target: null, priority: 2 }),
+      ],
+    });
+    const result = computeAllocation(input);
+    const fixedItem = result.items.find((it) => it.goalId === 'fixed-1');
+    const oeItem = result.items.find((it) => it.goalId === 'oe-1');
+    expect(fixedItem!.monthlyAmount).toBeCloseTo(250, 2); // 6000/24
+    expect(oeItem!.monthlyAmount).toBeCloseTo(250, 2); // 500 - 250
+    expect(result.totalAllocated).toBeCloseTo(500, 2);
+  });
+
+  it('multiple openended goals split residual equally', () => {
+    const input = makeInput({
+      monthlyIncome: 3000, essentialsPct: 50, monthlySavingsTarget: 600,
+      goals: [
+        makeGoal({ id: 'oe-1', name: 'Fondo Lifestyle', type: 'openended', target: null, priority: 2 }),
+        makeGoal({ id: 'oe-2', name: 'Riserva Opportunità', type: 'openended', target: null, priority: 3 }),
+        makeGoal({ id: 'oe-3', name: 'Crescita Patrimonio', type: 'openended', target: null, priority: 1 }),
+      ],
+    });
+    const result = computeAllocation(input);
+    const amounts = result.items.map((it) => it.monthlyAmount);
+    // All three should get equal shares of 600/3 = 200
+    for (const amt of amounts) {
+      expect(amt).toBeCloseTo(200, 2);
+    }
+    expect(result.totalAllocated).toBeCloseTo(600, 2);
+    expect(result.unallocated).toBeCloseTo(0, 2);
+  });
+
+  it('openended + fixed: waterfall exhausted → openended gets 0 + warning', () => {
+    const input = makeInput({
+      monthlyIncome: 2000, essentialsPct: 50, monthlySavingsTarget: 300,
+      goals: [
+        makeGoal({ id: 'fixed-1', name: 'Casa', type: 'fixed', target: 50000, current: 0, deadline: monthsFromToday(24), priority: 1 }),
+        makeGoal({ id: 'oe-1', name: 'Risparmio Libero', type: 'openended', target: null, priority: 2 }),
+      ],
+    });
+    const result = computeAllocation(input);
+    const fixedItem = result.items.find((it) => it.goalId === 'fixed-1');
+    const oeItem = result.items.find((it) => it.goalId === 'oe-1');
+    expect(fixedItem!.monthlyAmount).toBeCloseTo(300, 2);
+    expect(oeItem!.monthlyAmount).toBeCloseTo(0, 2);
+    expect(oeItem!.deadlineFeasible).toBe(true);
+    expect(oeItem!.warnings.some((w) => /esaurit|budget|aperto/i.test(w))).toBe(true);
+  });
+
+  it('openended emergency (Fondo Emergenza type=openended, target=null) gets 40% floor', () => {
+    const input = makeInput({
+      monthlyIncome: 2500, essentialsPct: 50, monthlySavingsTarget: 500,
+      goals: [
+        makeGoal({ id: 'emerg', name: 'Fondo Emergenza', type: 'openended', target: null, priority: 1 }),
+        makeGoal({ id: 'casa', name: 'Comprare Casa', type: 'fixed', target: 10000, current: 0, deadline: monthsFromToday(20), priority: 2 }),
+      ],
+    });
+    const result = computeAllocation(input);
+    const emergItem = result.items.find((it) => it.goalId === 'emerg');
+    // Emergency floor: 500 * 0.4 = 200
+    expect(emergItem!.monthlyAmount).toBeCloseTo(200, 2);
+    expect(emergItem!.deadlineFeasible).toBe(true);
+    // Casa gets remainder = 300
+    const casaItem = result.items.find((it) => it.goalId === 'casa');
+    expect(casaItem!.monthlyAmount).toBeCloseTo(300, 2);
+    expect(result.totalAllocated).toBeCloseTo(500, 2);
+  });
+
+  it('openended reasoning contains "Obiettivo aperto" or "residuo"', () => {
+    const input = makeInput({
+      monthlyIncome: 2500, essentialsPct: 50, monthlySavingsTarget: 400,
+      goals: [
+        makeGoal({ id: 'oe-1', name: 'Fondo Libero', type: 'openended', target: null, priority: 2 }),
+      ],
+    });
+    const result = computeAllocation(input);
+    expect(result.items[0]!.reasoning.toLowerCase()).toMatch(/aperto|residuo/);
   });
 });
 

--- a/apps/web/src/components/goals/GoalCard.tsx
+++ b/apps/web/src/components/goals/GoalCard.tsx
@@ -8,19 +8,27 @@ import {
   Target,
   Trash2,
   Calendar,
+  Infinity as InfinityIcon,
 } from 'lucide-react';
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
 import { PRIORITY_LABEL_IT, type PriorityRank } from '@/types/onboarding-plan';
-import type { GoalType } from './GoalTypeFilter';
+import type { GoalCategory } from './GoalTypeFilter';
 import type { Goal } from '@/services/goals.client';
 
 // =============================================================================
-// Type inference helper (pre-MED-11: heuristic from name)
+// Category inference helper (UI grouping from name — NOT the DB type field)
 // =============================================================================
 
-export function inferGoalType(name: string): GoalType {
+/**
+ * Derives a display category from the goal name for icon/color purposes.
+ * This is a UI heuristic; do NOT use it as a substitute for `goal.type`.
+ *
+ * WP-K: renamed from inferGoalType → inferGoalCategory (old name kept as
+ * deprecated alias to avoid breaking existing callers during migration).
+ */
+export function inferGoalCategory(name: string): GoalCategory {
   const lower = name.toLowerCase();
   if (lower.includes('emergenza') || lower.includes('fondo')) return 'emergency';
   if (lower.includes('debito') || lower.includes('debiti') || lower.includes('prestito')) return 'debt';
@@ -29,11 +37,16 @@ export function inferGoalType(name: string): GoalType {
   return 'savings';
 }
 
+/** @deprecated use inferGoalCategory — kept for backward compat */
+export function inferGoalType(name: string): GoalCategory {
+  return inferGoalCategory(name);
+}
+
 // =============================================================================
-// Icon per type
+// Icon per category
 // =============================================================================
 
-const TYPE_ICON: Record<GoalType, React.ComponentType<{ className?: string }>> = {
+const CATEGORY_ICON: Record<GoalCategory, React.ComponentType<{ className?: string }>> = {
   all: Target,
   emergency: PiggyBank,
   savings: Star,
@@ -42,7 +55,7 @@ const TYPE_ICON: Record<GoalType, React.ComponentType<{ className?: string }>> =
   lifestyle: Star,
 };
 
-const TYPE_COLOR: Record<GoalType, { bg: string; text: string; light: string }> = {
+const CATEGORY_COLOR: Record<GoalCategory, { bg: string; text: string; light: string }> = {
   all: { bg: 'bg-blue-600', text: 'text-blue-600', light: 'bg-blue-50 dark:bg-blue-950/30' },
   emergency: { bg: 'bg-blue-600', text: 'text-blue-600', light: 'bg-blue-50 dark:bg-blue-950/30' },
   savings: { bg: 'bg-emerald-600', text: 'text-emerald-600', light: 'bg-emerald-50 dark:bg-emerald-950/30' },
@@ -68,13 +81,17 @@ interface GoalCardProps {
 }
 
 export function GoalCard({ goal, onEditClick, onDeleteClick }: GoalCardProps) {
-  const type = inferGoalType(goal.name);
-  const Icon = TYPE_ICON[type];
-  const colors = TYPE_COLOR[type];
+  // WP-K: use goal.type (DB field) for openended-specific display logic.
+  // Use inferGoalCategory for icon/color (name heuristic — independent of type).
+  const isOpenended = goal.type === 'openended';
+  const category = inferGoalCategory(goal.name);
+  const Icon = CATEGORY_ICON[category];
+  const colors = CATEGORY_COLOR[category];
   const priorityColor = PRIORITY_COLOR[goal.priority];
 
-  const pct = goal.target > 0 ? Math.min(100, (goal.current / goal.target) * 100) : 0;
-  const remaining = Math.max(0, goal.target - goal.current);
+  const effectiveTarget = goal.target ?? 0;
+  const pct = effectiveTarget > 0 ? Math.min(100, (goal.current / effectiveTarget) * 100) : 0;
+  const remaining = Math.max(0, effectiveTarget - goal.current);
 
   let daysLeft: number | null = null;
   if (goal.deadline) {
@@ -106,14 +123,26 @@ export function GoalCard({ goal, onEditClick, onDeleteClick }: GoalCardProps) {
             >
               {goal.name}
             </h3>
-            <Badge
-              variant="outline"
-              className="text-xs mt-0.5"
-              data-testid="goal-card-priority"
-            >
-              <span className={`inline-block w-1.5 h-1.5 rounded-full mr-1 ${priorityColor.bg}`} />
-              {PRIORITY_LABEL_IT[goal.priority]}
-            </Badge>
+            <div className="flex items-center gap-1 mt-0.5 flex-wrap">
+              <Badge
+                variant="outline"
+                className="text-xs"
+                data-testid="goal-card-priority"
+              >
+                <span className={`inline-block w-1.5 h-1.5 rounded-full mr-1 ${priorityColor.bg}`} />
+                {PRIORITY_LABEL_IT[goal.priority]}
+              </Badge>
+              {isOpenended && (
+                <Badge
+                  variant="outline"
+                  className="text-xs gap-1"
+                  data-testid="goal-card-type-badge"
+                >
+                  <InfinityIcon className="w-3 h-3" />
+                  Aperto
+                </Badge>
+              )}
+            </div>
           </div>
         </div>
 
@@ -131,21 +160,35 @@ export function GoalCard({ goal, onEditClick, onDeleteClick }: GoalCardProps) {
         </button>
       </div>
 
-      <div className="mb-3">
-        <div className="flex justify-between text-sm mb-1.5">
-          <span className="text-muted-foreground">
-            &euro;{goal.current.toLocaleString('it-IT')}
-          </span>
-          <span
-            data-testid="goal-card-target"
-            className="font-semibold text-foreground"
-          >
-            &euro;{goal.target.toLocaleString('it-IT')}
-          </span>
+      {/* Target/progress: hidden for openended goals (no concrete target) */}
+      {!isOpenended && (
+        <div className="mb-3">
+          <div className="flex justify-between text-sm mb-1.5">
+            <span className="text-muted-foreground">
+              &euro;{goal.current.toLocaleString('it-IT')}
+            </span>
+            <span
+              data-testid="goal-card-target"
+              className="font-semibold text-foreground"
+            >
+              &euro;{effectiveTarget.toLocaleString('it-IT')}
+            </span>
+          </div>
+          <Progress value={pct} className="h-2" />
+          <p className={`text-xs font-bold mt-1 ${colors.text}`}>{pct.toFixed(0)}%</p>
         </div>
-        <Progress value={pct} className="h-2" />
-        <p className={`text-xs font-bold mt-1 ${colors.text}`}>{pct.toFixed(0)}%</p>
-      </div>
+      )}
+
+      {isOpenended && (
+        <div className="mb-3">
+          <p className="text-xs text-muted-foreground italic">
+            Obiettivo aperto — accumulo continuo senza target fisso
+          </p>
+          <p className="text-sm font-medium text-foreground mt-1">
+            &euro;{goal.current.toLocaleString('it-IT')} accumulati
+          </p>
+        </div>
+      )}
 
       <div className="grid grid-cols-2 gap-2 pt-3 border-t border-border/40">
         <div>
@@ -168,7 +211,7 @@ export function GoalCard({ goal, onEditClick, onDeleteClick }: GoalCardProps) {
         </div>
       </div>
 
-      {remaining > 0 && (
+      {!isOpenended && remaining > 0 && (
         <p className="text-xs text-muted-foreground mt-2">
           Mancano &euro;{remaining.toLocaleString('it-IT')} al target
         </p>

--- a/apps/web/src/components/goals/GoalTypeFilter.tsx
+++ b/apps/web/src/components/goals/GoalTypeFilter.tsx
@@ -1,19 +1,25 @@
 'use client';
 
 /**
- * GoalTypeFilter — horizontal chip row for filtering by goal type.
- * Since MED-11 migration (adds `type` column) is not yet applied, type is
- * inferred from goal names via heuristics in the parent page.
+ * GoalTypeFilter — horizontal chip row for filtering by goal category.
+ *
+ * WP-K: `GoalType` renamed to `GoalCategory` to avoid collision with the new
+ * DB-level `GoalType = 'fixed' | 'openended'` in types/onboarding-plan.ts.
+ * The 5-category taxonomy (emergency / savings / investment / debt / lifestyle)
+ * is a UI grouping derived from the goal name heuristic, not the DB field.
  */
 
-export type GoalType = 'all' | 'emergency' | 'savings' | 'investment' | 'debt' | 'lifestyle';
+export type GoalCategory = 'all' | 'emergency' | 'savings' | 'investment' | 'debt' | 'lifestyle';
+
+/** @deprecated use GoalCategory — alias kept for incremental migration */
+export type GoalType = GoalCategory;
 
 interface GoalTypeFilterProps {
-  selected: GoalType;
-  onTypeSelect: (type: GoalType) => void;
+  selected: GoalCategory;
+  onTypeSelect: (type: GoalCategory) => void;
 }
 
-const CHIPS: { type: GoalType; label: string }[] = [
+const CHIPS: { type: GoalCategory; label: string }[] = [
   { type: 'all', label: 'Tutti' },
   { type: 'emergency', label: 'Emergenza' },
   { type: 'savings', label: 'Risparmio' },

--- a/apps/web/src/components/onboarding/WizardPianoGenerato.tsx
+++ b/apps/web/src/components/onboarding/WizardPianoGenerato.tsx
@@ -119,6 +119,7 @@ export function WizardPianoGenerato({ mode = 'create', onClose }: WizardPianoGen
             target: g.target,
             deadline: g.deadline,
             priority: g.priority,
+            type: g.type ?? 'fixed',
             monthlyAllocation: item?.monthlyAmount ?? 0,
             allocation: {
               monthlyAmount: item?.monthlyAmount ?? 0,

--- a/apps/web/src/components/onboarding/steps/StepGoals.tsx
+++ b/apps/web/src/components/onboarding/steps/StepGoals.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef } from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
 import { useOnboardingPlanStore } from '@/store/onboarding-plan.store';
-import { PRIORITY_LABEL_IT, type PriorityRank, type WizardGoalDraft } from '@/types/onboarding-plan';
+import { PRIORITY_LABEL_IT, type PriorityRank, type WizardGoalDraft, type GoalType } from '@/types/onboarding-plan';
 import { Button } from '@/components/ui/button';
 import {
   Plus,
@@ -31,6 +31,8 @@ interface PresetGoal {
   defaultTarget: number;
   defaultDeadlineMonths: number;
   priority: PriorityRank;
+  /** DB type field. 'openended' for Fondo Emergenza. */
+  type: GoalType;
 }
 
 const PRESET_GOALS: PresetGoal[] = [
@@ -43,6 +45,7 @@ const PRESET_GOALS: PresetGoal[] = [
     defaultTarget: 5000,
     defaultDeadlineMonths: 12,
     priority: 1,
+    type: 'openended',
   },
   {
     id: 'comprare-casa',
@@ -53,6 +56,7 @@ const PRESET_GOALS: PresetGoal[] = [
     defaultTarget: 50000,
     defaultDeadlineMonths: 60,
     priority: 2,
+    type: 'fixed',
   },
   {
     id: 'iniziare-a-investire',
@@ -63,6 +67,7 @@ const PRESET_GOALS: PresetGoal[] = [
     defaultTarget: 10000,
     defaultDeadlineMonths: 24,
     priority: 2,
+    type: 'fixed',
   },
   {
     id: 'eliminare-debiti',
@@ -73,6 +78,7 @@ const PRESET_GOALS: PresetGoal[] = [
     defaultTarget: 3000,
     defaultDeadlineMonths: 12,
     priority: 1,
+    type: 'fixed',
   },
   {
     id: 'risparmiare-di-piu',
@@ -83,6 +89,7 @@ const PRESET_GOALS: PresetGoal[] = [
     defaultTarget: 5000,
     defaultDeadlineMonths: 12,
     priority: 3,
+    type: 'fixed',
   },
   {
     id: 'viaggi-vacanza',
@@ -93,6 +100,7 @@ const PRESET_GOALS: PresetGoal[] = [
     defaultTarget: 2000,
     defaultDeadlineMonths: 6,
     priority: 3,
+    type: 'fixed',
   },
   {
     id: 'far-crescere-patrimonio',
@@ -103,6 +111,7 @@ const PRESET_GOALS: PresetGoal[] = [
     defaultTarget: 20000,
     defaultDeadlineMonths: 36,
     priority: 2,
+    type: 'fixed',
   },
 ];
 
@@ -121,6 +130,8 @@ interface DraftState {
   target: string;
   deadline: string;
   priority: PriorityRank;
+  /** DB type: 'fixed' = has concrete target; 'openended' = no hard target. */
+  type: GoalType;
 }
 
 const EMPTY_DRAFT: DraftState = {
@@ -128,6 +139,7 @@ const EMPTY_DRAFT: DraftState = {
   target: '',
   deadline: '',
   priority: 2,
+  type: 'fixed',
 };
 
 // ---------------------------------------------------------------------------
@@ -140,7 +152,7 @@ interface AddGoalModalProps {
   presetId: string | null;
   /** When set, modal is in edit mode and pre-fills from this goal. */
   editingGoal: WizardGoalDraft | null;
-  onSubmit: (goal: { name: string; target: number; deadline: string | null; priority: PriorityRank }) => void;
+  onSubmit: (goal: { name: string; target: number | null; deadline: string | null; priority: PriorityRank; type: GoalType }) => void;
 }
 
 function AddGoalModal({ open, onOpenChange, presetId, editingGoal, onSubmit }: AddGoalModalProps) {
@@ -155,9 +167,10 @@ function AddGoalModal({ open, onOpenChange, presetId, editingGoal, onSubmit }: A
         // Edit mode: pre-fill from existing goal
         setDraft({
           name: editingGoal.name,
-          target: String(editingGoal.target),
+          target: editingGoal.target !== null ? String(editingGoal.target) : '',
           deadline: editingGoal.deadline ?? '',
           priority: editingGoal.priority,
+          type: editingGoal.type ?? 'fixed',
         });
       } else if (presetId) {
         // Add mode via preset: pre-fill from preset defaults
@@ -165,9 +178,10 @@ function AddGoalModal({ open, onOpenChange, presetId, editingGoal, onSubmit }: A
         if (preset) {
           setDraft({
             name: preset.name,
-            target: String(preset.defaultTarget),
-            deadline: addMonthsToToday(preset.defaultDeadlineMonths),
+            target: preset.type === 'openended' ? '' : String(preset.defaultTarget),
+            deadline: preset.type === 'openended' ? '' : addMonthsToToday(preset.defaultDeadlineMonths),
             priority: preset.priority,
+            type: preset.type,
           });
         }
       } else {
@@ -177,14 +191,19 @@ function AddGoalModal({ open, onOpenChange, presetId, editingGoal, onSubmit }: A
     }
   }, [open, presetId, editingGoal, isEditMode]);
 
+  const isOpenended = draft.type === 'openended';
+
   const handleSubmit = () => {
-    const target = Number(draft.target);
-    if (!draft.name || target <= 0) return;
+    if (!draft.name) return;
+    // Openended: target is null; fixed: target must be > 0
+    const target = isOpenended ? null : Number(draft.target);
+    if (!isOpenended && (!target || target <= 0)) return;
     onSubmit({
       name: draft.name,
       target,
       deadline: draft.deadline || null,
       priority: draft.priority,
+      type: draft.type,
     });
   };
 
@@ -217,6 +236,52 @@ function AddGoalModal({ open, onOpenChange, presetId, editingGoal, onSubmit }: A
           </div>
 
           <div className="space-y-3">
+            {/* Type toggle: fixed / openended */}
+            <div>
+              <label className="text-sm font-medium text-foreground block mb-1">
+                Tipo obiettivo
+              </label>
+              <div
+                className="flex rounded-xl border border-border overflow-hidden"
+                role="group"
+                aria-label="Tipo obiettivo"
+              >
+                <button
+                  type="button"
+                  data-testid="goal-type-fixed"
+                  onClick={() => setDraft({ ...draft, type: 'fixed' })}
+                  className={[
+                    'flex-1 px-3 py-2 text-sm font-medium transition-colors',
+                    draft.type === 'fixed'
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-muted/50 text-muted-foreground hover:bg-muted',
+                  ].join(' ')}
+                  aria-pressed={draft.type === 'fixed'}
+                >
+                  Importo fisso
+                </button>
+                <button
+                  type="button"
+                  data-testid="goal-type-openended"
+                  onClick={() => setDraft({ ...draft, type: 'openended', target: '', deadline: '' })}
+                  className={[
+                    'flex-1 px-3 py-2 text-sm font-medium transition-colors',
+                    draft.type === 'openended'
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-muted/50 text-muted-foreground hover:bg-muted',
+                  ].join(' ')}
+                  aria-pressed={draft.type === 'openended'}
+                >
+                  Aperto
+                </button>
+              </div>
+              {isOpenended && (
+                <p className="text-xs text-muted-foreground mt-1">
+                  Obiettivo aperto: riceve la quota residua ogni mese, senza target fisso.
+                </p>
+              )}
+            </div>
+
             <div>
               <label htmlFor="goal-name" className="text-sm font-medium text-foreground block mb-1">
                 Nome
@@ -232,34 +297,37 @@ function AddGoalModal({ open, onOpenChange, presetId, editingGoal, onSubmit }: A
               />
             </div>
 
-            <div className="grid grid-cols-2 gap-3">
-              <div>
-                <label htmlFor="goal-target" className="text-sm font-medium text-foreground block mb-1">
-                  Target (€)
-                </label>
-                <input
-                  id="goal-target"
-                  type="number"
-                  min={0}
-                  value={draft.target}
-                  onChange={(e) => setDraft({ ...draft, target: e.target.value })}
-                  className="w-full bg-muted/50 border border-border rounded-xl px-3 py-2 text-sm text-foreground"
-                  placeholder="15000"
-                />
+            {/* Target + deadline: hidden for openended */}
+            {!isOpenended && (
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label htmlFor="goal-target" className="text-sm font-medium text-foreground block mb-1">
+                    Target (€)
+                  </label>
+                  <input
+                    id="goal-target"
+                    type="number"
+                    min={0}
+                    value={draft.target}
+                    onChange={(e) => setDraft({ ...draft, target: e.target.value })}
+                    className="w-full bg-muted/50 border border-border rounded-xl px-3 py-2 text-sm text-foreground"
+                    placeholder="15000"
+                  />
+                </div>
+                <div>
+                  <label htmlFor="goal-deadline" className="text-sm font-medium text-foreground block mb-1">
+                    Scadenza (opzionale)
+                  </label>
+                  <input
+                    id="goal-deadline"
+                    type="date"
+                    value={draft.deadline}
+                    onChange={(e) => setDraft({ ...draft, deadline: e.target.value })}
+                    className="w-full bg-muted/50 border border-border rounded-xl px-3 py-2 text-sm text-foreground"
+                  />
+                </div>
               </div>
-              <div>
-                <label htmlFor="goal-deadline" className="text-sm font-medium text-foreground block mb-1">
-                  Scadenza (opzionale)
-                </label>
-                <input
-                  id="goal-deadline"
-                  type="date"
-                  value={draft.deadline}
-                  onChange={(e) => setDraft({ ...draft, deadline: e.target.value })}
-                  className="w-full bg-muted/50 border border-border rounded-xl px-3 py-2 text-sm text-foreground"
-                />
-              </div>
-            </div>
+            )}
 
             <div>
               <label htmlFor="goal-priority" className="text-sm font-medium text-foreground block mb-1">
@@ -344,7 +412,7 @@ export function StepGoals() {
     }
   };
 
-  const handleSubmit = (goal: { name: string; target: number; deadline: string | null; priority: PriorityRank }) => {
+  const handleSubmit = (goal: { name: string; target: number | null; deadline: string | null; priority: PriorityRank; type: GoalType }) => {
     if (editingGoalId) {
       updateGoal(editingGoalId, goal);
     } else {
@@ -415,7 +483,10 @@ export function StepGoals() {
               >
                 <p className="text-sm font-medium text-foreground">{g.name}</p>
                 <p className="text-xs text-muted-foreground">
-                  €{g.target.toLocaleString('it-IT')} — {PRIORITY_LABEL_IT[g.priority]} priorità
+                  {g.type === 'openended'
+                    ? 'Aperto'
+                    : `€${(g.target ?? 0).toLocaleString('it-IT')}`}{' '}
+                  — {PRIORITY_LABEL_IT[g.priority]} priorità
                   {g.deadline ? ` — entro ${g.deadline}` : ''}
                 </p>
               </div>

--- a/apps/web/src/lib/onboarding/allocation.ts
+++ b/apps/web/src/lib/onboarding/allocation.ts
@@ -71,12 +71,12 @@ function _buildReasoning(
   requiredMonthly: number,
   remainingPoolBefore: number,
 ): string {
+  if (isEmergency) {
+    return `Fondo di emergenza: allocazione prioritaria del ${Math.round(_EMERGENCY_OVERRIDE_FRACTION * 100)}% del budget mensile disponibile come protezione finanziaria.`;
+  }
   if (goal.target === null || goal.target === 0) {
     if (_isOpenended(goal)) return 'Obiettivo aperto: quota mensile dal budget residuo.';
     return 'Target non specificato';
-  }
-  if (isEmergency) {
-    return `Fondo di emergenza: allocazione prioritaria del ${Math.round(_EMERGENCY_OVERRIDE_FRACTION * 100)}% del budget mensile disponibile come protezione finanziaria.`;
   }
   const priorityLabel = goal.priority === 1 ? 'alta' : goal.priority === 2 ? 'media' : 'bassa';
   const parts: string[] = [`Priorità ${priorityLabel}`];
@@ -181,15 +181,23 @@ export function computeAllocation(input: AllocationInput): AllocationResult {
 
   const waterfallResults = _runWaterfall(otherGoals, remainingPool, now);
 
-  // Residual after waterfall → split equally among openended non-emergency goals
+  // Residual after waterfall → split equally among openended non-emergency goals.
+  // To avoid leaving cent-level residuals unallocated due to floating-point rounding,
+  // the last openended goal absorbs any remaining amount so the total matches the pool.
   const waterfallConsumed = _round2(waterfallResults.reduce((sum, e) => sum + e.amount, 0));
   const waterfallRemainder = _round2(remainingPool - waterfallConsumed);
   const openendedAmountMap = new Map<number, number>();
   if (openendedNonEmergencyGoals.length > 0 && waterfallRemainder > 0) {
     const perOpenended = _round2(waterfallRemainder / openendedNonEmergencyGoals.length);
-    for (const { originalIndex } of openendedNonEmergencyGoals) {
-      openendedAmountMap.set(originalIndex, perOpenended);
-    }
+    let allocatedToOpenended = 0;
+    openendedNonEmergencyGoals.forEach(({ originalIndex }, index) => {
+      const isLast = index === openendedNonEmergencyGoals.length - 1;
+      const amount = isLast
+        ? _round2(waterfallRemainder - allocatedToOpenended)
+        : perOpenended;
+      openendedAmountMap.set(originalIndex, amount);
+      allocatedToOpenended = _round2(allocatedToOpenended + amount);
+    });
   } else if (openendedNonEmergencyGoals.length > 0) {
     for (const { originalIndex } of openendedNonEmergencyGoals) {
       openendedAmountMap.set(originalIndex, 0);

--- a/apps/web/src/lib/onboarding/allocation.ts
+++ b/apps/web/src/lib/onboarding/allocation.ts
@@ -55,6 +55,10 @@ function _isEmergencyGoal(goal: AllocationGoalInput, _now: Date): boolean {
   return _EMERGENCY_NAME_PATTERN.test(goal.name);
 }
 
+function _isOpenended(goal: AllocationGoalInput): boolean {
+  return goal.type === 'openended';
+}
+
 function _round2(n: number): number {
   return Math.round(n * 100) / 100;
 }
@@ -67,7 +71,10 @@ function _buildReasoning(
   requiredMonthly: number,
   remainingPoolBefore: number,
 ): string {
-  if (goal.target === 0) return 'Target non specificato';
+  if (goal.target === null || goal.target === 0) {
+    if (_isOpenended(goal)) return 'Obiettivo aperto: quota mensile dal budget residuo.';
+    return 'Target non specificato';
+  }
   if (isEmergency) {
     return `Fondo di emergenza: allocazione prioritaria del ${Math.round(_EMERGENCY_OVERRIDE_FRACTION * 100)}% del budget mensile disponibile come protezione finanziaria.`;
   }
@@ -101,7 +108,8 @@ function _runWaterfall(
   let remainingPool = pool;
   const results: _WaterfallEntry[] = [];
   for (const { goal, originalIndex } of sorted) {
-    const need = Math.max(0, goal.target - goal.current);
+    const target = goal.target ?? 0;
+    const need = Math.max(0, target - goal.current);
     const deadlineDate = _parseDeadline(goal.deadline);
     const monthsLeft = deadlineDate ? _monthsDiff(now, deadlineDate) : null;
     const requiredMonthly =
@@ -139,24 +147,61 @@ export function computeAllocation(input: AllocationInput): AllocationResult {
   let emergencyAmount = 0;
   let remainingPool = savingsPool;
 
-  if (emergencyIndex >= 0 && goals[emergencyIndex]!.target > 0) {
+  if (emergencyIndex >= 0) {
     const emergencyGoal = goals[emergencyIndex]!;
-    const emergencyNeed = Math.max(0, emergencyGoal.target - emergencyGoal.current);
-    emergencyAmount = _round2(Math.min(savingsPool * _EMERGENCY_OVERRIDE_FRACTION, emergencyNeed));
-    remainingPool = _round2(savingsPool - emergencyAmount);
+    // Openended emergency: null target = uncapped need → take full 40% floor
+    const isOpenendedEmergency = _isOpenended(emergencyGoal);
+    const effectiveTarget = emergencyGoal.target ?? 0;
+    const emergencyNeed = isOpenendedEmergency
+      ? savingsPool * _EMERGENCY_OVERRIDE_FRACTION // no cap for openended
+      : Math.max(0, effectiveTarget - emergencyGoal.current);
+    if (isOpenendedEmergency || effectiveTarget > 0) {
+      emergencyAmount = _round2(Math.min(savingsPool * _EMERGENCY_OVERRIDE_FRACTION, emergencyNeed));
+      remainingPool = _round2(savingsPool - emergencyAmount);
+    }
   }
 
+  // Non-emergency, non-openended goals with a real target go into the waterfall.
+  // Openended goals (other than emergency) get the residual split after waterfall.
   const otherGoals: Array<{ goal: AllocationGoalInput; originalIndex: number }> = goals
     .map((goal, originalIndex) => ({ goal, originalIndex }))
-    .filter(({ originalIndex, goal }) => originalIndex !== emergencyIndex && goal.target > 0)
+    .filter(({ originalIndex, goal }) => {
+      if (originalIndex === emergencyIndex) return false;
+      if (_isOpenended(goal)) return false;
+      return (goal.target ?? 0) > 0;
+    })
     .sort((a, b) => (a.goal.priority as number) - (b.goal.priority as number));
+
+  const openendedNonEmergencyGoals: Array<{ goal: AllocationGoalInput; originalIndex: number }> = goals
+    .map((goal, originalIndex) => ({ goal, originalIndex }))
+    .filter(({ originalIndex, goal }) => {
+      if (originalIndex === emergencyIndex) return false;
+      return _isOpenended(goal);
+    });
 
   const waterfallResults = _runWaterfall(otherGoals, remainingPool, now);
 
+  // Residual after waterfall → split equally among openended non-emergency goals
+  const waterfallConsumed = _round2(waterfallResults.reduce((sum, e) => sum + e.amount, 0));
+  const waterfallRemainder = _round2(remainingPool - waterfallConsumed);
+  const openendedAmountMap = new Map<number, number>();
+  if (openendedNonEmergencyGoals.length > 0 && waterfallRemainder > 0) {
+    const perOpenended = _round2(waterfallRemainder / openendedNonEmergencyGoals.length);
+    for (const { originalIndex } of openendedNonEmergencyGoals) {
+      openendedAmountMap.set(originalIndex, perOpenended);
+    }
+  } else if (openendedNonEmergencyGoals.length > 0) {
+    for (const { originalIndex } of openendedNonEmergencyGoals) {
+      openendedAmountMap.set(originalIndex, 0);
+    }
+  }
+
   if (emergencyAmount > 0 && otherGoals.length > 0 && savingsPool > 0) {
+    // Gamma warning: compare pure waterfall (no emergency floor) vs actual.
+    // Only consider fixed goals for this comparison.
     const allNonZeroGoals: Array<{ goal: AllocationGoalInput; originalIndex: number }> = goals
       .map((goal, originalIndex) => ({ goal, originalIndex }))
-      .filter(({ goal }) => goal.target > 0)
+      .filter(({ goal }) => !_isOpenended(goal) && (goal.target ?? 0) > 0)
       .sort((a, b) => (a.goal.priority as number) - (b.goal.priority as number));
 
     const pureWaterfallResults = _runWaterfall(allNonZeroGoals, savingsPool, now);
@@ -186,7 +231,27 @@ export function computeAllocation(input: AllocationInput): AllocationResult {
     const isEmergency = i === emergencyIndex;
     const itemWarnings: string[] = [];
 
-    if (goal.target === 0) {
+    // Openended non-emergency: distribute from residual split
+    if (!isEmergency && _isOpenended(goal)) {
+      const openendedAmount = openendedAmountMap.get(i) ?? 0;
+      if (openendedAmount === 0) {
+        itemWarnings.push('Budget esaurito: obiettivo aperto non riceverà allocazione in questo mese.');
+      }
+      items.push({
+        goalId: goal.id, monthlyAmount: openendedAmount, deadlineFeasible: true,
+        reasoning: openendedAmount > 0
+          ? `Obiettivo aperto: quota mensile dal budget residuo (${_fmtEur(openendedAmount)}).`
+          : 'Obiettivo aperto: budget residuo esaurito.',
+        warnings: itemWarnings,
+      });
+      continue;
+    }
+
+    // effectiveTarget: use 0 for null (openended or unspecified) for numeric ops below
+    const effectiveTarget = goal.target ?? 0;
+
+    // Fixed non-emergency with target=0: no allocation
+    if (!isEmergency && !_isOpenended(goal) && effectiveTarget === 0) {
       items.push({
         goalId: goal.id, monthlyAmount: 0, deadlineFeasible: true,
         reasoning: 'Target non specificato',
@@ -198,20 +263,21 @@ export function computeAllocation(input: AllocationInput): AllocationResult {
     if (isEmergency) {
       const deadlineDate = _parseDeadline(goal.deadline);
       let deadlineFeasible = true;
-      if (deadlineDate !== null) {
+      // Openended emergency: no deadline feasibility check (no hard target)
+      if (deadlineDate !== null && !_isOpenended(goal)) {
         const monthsLeft = _monthsDiff(now, deadlineDate);
         if (monthsLeft < 0) {
           deadlineFeasible = false;
           itemWarnings.push('La scadenza di questo goal è già trascorsa.');
         } else if (emergencyAmount > 0) {
-          const remaining = Math.max(0, goal.target - goal.current);
+          const remaining = Math.max(0, effectiveTarget - goal.current);
           const reqM = monthsLeft > 0 ? remaining / monthsLeft : Infinity;
           if (reqM > emergencyAmount) {
             deadlineFeasible = false;
             itemWarnings.push(`Con ${_fmtEur(emergencyAmount)}/mese non sarà possibile raggiungere l'obiettivo entro la scadenza (necessari ${_fmtEur(reqM)}/mese).`);
           }
         } else {
-          const remaining = Math.max(0, goal.target - goal.current);
+          const remaining = Math.max(0, effectiveTarget - goal.current);
           if (remaining > 0) {
             deadlineFeasible = false;
             itemWarnings.push('Nessun importo allocato: la scadenza non sarà rispettata.');
@@ -253,7 +319,7 @@ export function computeAllocation(input: AllocationInput): AllocationResult {
           itemWarnings.push(`Budget insufficiente per raggiungere questo goal in tempo (necessari ${_fmtEur(requiredMonthly)}/mese, allocati ${_fmtEur(amount)}/mese).`);
         }
       } else {
-        const remaining = Math.max(0, goal.target - goal.current);
+        const remaining = Math.max(0, effectiveTarget - goal.current);
         if (remaining > 0) {
           deadlineFeasible = false;
           itemWarnings.push(`Budget insufficiente per raggiungere questo goal: importo allocato ${_fmtEur(0)}.`);
@@ -261,7 +327,7 @@ export function computeAllocation(input: AllocationInput): AllocationResult {
       }
     } else {
       if (amount === 0) {
-        const remaining = Math.max(0, goal.target - goal.current);
+        const remaining = Math.max(0, effectiveTarget - goal.current);
         if (remaining > 0) itemWarnings.push('Budget esaurito: questo goal non riceverà allocazione in questo mese.');
       }
     }

--- a/apps/web/src/services/goals.client.ts
+++ b/apps/web/src/services/goals.client.ts
@@ -7,7 +7,7 @@
  */
 
 import { createClient } from '@/utils/supabase/client';
-import type { PriorityRank } from '@/types/onboarding-plan';
+import type { PriorityRank, GoalType } from '@/types/onboarding-plan';
 
 // =============================================================================
 // Types
@@ -16,20 +16,25 @@ import type { PriorityRank } from '@/types/onboarding-plan';
 export interface Goal {
   id: string;
   name: string;
-  target: number;
+  /** Null for openended goals (no hard target). WP-K. */
+  target: number | null;
   current: number;
   deadline: string | null;
   priority: PriorityRank;
   monthlyAllocation: number;
   status: string;
+  /** DB type field: 'fixed' | 'openended'. Defaults to 'fixed'. WP-K. */
+  type: GoalType;
 }
 
 export interface GoalInput {
   name: string;
-  target: number;
+  /** Null for openended goals. */
+  target: number | null;
   deadline: string | null;
   priority: PriorityRank;
   monthlyAllocation?: number;
+  type?: GoalType;
 }
 
 export class GoalsApiError extends Error {
@@ -57,7 +62,7 @@ export const goalsClient = {
     const supabase = createClient();
     const { data, error } = await supabase
       .from('goals')
-      .select('id, name, target, current, deadline, priority, monthly_allocation, status')
+      .select('id, name, target, current, deadline, priority, monthly_allocation, status, type')
       .eq('user_id', userId)
       .eq('status', 'ACTIVE')
       .order('priority', { ascending: true });
@@ -67,12 +72,13 @@ export const goalsClient = {
     return (data ?? []).map((g) => ({
       id: g.id,
       name: g.name,
-      target: Number(g.target),
+      target: g.target !== null ? Number(g.target) : null,
       current: Number(g.current),
       deadline: g.deadline,
       priority: g.priority as PriorityRank,
       monthlyAllocation: Number(g.monthly_allocation),
       status: g.status,
+      type: (g.type ?? 'fixed') as GoalType,
     }));
   },
 
@@ -95,8 +101,9 @@ export const goalsClient = {
         priority: goal.priority,
         monthly_allocation: goal.monthlyAllocation ?? 0,
         status: 'ACTIVE' as const,
+        type: goal.type ?? 'fixed',
       })
-      .select('id, name, target, current, deadline, priority, monthly_allocation, status')
+      .select('id, name, target, current, deadline, priority, monthly_allocation, status, type')
       .single();
 
     if (error || !data) throw new GoalsApiError(error?.message ?? 'Failed to add goal', 500, error);
@@ -104,12 +111,13 @@ export const goalsClient = {
     return {
       id: data.id,
       name: data.name,
-      target: Number(data.target),
+      target: data.target !== null ? Number(data.target) : null,
       current: Number(data.current),
       deadline: data.deadline,
       priority: data.priority as PriorityRank,
       monthlyAllocation: Number(data.monthly_allocation),
       status: data.status,
+      type: (data.type ?? 'fixed') as GoalType,
     };
   },
 
@@ -129,9 +137,10 @@ export const goalsClient = {
         ...(patch.deadline !== undefined ? { deadline: patch.deadline } : {}),
         ...(patch.priority !== undefined ? { priority: patch.priority } : {}),
         ...(patch.monthlyAllocation !== undefined ? { monthly_allocation: patch.monthlyAllocation } : {}),
+        ...(patch.type !== undefined ? { type: patch.type } : {}),
       })
       .eq('id', goalId)
-      .select('id, name, target, current, deadline, priority, monthly_allocation, status')
+      .select('id, name, target, current, deadline, priority, monthly_allocation, status, type')
       .single();
 
     if (error || !data) throw new GoalsApiError(error?.message ?? 'Failed to update goal', 500, error);
@@ -139,12 +148,13 @@ export const goalsClient = {
     return {
       id: data.id,
       name: data.name,
-      target: Number(data.target),
+      target: data.target !== null ? Number(data.target) : null,
       current: Number(data.current),
       deadline: data.deadline,
       priority: data.priority as PriorityRank,
       monthlyAllocation: Number(data.monthly_allocation),
       status: data.status,
+      type: (data.type ?? 'fixed') as GoalType,
     };
   },
 

--- a/apps/web/src/services/onboarding-plan.client.ts
+++ b/apps/web/src/services/onboarding-plan.client.ts
@@ -16,7 +16,7 @@
  */
 
 import { createClient } from '@/utils/supabase/client';
-import type { PriorityRank } from '@/types/onboarding-plan';
+import type { PriorityRank, GoalType } from '@/types/onboarding-plan';
 
 // =============================================================================
 // Error class
@@ -52,10 +52,13 @@ export interface PersistPlanInput {
   };
   goals: Array<{
     name: string;
-    target: number;
+    /** Null for openended goals. WP-K. */
+    target: number | null;
     deadline: string | null;
     priority: PriorityRank;
     monthlyAllocation: number;
+    /** DB type field. WP-K. */
+    type: GoalType;
     allocation: {
       monthlyAmount: number;
       deadlineFeasible: boolean;
@@ -187,6 +190,7 @@ export const onboardingPlanClient = {
           priority: g.priority,
           monthly_allocation: g.monthlyAllocation,
           status: 'ACTIVE' as const,
+          type: g.type,
         })
         .select('id')
         .single();
@@ -292,12 +296,15 @@ export const onboardingPlanClient = {
     goals: Array<{
       id: string;
       name: string;
-      target: number;
+      /** Null for openended goals. WP-K. */
+      target: number | null;
       current: number;
       deadline: string | null;
       priority: PriorityRank;
       monthlyAllocation: number;
       status: string;
+      /** DB type field. WP-K. */
+      type: GoalType;
     }>;
     allocations: Array<{
       goalId: string;
@@ -325,7 +332,7 @@ export const onboardingPlanClient = {
 
     const { data: goalRows, error: goalsErr } = await supabase
       .from('goals')
-      .select('id, name, target, current, deadline, priority, monthly_allocation, status')
+      .select('id, name, target, current, deadline, priority, monthly_allocation, status, type')
       .eq('user_id', userId)
       .eq('status', 'ACTIVE')
       .order('priority', { ascending: true });
@@ -354,12 +361,13 @@ export const onboardingPlanClient = {
       goals: goalRows.map((g) => ({
         id: g.id,
         name: g.name,
-        target: Number(g.target),
+        target: g.target !== null ? Number(g.target) : null,
         current: Number(g.current),
         deadline: g.deadline,
         priority: g.priority as PriorityRank,
         monthlyAllocation: Number(g.monthly_allocation),
         status: g.status,
+        type: (g.type ?? 'fixed') as GoalType,
       })),
       allocations: allocRows.map((a) => ({
         goalId: a.goal_id,

--- a/apps/web/src/store/onboarding-plan.store.ts
+++ b/apps/web/src/store/onboarding-plan.store.ts
@@ -21,6 +21,7 @@ import type {
   WizardSkipState,
   WizardStepProfile,
   AllocationResult,
+  GoalType,
 } from '@/types/onboarding-plan';
 
 // -------------------------------------------------------------------------
@@ -97,12 +98,15 @@ export interface LoadedPlanBundle {
   goals: Array<{
     id: string;
     name: string;
-    target: number;
+    /** Null for openended goals. WP-K. */
+    target: number | null;
     current: number;
     deadline: string | null;
     priority: WizardGoalDraft['priority'];
     monthlyAllocation: number;
     status: string;
+    /** DB type field. WP-K. */
+    type: GoalType;
   }>;
   allocations: Array<{
     goalId: string;
@@ -126,7 +130,7 @@ interface Actions {
   updateSavingsTarget: (monthlySavingsTarget: number, essentialsPct?: number) => void;
   /** Update any subset of the Profilo step (step2) fields. */
   updateProfile: (patch: Partial<WizardStepProfile>) => void;
-  addGoal: (goal: Omit<WizardGoalDraft, 'tempId'>) => void;
+  addGoal: (goal: Omit<WizardGoalDraft, 'tempId'> & { type?: GoalType }) => void;
   updateGoal: (tempId: string, patch: Partial<Omit<WizardGoalDraft, 'tempId'>>) => void;
   removeGoal: (tempId: string) => void;
   setAllocationPreview: (allocation: AllocationResult | null) => void;
@@ -220,7 +224,7 @@ export const useOnboardingPlanStore = create<WizardStore>((set) => ({
   addGoal: (goal) =>
     set((s) => ({
       step3: {
-        goals: [...s.step3.goals, { ...goal, tempId: globalThis.crypto.randomUUID() }],
+        goals: [...s.step3.goals, { ...goal, type: goal.type ?? 'fixed', tempId: globalThis.crypto.randomUUID() }],
       },
     })),
   updateGoal: (tempId, patch) =>
@@ -294,6 +298,7 @@ export const useOnboardingPlanStore = create<WizardStore>((set) => ({
           target: g.target,
           deadline: g.deadline,
           priority: g.priority,
+          type: g.type,
         })),
       },
       step4: { allocationPreview, userOverrides: {} },

--- a/apps/web/src/store/onboarding-plan.store.ts
+++ b/apps/web/src/store/onboarding-plan.store.ts
@@ -130,7 +130,7 @@ interface Actions {
   updateSavingsTarget: (monthlySavingsTarget: number, essentialsPct?: number) => void;
   /** Update any subset of the Profilo step (step2) fields. */
   updateProfile: (patch: Partial<WizardStepProfile>) => void;
-  addGoal: (goal: Omit<WizardGoalDraft, 'tempId'> & { type?: GoalType }) => void;
+  addGoal: (goal: Omit<WizardGoalDraft, 'tempId' | 'type'> & { type?: GoalType }) => void;
   updateGoal: (tempId: string, patch: Partial<Omit<WizardGoalDraft, 'tempId'>>) => void;
   removeGoal: (tempId: string) => void;
   setAllocationPreview: (allocation: AllocationResult | null) => void;

--- a/apps/web/src/types/onboarding-plan.ts
+++ b/apps/web/src/types/onboarding-plan.ts
@@ -29,6 +29,15 @@ export type GoalAllocationInsert = Database['public']['Tables']['goal_allocation
 export type GoalStatus = Database['public']['Enums']['goal_status'];
 
 // ─────────────────────────────────────────────────────────────────────────
+// Goal type (DB TEXT column: 'fixed' | 'openended')
+// 'fixed' = has a concrete target amount + optional deadline
+// 'openended' = no hard target (e.g. Fondo Emergenza, general savings habit);
+//   target is nullable; deadline is optional informational hint.
+// ─────────────────────────────────────────────────────────────────────────
+
+export type GoalType = 'fixed' | 'openended';
+
+// ─────────────────────────────────────────────────────────────────────────
 // Priority mapping (DB SMALLINT 1-3 <-> UI labels)
 // ─────────────────────────────────────────────────────────────────────────
 
@@ -51,14 +60,22 @@ export const PRIORITY_URGENCY_FACTOR: Record<PriorityRank, number> = {
 /**
  * Goal input to the allocation algorithm.
  * Subset of GoalRow relevant for allocation decisions.
+ *
+ * WP-K: `type` added (default 'fixed'). `target` is now nullable:
+ *   - 'fixed' goals: target must be > 0 (validated before reaching algorithm)
+ *   - 'openended' goals: target may be null or 0; they receive the residual
+ *     pool split after the waterfall (equal share among openended goals).
  */
 export interface AllocationGoalInput {
   id: string;
   name: string;
-  target: number;
+  /** Null allowed for openended goals. */
+  target: number | null;
   current: number;
   deadline: string | null;
   priority: PriorityRank;
+  /** DB type field; defaults to 'fixed' when absent (backward compat). */
+  type?: GoalType;
 }
 
 /**
@@ -230,9 +247,12 @@ export interface WizardGoalDraft {
   /** Temp UUID for form state before DB insert. */
   tempId: string;
   name: string;
-  target: number;
+  /** Null for openended goals (no concrete target). */
+  target: number | null;
   deadline: string | null;
   priority: PriorityRank;
+  /** DB type field. Defaults to 'fixed'. */
+  type: GoalType;
 }
 
 export interface WizardStepGoals {

--- a/supabase/migrations/20260419210000_add_goal_type_openended.sql
+++ b/supabase/migrations/20260419210000_add_goal_type_openended.sql
@@ -26,6 +26,9 @@ ALTER TABLE goals
 
 -- 3. Re-add conditional CHECK: fixed goals must have a non-null, non-negative target.
 --    openended goals may have target IS NULL (no hard target).
+-- Idempotent: DROP IF EXISTS prima di ADD per permettere re-run (es. DB prod
+-- già aggiornato via MCP apply_migration prior ai commit landing in git).
+ALTER TABLE goals DROP CONSTRAINT IF EXISTS goals_target_fixed_not_null;
 ALTER TABLE goals
   ADD CONSTRAINT goals_target_fixed_not_null
   CHECK (

--- a/supabase/migrations/20260419210000_add_goal_type_openended.sql
+++ b/supabase/migrations/20260419210000_add_goal_type_openended.sql
@@ -1,0 +1,36 @@
+-- Sprint 1.5.2 WP-K — Goal Type: openended support
+-- Adds goals.type TEXT column (fixed | openended) and makes goals.target nullable.
+--
+-- Context:
+--   Sprint 1.5 migration (20260419160000_sprint_1_5_onboarding_plans.sql) created goals
+--   with target NUMERIC(15,2) NOT NULL and no type column.
+--   WP-K requires:
+--     - goals.type to distinguish between concrete-target goals and open-ended
+--       goals (e.g. Fondo Emergenza) that have no hard target amount.
+--     - goals.target to be nullable: openended goals may have target = NULL.
+--
+-- Backward compatibility:
+--   Existing rows get type = 'fixed' (DEFAULT). Their target is non-null by definition.
+--   New openended goals will have type = 'openended' and target IS NULL.
+--
+-- CHECK constraint:
+--   target IS NULL only when type = 'openended'. Fixed goals must still have target >= 0.
+
+-- 1. Drop existing NOT NULL constraint on target (requires recreating the CHECK constraint)
+ALTER TABLE goals ALTER COLUMN target DROP NOT NULL;
+
+-- 2. Add type column (default 'fixed' for backward compat — existing rows are unaffected)
+ALTER TABLE goals
+  ADD COLUMN IF NOT EXISTS type TEXT NOT NULL DEFAULT 'fixed'
+  CHECK (type IN ('fixed', 'openended'));
+
+-- 3. Re-add conditional CHECK: fixed goals must have a non-null, non-negative target.
+--    openended goals may have target IS NULL (no hard target).
+ALTER TABLE goals
+  ADD CONSTRAINT goals_target_fixed_not_null
+  CHECK (
+    (type = 'openended') OR (type = 'fixed' AND target IS NOT NULL AND target >= 0)
+  );
+
+COMMENT ON COLUMN goals.type IS 'Goal type: fixed = concrete target amount required; openended = no hard target (e.g. Fondo Emergenza). Sprint 1.5.2 WP-K.';
+COMMENT ON COLUMN goals.target IS 'Target amount (nullable). NULL allowed only when type = openended. Fixed goals must have target >= 0.';


### PR DESCRIPTION
## Summary

- Adds `GoalType = 'fixed' | 'openended'` to `types/onboarding-plan.ts`; aligns `WizardGoalDraft.target: number | null` and `AllocationGoalInput.target: number | null`
- `allocation.ts`: openended non-emergency goals receive residual pool equal split after waterfall; openended emergency gets 40% floor regardless of null target; all `goal.target` references are null-safe
- `GoalTypeFilter.tsx`: `GoalType` renamed to `GoalCategory` (deprecated alias kept); no breaking change to filter chips
- `GoalCard.tsx`: `inferGoalType` → `inferGoalCategory` (alias kept); uses `goal.type` directly for openended display (hides progress bar/target, shows "Aperto" badge + accumulated text); icon/color still from name heuristic
- `StepGoals.tsx`: type toggle UI (Importo fisso / Aperto); openended hides target+deadline inputs; `fondo-emergenza` preset defaults to `openended`
- `goals.client.ts`, `onboarding-plan.client.ts`, `onboarding-plan.store.ts`, `WizardPianoGenerato.tsx`: propagate `type` through all select/insert/update/load/persist/hydrate paths
- **Tests**: 6 openended allocation scenarios + 5 StepGoals type-toggle tests + 5 GoalCard openended display tests; all 1775 existing tests continue to pass

## Test plan

- [x] `pnpm --filter @money-wise/web test` — 86 test files, 1775 tests, 0 failures
- [x] `pnpm --filter @money-wise/web typecheck` — only pre-existing `@money-wise/ui` unresolved module error (not introduced by this PR)
- [x] Pre-commit hooks passed (lint + typecheck + unit tests)
- [ ] Manual: verify Fondo Emergenza preset opens modal in openended mode (no target input)
- [ ] Manual: verify openended goal card shows "Aperto" badge, no progress bar
- [ ] Manual: verify allocation assigns residual to openended goals after waterfall

🤖 Generated with [Claude Code](https://claude.com/claude-code)