### PR TITLE
fix(a11y): AddGoalModal aria-labelledby binding

### DIFF
--- a/apps/web/src/components/onboarding/steps/StepGoals.tsx
+++ b/apps/web/src/components/onboarding/steps/StepGoals.tsx
@@ -197,6 +197,7 @@ function AddGoalModal({ open, onOpenChange, presetId, editingGoal, onSubmit }: A
         <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
         <Dialog.Content
           className="fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-border bg-background p-6 shadow-lg focus:outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95"
+          aria-labelledby="add-goal-dialog-title"
           aria-describedby={undefined}
         >
           <div className="flex items-center justify-between mb-4">


### PR DESCRIPTION
Silences Radix dev-mode warning 'DialogContent requires DialogTitle' — explicit aria-labelledby binding. Zero logic change, pure a11y.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>