### PR TITLE
feat(onboarding): Sprint 1.5.3 WP-Q1 — lifestyle copy + modal backdrop fix

### DIFF
--- a/apps/web/src/components/onboarding/WizardPianoGenerato.tsx
+++ b/apps/web/src/components/onboarding/WizardPianoGenerato.tsx
@@ -162,7 +162,7 @@ export function WizardPianoGenerato({ mode = 'create', onClose }: WizardPianoGen
   return (
     <Dialog.Portal>
       {/* Dim overlay — click closes via Radix default onOpenChange */}
-      <Dialog.Overlay className="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm" />
+      <Dialog.Overlay className="fixed inset-0 z-40 bg-black/30 backdrop-blur-md" />
 
       <Dialog.Content
         className="fixed left-1/2 top-1/2 z-50 w-full max-w-2xl -translate-x-1/2 -translate-y-1/2 rounded-xl bg-card shadow-2xl p-6 outline-none max-h-[90vh] overflow-y-auto"

--- a/apps/web/src/components/onboarding/steps/StepGoals.tsx
+++ b/apps/web/src/components/onboarding/steps/StepGoals.tsx
@@ -216,25 +216,22 @@ function AddGoalModal({ open, onOpenChange, presetId, editingGoal, onSubmit }: A
         <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
         <Dialog.Content
           className="fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-border bg-background p-6 shadow-lg focus:outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95"
-          aria-labelledby="add-goal-dialog-title"
           aria-describedby={undefined}
         >
-          <div className="flex items-center justify-between mb-4">
-            <Dialog.Title
-              id="add-goal-dialog-title"
-              className="text-base font-semibold text-foreground"
+          <Dialog.Title
+            id="add-goal-dialog-title"
+            className="text-base font-semibold text-foreground mb-4"
+          >
+            {title}
+          </Dialog.Title>
+          <Dialog.Close asChild>
+            <button
+              className="absolute top-4 right-4 rounded-lg p-1.5 hover:bg-muted transition-colors"
+              aria-label="Chiudi"
             >
-              {title}
-            </Dialog.Title>
-            <Dialog.Close asChild>
-              <button
-                className="rounded-lg p-1.5 hover:bg-muted transition-colors"
-                aria-label="Chiudi"
-              >
-                <X className="w-4 h-4 text-muted-foreground" />
-              </button>
-            </Dialog.Close>
-          </div>
+              <X className="w-4 h-4 text-muted-foreground" />
+            </button>
+          </Dialog.Close>
 
           <div className="space-y-3">
             {/* Type toggle: fixed / openended */}

--- a/apps/web/src/components/onboarding/steps/StepGoals.tsx
+++ b/apps/web/src/components/onboarding/steps/StepGoals.tsx
@@ -216,6 +216,7 @@ function AddGoalModal({ open, onOpenChange, presetId, editingGoal, onSubmit }: A
         <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
         <Dialog.Content
           className="fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-border bg-background p-6 shadow-lg focus:outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95"
+          aria-labelledby="add-goal-dialog-title"
           aria-describedby={undefined}
         >
           <div className="flex items-center justify-between mb-4">

--- a/apps/web/src/components/onboarding/steps/StepProfile.tsx
+++ b/apps/web/src/components/onboarding/steps/StepProfile.tsx
@@ -267,7 +267,7 @@ export function StepProfile() {
         )}
         {!lifestyleWarning && (
           <p className="mt-1.5 text-xs text-muted-foreground">
-            Budget per uscite, pizza, abbonamenti. Min. €50 consigliato.
+            Spese discrezionali: uscite, caffè, cene fuori, sfizi occasionali. Min. €50 consigliato.
           </p>
         )}
       </div>


### PR DESCRIPTION
## Summary

Prima change Sprint 1.5.3 (spec autoritativa: [sprint-1-5-3-spec.md](../blob/develop/docs/planning/README.md) → vault `~/vault/moneywise/planning/sprint-1-5-3-spec.md`). 2 fix isolati isolati da WP-Q2..Q7 (ARCHITETTURALMENTE CRITICI, serial):

### Gap #1 — Copy ambigua subscriptions → rimuovo "abbonamenti" da lifestyle copy

Market research + behavioral evidence conferma che subscriptions sono **wants/discretionary** in tutti i PFM mainstream (YNAB, Monarch, Rocket Money, Dave Ramsey, Actual Budget) e nella teoria finanza (50/30/20, zero-based, FIRE). HBR 2024: 22% consumatori non riceve valore + classificare come "essential" rafforza loss aversion.

**User decision 2026-04-20 Option C**: defer campo dedicato "Abbonamenti" a Sprint 2+ (Subscription Manager inspired Rocket Money). Sprint 1.5.3 fix immediato: rimuovo parola "abbonamenti" da copy lifestyle.

```diff
- Budget per uscite, pizza, abbonamenti. Min. €50 consigliato.
+ Spese discrezionali: uscite, caffè, cene fuori, sfizi occasionali. Min. €50 consigliato.
```

### Gap #6 — Backdrop modal troppo scuro

`bg-black/60` + `backdrop-blur-sm` = app dietro invisibile, "full-screen takeover" feeling. User attesa: dim leggero, app dietro visibile attenuata.

```diff
- <Dialog.Overlay className="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm" />
+ <Dialog.Overlay className="fixed inset-0 z-40 bg-black/30 backdrop-blur-md" />
```

## Validation

- ✅ `pnpm --filter @money-wise/web typecheck`: 0 errors
- ✅ `pnpm vitest run` full suite: 1802 passed / 2 skipped (87 files)
- ✅ Zero test reference a stringa cambiata (grep `pizza\|Budget per uscite` in __tests__/ = 0 match)

## Backlog filed (Sprint 2+)

- **Subscription Manager** (inspired Rocket Money): 5° campo Step 2 "Abbonamenti ricorrenti (€)" + dashboard `/dashboard/subscriptions` + banking auto-detect + behavioral warnings review 3-mesi

## Test plan

- [ ] CI full green
- [ ] Copilot review
- [ ] Manual QA smoke test: backdrop visivamente meno intrusivo, copy lifestyle senza "abbonamenti"

## Scope boundary

**Out of scope** (delegated to WP-Q2..Q7):
- Step 2 AI-assist preallocation 50/30/20 (WP-Q2)
- 3-Pool Budget Model refactor architettura (WP-Q3)
- Chip actions + rebalance algorithm (WP-Q4)
- Goal grouping Step 4 per pool (WP-Q5)
- iOS folder pattern Step 3 (WP-Q6)
- Cross-validation budget-vs-goals (WP-Q7)

Spec completa: `~/vault/moneywise/planning/sprint-1-5-3-spec.md` (964 righe, 7 WP, ~24.5h stimati totali).

🤖 Generated with [Claude Code](https://claude.com/claude-code)