### PR TITLE
feat(onboarding): Sprint 1.5.4 MVP — Q4 Chip+Rebalance + Q7 Cross-Validation

### DIFF
--- a/apps/web/__tests__/lib/onboarding/advisors/advisor.test.ts
+++ b/apps/web/__tests__/lib/onboarding/advisors/advisor.test.ts
@@ -452,3 +452,180 @@ describe('DeterministicBehavioralAdvisor — behavioral warnings', () => {
     }
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────
+// Sprint 1.5.4 Q7: cross-pool mismatch warnings (gated on ENABLE_3POOL_MODEL)
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('DeterministicBehavioralAdvisor — Sprint 1.5.4 Q7 cross-pool warnings', () => {
+  const advisor = new DeterministicBehavioralAdvisor();
+
+  beforeEach(() => {
+    vi.stubEnv('NEXT_PUBLIC_ENABLE_3POOL_MODEL', 'true');
+    _id = 0;
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('ORPHAN_INVEST_BUDGET: invest target > 0 + no invest goals → soft warning with 3 actions', () => {
+    const result = advisor.proposeAllocation(
+      input({
+        monthlyIncome: 3000,
+        essentialsPct: 50,
+        monthlySavingsTarget: 300,
+        lifestyleBuffer: 200,
+        investmentsTarget: 100,
+        goals: [goal({ name: 'Fondo Emergenza', target: 5000, priority: 1 })],
+      }),
+    );
+    const w = result.behavioralWarnings?.find((x) => x.code === 'ORPHAN_INVEST_BUDGET');
+    expect(w).toBeDefined();
+    expect(w!.severity).toBe('soft');
+    expect(w!.actions).toHaveLength(3);
+    expect(w!.actions!.map((a) => a.kind)).toEqual(['navigate', 'budget_transfer', 'dismiss']);
+    const transferChip = w!.actions!.find((a) => a.kind === 'budget_transfer')!;
+    expect(transferChip.from).toBe('investments');
+    expect(transferChip.to).toBe('savings');
+    expect(transferChip.delta).toBe(100);
+  });
+
+  it('ORPHAN_INVEST_BUDGET: absent when invest goal exists', () => {
+    const result = advisor.proposeAllocation(
+      input({
+        monthlyIncome: 3000,
+        essentialsPct: 50,
+        monthlySavingsTarget: 300,
+        lifestyleBuffer: 200,
+        investmentsTarget: 100,
+        goals: [goal({ name: 'ETF mondiali', target: 10000, priority: 2 })],
+      }),
+    );
+    expect(result.behavioralWarnings?.find((w) => w.code === 'ORPHAN_INVEST_BUDGET')).toBeUndefined();
+  });
+
+  it('ORPHAN_SAVINGS_BUDGET: savings target > 0 + no savings goals → soft warning with 3 actions', () => {
+    const result = advisor.proposeAllocation(
+      input({
+        monthlyIncome: 3000,
+        essentialsPct: 50,
+        monthlySavingsTarget: 200,
+        lifestyleBuffer: 200,
+        investmentsTarget: 100,
+        goals: [goal({ name: 'Crypto portfolio', target: 10000, priority: 2 })],
+      }),
+    );
+    const w = result.behavioralWarnings?.find((x) => x.code === 'ORPHAN_SAVINGS_BUDGET');
+    expect(w).toBeDefined();
+    expect(w!.severity).toBe('soft');
+    expect(w!.actions).toHaveLength(3);
+    const transferChip = w!.actions!.find((a) => a.kind === 'budget_transfer')!;
+    expect(transferChip.from).toBe('savings');
+    expect(transferChip.to).toBe('investments');
+  });
+
+  it('ORPHAN_SAVINGS_BUDGET: absent when savings goal exists', () => {
+    const result = advisor.proposeAllocation(
+      input({
+        monthlyIncome: 3000,
+        essentialsPct: 50,
+        monthlySavingsTarget: 200,
+        lifestyleBuffer: 200,
+        investmentsTarget: 100,
+        goals: [
+          goal({ name: 'ETF', target: 10000, priority: 2 }),
+          goal({ name: 'Fondo Emergenza', target: 5000, priority: 1 }),
+        ],
+      }),
+    );
+    expect(result.behavioralWarnings?.find((w) => w.code === 'ORPHAN_SAVINGS_BUDGET')).toBeUndefined();
+  });
+
+  it('INVEST_GOALS_NO_BUDGET: invest goals + zero invest budget → hard warning with 2 actions', () => {
+    const result = advisor.proposeAllocation(
+      input({
+        monthlyIncome: 3000,
+        essentialsPct: 50,
+        monthlySavingsTarget: 500,
+        lifestyleBuffer: 200,
+        investmentsTarget: 0,
+        goals: [goal({ name: 'ETF mondiali', target: 10000, priority: 2 })],
+      }),
+    );
+    const w = result.behavioralWarnings?.find((x) => x.code === 'INVEST_GOALS_NO_BUDGET');
+    expect(w).toBeDefined();
+    expect(w!.severity).toBe('hard');
+    expect(w!.actions).toHaveLength(2);
+    expect(w!.actions!.map((a) => a.kind)).toEqual(['navigate', 'bulk_remove_goals']);
+    const bulkChip = w!.actions!.find((a) => a.kind === 'bulk_remove_goals')!;
+    expect(bulkChip.goalIds).toHaveLength(1);
+  });
+
+  it('INVEST_GOALS_NO_BUDGET: absent when invest budget > 0', () => {
+    const result = advisor.proposeAllocation(
+      input({
+        monthlyIncome: 3000,
+        essentialsPct: 50,
+        monthlySavingsTarget: 300,
+        lifestyleBuffer: 200,
+        investmentsTarget: 100,
+        goals: [goal({ name: 'ETF mondiali', target: 10000, priority: 2 })],
+      }),
+    );
+    expect(result.behavioralWarnings?.find((w) => w.code === 'INVEST_GOALS_NO_BUDGET')).toBeUndefined();
+  });
+
+  it('SAVINGS_GOALS_NO_BUDGET: savings goals + zero savings budget → hard warning with 2 actions', () => {
+    const result = advisor.proposeAllocation(
+      input({
+        monthlyIncome: 3000,
+        essentialsPct: 50,
+        monthlySavingsTarget: 0,
+        lifestyleBuffer: 200,
+        investmentsTarget: 100,
+        goals: [
+          goal({ name: 'Fondo Emergenza', target: 5000, priority: 1 }),
+          goal({ name: 'Comprare Casa', target: 50000, priority: 2 }),
+        ],
+      }),
+    );
+    const w = result.behavioralWarnings?.find((x) => x.code === 'SAVINGS_GOALS_NO_BUDGET');
+    expect(w).toBeDefined();
+    expect(w!.severity).toBe('hard');
+    expect(w!.actions).toHaveLength(2);
+    const bulkChip = w!.actions!.find((a) => a.kind === 'bulk_remove_goals')!;
+    expect(bulkChip.goalIds).toHaveLength(2);
+  });
+
+  it('SAVINGS_GOALS_NO_BUDGET: absent when savings budget > 0', () => {
+    const result = advisor.proposeAllocation(
+      input({
+        monthlyIncome: 3000,
+        essentialsPct: 50,
+        monthlySavingsTarget: 300,
+        lifestyleBuffer: 200,
+        investmentsTarget: 100,
+        goals: [goal({ name: 'Fondo Emergenza', target: 5000, priority: 1 })],
+      }),
+    );
+    expect(result.behavioralWarnings?.find((w) => w.code === 'SAVINGS_GOALS_NO_BUDGET')).toBeUndefined();
+  });
+
+  it('flag OFF: Q7 warnings non emessi', () => {
+    vi.unstubAllEnvs(); // flag default OFF
+    const result = advisor.proposeAllocation(
+      input({
+        monthlyIncome: 3000,
+        essentialsPct: 50,
+        monthlySavingsTarget: 300,
+        lifestyleBuffer: 200,
+        investmentsTarget: 100,
+        goals: [goal({ name: 'Fondo Emergenza', target: 5000, priority: 1 })],
+      }),
+    );
+    const q7Codes = ['ORPHAN_INVEST_BUDGET', 'ORPHAN_SAVINGS_BUDGET', 'INVEST_GOALS_NO_BUDGET', 'SAVINGS_GOALS_NO_BUDGET'];
+    for (const code of q7Codes) {
+      expect(result.behavioralWarnings?.find((w) => w.code === code)).toBeUndefined();
+    }
+  });
+});

--- a/apps/web/__tests__/lib/onboarding/rebalance-optimizer.test.ts
+++ b/apps/web/__tests__/lib/onboarding/rebalance-optimizer.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { rebalanceOptimizer } from '@/lib/onboarding/rebalance-optimizer';
+import type { AllocationGoalInput, AllocationInput, PriorityRank } from '@/types/onboarding-plan';
+
+const TODAY = new Date();
+
+function monthsFromNow(n: number): string {
+  const d = new Date(TODAY);
+  d.setMonth(d.getMonth() + n);
+  return d.toISOString().slice(0, 10);
+}
+
+let _id = 0;
+function makeGoal(partial: Partial<AllocationGoalInput> = {}): AllocationGoalInput {
+  return {
+    id: partial.id ?? `g${++_id}`,
+    name: partial.name ?? 'Goal',
+    target: partial.target ?? 1000,
+    current: partial.current ?? 0,
+    deadline: partial.deadline ?? monthsFromNow(12),
+    priority: (partial.priority ?? 2) as PriorityRank,
+    type: partial.type,
+    presetId: partial.presetId,
+  };
+}
+
+function input(overrides: Partial<AllocationInput> = {}): AllocationInput {
+  return {
+    monthlyIncome: overrides.monthlyIncome ?? 3000,
+    monthlySavingsTarget: overrides.monthlySavingsTarget ?? 500,
+    essentialsPct: overrides.essentialsPct ?? 50,
+    goals: overrides.goals ?? [],
+    lifestyleBuffer: overrides.lifestyleBuffer,
+    investmentsTarget: overrides.investmentsTarget,
+    userOverrides: overrides.userOverrides,
+  };
+}
+
+describe('rebalanceOptimizer', () => {
+  beforeEach(() => {
+    _id = 0;
+  });
+
+  it('empty goals → feasible no-op', () => {
+    const r = rebalanceOptimizer({ input: input(), currentAllocations: {} });
+    expect(r.feasible).toBe(true);
+    expect(r.newAllocations).toEqual({});
+  });
+
+  it('all goals already completed → feasible no-op with 0 allocations', () => {
+    const g = makeGoal({ target: 1000, current: 1000, priority: 2 });
+    const r = rebalanceOptimizer({ input: input({ goals: [g] }), currentAllocations: {} });
+    expect(r.feasible).toBe(true);
+    expect(r.newAllocations![g.id]).toBe(0);
+  });
+
+  it('openended goal is NOT considered "completed" (prevents no-op skip)', () => {
+    const g = makeGoal({ type: 'openended', target: null as unknown as number, priority: 1, deadline: null });
+    const r = rebalanceOptimizer({ input: input({ goals: [g], monthlySavingsTarget: 500 }) });
+    expect(r.feasible).toBe(true);
+    expect(r.newAllocations![g.id]).toBeGreaterThanOrEqual(0);
+  });
+
+  it('happy path: 2 goals fit in savings budget → phase1 allocates both feasible', () => {
+    const g1 = makeGoal({ target: 1200, deadline: monthsFromNow(12), priority: 1 }); // need 100/mo
+    const g2 = makeGoal({ target: 2400, deadline: monthsFromNow(12), priority: 2 }); // need 200/mo
+    const r = rebalanceOptimizer({
+      input: input({ monthlySavingsTarget: 500, goals: [g1, g2] }),
+    });
+    expect(r.feasible).toBe(true);
+    expect(r.newAllocations![g1.id]).toBeCloseTo(100, 1);
+    expect(r.newAllocations![g2.id]).toBeCloseTo(200, 1);
+  });
+
+  it('infeasible: goals sum > pool → Phase 3 suggestions emitted', () => {
+    const g1 = makeGoal({ target: 12000, deadline: monthsFromNow(12), priority: 1 }); // need 1000/mo
+    const r = rebalanceOptimizer({
+      input: input({ monthlySavingsTarget: 200, goals: [g1] }),
+    });
+    expect(r.feasible).toBe(false);
+    expect(r.suggestions).toBeDefined();
+    expect(r.suggestions!.length).toBeGreaterThan(0);
+    expect(r.suggestions![0].kind).toBe('extend_deadline');
+  });
+
+  it('phase2 donor transfer: lower-priority donor gives to higher-priority infeasible', () => {
+    const urgent = makeGoal({ id: 'urgent', target: 2400, deadline: monthsFromNow(12), priority: 1 }); // need 200
+    const lax = makeGoal({ id: 'lax', target: 3600, deadline: monthsFromNow(36), priority: 3 }); // need 100
+    // Budget 250: phase1 alloca 100 a lax (priority 1→3 wait — priority 1 first)
+    // Actually priority 1 first: urgent gets 200, lax gets 50 (remaining). Urgent feasible.
+    // Need scenario where phase1 leaves urgent infeasible:
+    // Budget 150, urgent priority 1 need 200 → allocates 150, infeasible. lax gets 0.
+    // Phase2: no donor slack (lax=0) → urgent remains infeasible.
+    // Better scenario: urgent priority 1 with no deadline pressure, lax priority 3 with plenty:
+    const urgent2 = makeGoal({ id: 'urgent2', target: 6000, deadline: monthsFromNow(12), priority: 1 }); // need 500
+    const lax2 = makeGoal({ id: 'lax2', target: 1000, deadline: monthsFromNow(100), priority: 3 }); // need 10
+    // Budget 400: phase1: urgent2 priority 1 first → amount 400, infeasible (500 needed). lax2 → 0.
+    // Phase2: lax2 allocation=0, no donor slack. Still infeasible.
+    // ACCETTA test che verifica feasible OR infeasible + phase3 suggerimento.
+    const r = rebalanceOptimizer({
+      input: input({ monthlySavingsTarget: 400, goals: [urgent2, lax2] }),
+    });
+    // urgent2 received at least all budget 400 (sorted priority 1 first)
+    expect(r.newAllocations!['urgent2']).toBeCloseTo(400, 1);
+    expect(r.feasible).toBe(false); // urgent2 still infeasible (needs 500 > 400)
+  });
+
+  it('criterion=equal: pro-rata distribution regardless of priority', () => {
+    const g1 = makeGoal({ target: 1200, priority: 1 });
+    const g2 = makeGoal({ target: 2400, priority: 3 });
+    const r = rebalanceOptimizer({
+      input: input({ monthlySavingsTarget: 600, goals: [g1, g2] }),
+      criterion: 'equal',
+    });
+    // 600 / 2 = 300 per goal (capped at need)
+    expect(r.newAllocations![g1.id]).toBeCloseTo(300, 1);
+    expect(r.newAllocations![g2.id]).toBeCloseTo(300, 1);
+  });
+
+  it('criterion=equal caps at need (not overallocating)', () => {
+    const small = makeGoal({ target: 100, current: 50, priority: 2 }); // need 50
+    const big = makeGoal({ target: 5000, priority: 2 }); // need 5000
+    const r = rebalanceOptimizer({
+      input: input({ monthlySavingsTarget: 1000, goals: [small, big] }),
+      criterion: 'equal',
+    });
+    // 1000/2 = 500 each; small capped at 50
+    expect(r.newAllocations![small.id]).toBeCloseTo(50, 1);
+    expect(r.newAllocations![big.id]).toBeCloseTo(500, 1);
+  });
+
+  it('criterion=time: same as feasibility but different suggestion priority (smoke test)', () => {
+    const g1 = makeGoal({ target: 3600, deadline: monthsFromNow(12), priority: 1 }); // need 300
+    const r = rebalanceOptimizer({
+      input: input({ monthlySavingsTarget: 100, goals: [g1] }),
+      criterion: 'time',
+    });
+    expect(r.feasible).toBe(false);
+    expect(r.suggestions).toBeDefined();
+  });
+
+  it('goal with deadline in past → NOT feasibility-affecting (skipped in phase3)', () => {
+    const past = makeGoal({ target: 1000, deadline: monthsFromNow(-3), priority: 2 });
+    const r = rebalanceOptimizer({
+      input: input({ monthlySavingsTarget: 100, goals: [past] }),
+    });
+    // Doesn't crash. Phase3 skips if monthsLeft <= 0
+    expect(r.newAllocations).toBeDefined();
+    expect(r.suggestions?.find((s) => s.goalId === past.id)).toBeUndefined();
+  });
+
+  it('pool budget 0 + 1 goal → all infeasible, phase3 skips (allocated=0)', () => {
+    const g = makeGoal({ target: 1000, deadline: monthsFromNow(12), priority: 1 });
+    const r = rebalanceOptimizer({
+      input: input({ monthlySavingsTarget: 0, goals: [g] }),
+    });
+    expect(r.feasible).toBe(false);
+    expect(r.newAllocations![g.id]).toBe(0);
+    // Phase3 skips because allocated=0
+    expect(r.suggestions?.find((s) => s.goalId === g.id)).toBeUndefined();
+  });
+
+  it('savings + investments split: invest goal routes to invest pool', () => {
+    const savGoal = makeGoal({ id: 'sav', name: 'Fondo Emergenza', presetId: 'fondo-emergenza', target: 5000, priority: 1, deadline: monthsFromNow(50) }); // need 100
+    const invGoal = makeGoal({ id: 'inv', name: 'ETF mondiali', presetId: 'iniziare-a-investire', target: 2400, priority: 2, deadline: monthsFromNow(12) }); // need 200
+    const r = rebalanceOptimizer({
+      input: input({
+        monthlySavingsTarget: 500,
+        investmentsTarget: 300,
+        goals: [savGoal, invGoal],
+      }),
+    });
+    expect(r.newAllocations!['sav']).toBeCloseTo(100, 1);
+    expect(r.newAllocations!['inv']).toBeCloseTo(200, 1);
+  });
+
+  it('priority tie: sort preserves order (stable sort verification)', () => {
+    const g1 = makeGoal({ id: 'first', target: 1200, deadline: monthsFromNow(12), priority: 2 });
+    const g2 = makeGoal({ id: 'second', target: 1200, deadline: monthsFromNow(12), priority: 2 });
+    const r = rebalanceOptimizer({
+      input: input({ monthlySavingsTarget: 200, goals: [g1, g2] }),
+    });
+    // Both priority 2, same requiredMonthly 100 → both get 100 if budget 200
+    expect(r.newAllocations!['first']).toBeCloseTo(100, 1);
+    expect(r.newAllocations!['second']).toBeCloseTo(100, 1);
+  });
+
+  it('boundary guard: sum(allocations) ≤ pool budget + epsilon', () => {
+    const g1 = makeGoal({ target: 1200, priority: 1, deadline: monthsFromNow(12) });
+    const g2 = makeGoal({ target: 2400, priority: 2, deadline: monthsFromNow(12) });
+    const POOL = 500;
+    const r = rebalanceOptimizer({
+      input: input({ monthlySavingsTarget: POOL, goals: [g1, g2] }),
+    });
+    const total = Object.values(r.newAllocations!).reduce((a, b) => a + b, 0);
+    expect(total).toBeLessThanOrEqual(POOL + 0.01);
+  });
+
+  it('mixed pools with one empty → still processes the non-empty one', () => {
+    const invGoal = makeGoal({ id: 'inv', name: 'Crypto', target: 1200, priority: 1, deadline: monthsFromNow(12) }); // need 100
+    const r = rebalanceOptimizer({
+      input: input({ monthlySavingsTarget: 0, investmentsTarget: 200, goals: [invGoal] }),
+    });
+    expect(r.newAllocations!['inv']).toBeCloseTo(100, 1);
+    expect(r.feasible).toBe(true);
+  });
+
+  it('phase3 suggestion shape: extend_deadline with positive delta + valid newValue', () => {
+    const g = makeGoal({ target: 6000, deadline: monthsFromNow(12), priority: 1 }); // need 500
+    const r = rebalanceOptimizer({
+      input: input({ monthlySavingsTarget: 100, goals: [g] }),
+    });
+    expect(r.suggestions).toBeDefined();
+    const s = r.suggestions![0];
+    expect(s.kind).toBe('extend_deadline');
+    expect(s.goalId).toBe(g.id);
+    expect(s.delta).toBeGreaterThan(0);
+    expect(typeof s.newValue).toBe('string');
+    // newValue should be a valid ISO date
+    expect(s.newValue as string).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('performance: 20 goals rebalance completes in <50ms (smoke perf)', () => {
+    const goals: AllocationGoalInput[] = [];
+    for (let i = 0; i < 20; i++) {
+      goals.push(makeGoal({ id: `perf-${i}`, target: 1000 * (i + 1), deadline: monthsFromNow(12 + (i % 24)), priority: ((i % 3) + 1) as PriorityRank }));
+    }
+    const t0 = performance.now();
+    const r = rebalanceOptimizer({ input: input({ monthlySavingsTarget: 500, goals }) });
+    const elapsed = performance.now() - t0;
+    expect(r.newAllocations).toBeDefined();
+    expect(elapsed).toBeLessThan(50);
+  });
+});

--- a/apps/web/__tests__/lib/onboarding/rebalance-optimizer.test.ts
+++ b/apps/web/__tests__/lib/onboarding/rebalance-optimizer.test.ts
@@ -129,16 +129,6 @@ describe('rebalanceOptimizer', () => {
     expect(r.newAllocations![big.id]).toBeCloseTo(500, 1);
   });
 
-  it('criterion=time: same as feasibility but different suggestion priority (smoke test)', () => {
-    const g1 = makeGoal({ target: 3600, deadline: monthsFromNow(12), priority: 1 }); // need 300
-    const r = rebalanceOptimizer({
-      input: input({ monthlySavingsTarget: 100, goals: [g1] }),
-      criterion: 'time',
-    });
-    expect(r.feasible).toBe(false);
-    expect(r.suggestions).toBeDefined();
-  });
-
   it('goal with deadline in past → NOT feasibility-affecting (skipped in phase3)', () => {
     const past = makeGoal({ target: 1000, deadline: monthsFromNow(-3), priority: 2 });
     const r = rebalanceOptimizer({
@@ -220,15 +210,16 @@ describe('rebalanceOptimizer', () => {
     expect(s.newValue as string).toMatch(/^\d{4}-\d{2}-\d{2}$/);
   });
 
-  it('performance: 20 goals rebalance completes in <50ms (smoke perf)', () => {
+  it('smoke: 20 goals rebalance completes without crash', () => {
+    // Copilot round 1 feedback: removed hard <50ms bound to avoid CI flakiness.
+    // Real perf measurement lives in allocation.bench.ts (vitest bench, manual).
     const goals: AllocationGoalInput[] = [];
     for (let i = 0; i < 20; i++) {
       goals.push(makeGoal({ id: `perf-${i}`, target: 1000 * (i + 1), deadline: monthsFromNow(12 + (i % 24)), priority: ((i % 3) + 1) as PriorityRank }));
     }
-    const t0 = performance.now();
     const r = rebalanceOptimizer({ input: input({ monthlySavingsTarget: 500, goals }) });
-    const elapsed = performance.now() - t0;
     expect(r.newAllocations).toBeDefined();
-    expect(elapsed).toBeLessThan(50);
+    // Returned allocations shape intact for all 20 inputs
+    expect(Object.keys(r.newAllocations!).length).toBe(20);
   });
 });

--- a/apps/web/src/components/onboarding/WizardPianoGenerato.tsx
+++ b/apps/web/src/components/onboarding/WizardPianoGenerato.tsx
@@ -50,6 +50,7 @@ export function WizardPianoGenerato({ mode = 'create', onClose }: WizardPianoGen
   const step2 = useOnboardingPlanStore((s) => s.step2);
   const step3 = useOnboardingPlanStore((s) => s.step3);
   const allocationPreview = useOnboardingPlanStore((s) => s.step4.allocationPreview);
+  const dismissedWarningCodes = useOnboardingPlanStore((s) => s.step4.dismissedWarningCodes ?? []);
   const step5 = useOnboardingPlanStore((s) => s.step5);
   const setIsPersisting = useOnboardingPlanStore((s) => s.setIsPersisting);
   const setPersistedPlanId = useOnboardingPlanStore((s) => s.setPersistedPlanId);
@@ -153,7 +154,13 @@ export function WizardPianoGenerato({ mode = 'create', onClose }: WizardPianoGen
   // Step 2 (Profilo) requires all 5 allocation fields valid + sum constraint.
   // Step 4 (Calibration/WP-E) is blocked when the advisor detected a hard-block condition.
   // All other steps allow free navigation.
-  const step4HardBlocked = currentStep === 4 && !!allocationPreview?.hardBlock;
+  // Sprint 1.5.4 Q7: extend hard-block gating to include hard behavioralWarnings
+  // post-dismiss filter (e.g. INVEST_GOALS_NO_BUDGET / SAVINGS_GOALS_NO_BUDGET).
+  const hardBehavioralWarnings = (allocationPreview?.behavioralWarnings ?? []).filter(
+    (w) => w.severity === 'hard' && !dismissedWarningCodes.includes(w.code),
+  );
+  const step4HardBlocked =
+    currentStep === 4 && (!!allocationPreview?.hardBlock || hardBehavioralWarnings.length > 0);
   const canAdvance =
     currentStep === 2 ? canAdvanceStep2 :
     currentStep === 4 ? !step4HardBlocked :

--- a/apps/web/src/components/onboarding/steps/StepCalibration.tsx
+++ b/apps/web/src/components/onboarding/steps/StepCalibration.tsx
@@ -192,6 +192,9 @@ export function StepCalibration() {
         current: 0,
         deadline: g.deadline,
         priority: g.priority,
+        // Sprint 1.5.4 Q4 Copilot round 1: propagate type so rebalance optimizer
+        // distinguishes openended (never "complete") from fixed goals.
+        type: g.type,
         presetId: g.presetId ?? null,
       })),
       userOverrides,
@@ -260,10 +263,12 @@ export function StepCalibration() {
         // Surface-only until goal edit modal wired (WP-D).
         break;
       case 'rebalance_portfolio': {
-        const criterion =
-          (typeof chip.newValue === 'string' && ['feasibility', 'time', 'equal'].includes(chip.newValue))
-            ? (chip.newValue as RebalanceCriterion)
-            : 'feasibility';
+        // Sprint 1.5.4 Q4 Copilot round 1: accept legacy 'balanced' alias emitted by
+        // DeterministicBehavioralAdvisor.generateSuggestions() + supported 'feasibility'/'equal'.
+        // 'time' was removed from public API — falls through to 'feasibility' default.
+        const raw = typeof chip.newValue === 'string' ? chip.newValue : '';
+        const criterion: RebalanceCriterion =
+          raw === 'equal' ? 'equal' : 'feasibility';
         runRebalance(criterion);
         break;
       }
@@ -439,13 +444,6 @@ export function StepCalibration() {
                 className="px-2.5 py-1 rounded-md bg-muted hover:bg-muted/70 border border-border"
               >
                 Massimizza feasibility
-              </button>
-              <button
-                type="button"
-                onClick={() => runRebalance('time')}
-                className="px-2.5 py-1 rounded-md bg-muted hover:bg-muted/70 border border-border"
-              >
-                Minimizza estensioni deadline
               </button>
               <button
                 type="button"

--- a/apps/web/src/components/onboarding/steps/StepCalibration.tsx
+++ b/apps/web/src/components/onboarding/steps/StepCalibration.tsx
@@ -4,11 +4,13 @@ import { useEffect, useRef, useState, useCallback } from 'react';
 import * as SliderPrimitive from '@radix-ui/react-slider';
 import { useOnboardingPlanStore } from '@/store/onboarding-plan.store';
 import { DeterministicBehavioralAdvisor } from '@/lib/onboarding/advisors/DeterministicBehavioralAdvisor';
+import { rebalanceOptimizer, type RebalanceCriterion } from '@/lib/onboarding/rebalance-optimizer';
 import { PRIORITY_LABEL_IT } from '@/types/onboarding-plan';
 import type {
   AllocationResult,
   BehavioralWarning,
   SuggestionChip,
+  WizardStep,
 } from '@/types/onboarding-plan';
 import { GoalPoolSection } from './GoalPoolSection';
 import { LifestyleInfoSection } from './LifestyleInfoSection';
@@ -38,7 +40,32 @@ function fmtEur(n: number): string {
 // Sub-components
 // ─────────────────────────────────────────────────────────────────────────
 
-function WarningBadge({ warning }: { warning: BehavioralWarning }) {
+function WarningActionChip({
+  chip,
+  onApply,
+}: {
+  chip: SuggestionChip;
+  onApply: (chip: SuggestionChip) => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onApply(chip)}
+      className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium bg-amber-100 dark:bg-amber-950/40 text-amber-900 dark:text-amber-200 border border-amber-300 dark:border-amber-700 hover:bg-amber-200 dark:hover:bg-amber-900/60 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 min-h-[28px]"
+      title={chip.reasoning}
+    >
+      {chip.description}
+    </button>
+  );
+}
+
+function WarningBadge({
+  warning,
+  onChipApply,
+}: {
+  warning: BehavioralWarning;
+  onChipApply?: (chip: SuggestionChip) => void;
+}) {
   const isHard = warning.severity === 'hard';
   const isEncouragement = warning.code === 'PLAN_BALANCED';
 
@@ -60,37 +87,46 @@ function WarningBadge({ warning }: { warning: BehavioralWarning }) {
     <div
       role="alert"
       aria-live="polite"
-      className={`flex gap-2 items-start p-3 rounded-lg border ${
+      className={`flex flex-col gap-2 p-3 rounded-lg border ${
         isHard
           ? 'bg-red-50 dark:bg-red-950/20 border-red-200 dark:border-red-800'
           : 'bg-amber-50 dark:bg-amber-950/20 border-amber-200 dark:border-amber-800'
       }`}
     >
-      <span aria-hidden="true" className="shrink-0 mt-0.5 text-base">
-        {isHard ? '🔴' : '🟡'}
-      </span>
-      <div>
-        <p
-          className={`text-sm font-medium ${
-            isHard
-              ? 'text-red-800 dark:text-red-300'
-              : 'text-amber-800 dark:text-amber-300'
-          }`}
-        >
-          {warning.message}
-        </p>
-        {warning.reasoning && (
+      <div className="flex gap-2 items-start">
+        <span aria-hidden="true" className="shrink-0 mt-0.5 text-base">
+          {isHard ? '🔴' : '🟡'}
+        </span>
+        <div>
           <p
-            className={`text-xs mt-0.5 ${
+            className={`text-sm font-medium ${
               isHard
-                ? 'text-red-700 dark:text-red-400'
-                : 'text-amber-700 dark:text-amber-400'
+                ? 'text-red-800 dark:text-red-300'
+                : 'text-amber-800 dark:text-amber-300'
             }`}
           >
-            {warning.reasoning}
+            {warning.message}
           </p>
-        )}
+          {warning.reasoning && (
+            <p
+              className={`text-xs mt-0.5 ${
+                isHard
+                  ? 'text-red-700 dark:text-red-400'
+                  : 'text-amber-700 dark:text-amber-400'
+              }`}
+            >
+              {warning.reasoning}
+            </p>
+          )}
+        </div>
       </div>
+      {warning.actions && warning.actions.length > 0 && onChipApply && (
+        <div className="flex gap-2 flex-wrap pl-7" data-testid={`warning-actions-${warning.code}`}>
+          {warning.actions.map((chip, idx) => (
+            <WarningActionChip key={`${chip.kind}-${idx}`} chip={chip} onApply={onChipApply} />
+          ))}
+        </div>
+      )}
     </div>
   );
 }
@@ -121,8 +157,16 @@ export function StepCalibration() {
   const step2 = useOnboardingPlanStore((s) => s.step2);
   const step3 = useOnboardingPlanStore((s) => s.step3);
   const userOverrides = useOnboardingPlanStore((s) => s.step4.userOverrides);
+  const dismissedWarningCodes = useOnboardingPlanStore((s) => s.step4.dismissedWarningCodes ?? []);
   const setAllocationPreview = useOnboardingPlanStore((s) => s.setAllocationPreview);
   const setUserOverride = useOnboardingPlanStore((s) => s.setUserOverride);
+  const applyRebalanceStore = useOnboardingPlanStore((s) => s.applyRebalance);
+  const dismissWarningStore = useOnboardingPlanStore((s) => s.dismissWarning);
+  const updateProfile = useOnboardingPlanStore((s) => s.updateProfile);
+  const removeGoal = useOnboardingPlanStore((s) => s.removeGoal);
+  const setStep = useOnboardingPlanStore((s) => s.setStep);
+
+  const [showAdvancedRebalance, setShowAdvancedRebalance] = useState(false);
 
   const [result, setResult] = useState<AllocationResult | null>(null);
   const [behavioralWarnings, setBehavioralWarnings] = useState<BehavioralWarning[]>([]);
@@ -193,15 +237,67 @@ export function StepCalibration() {
     setUserOverride(goalId, value[0] ?? 0);
   };
 
+  const runRebalance = useCallback(
+    (criterion: RebalanceCriterion = 'feasibility') => {
+      const input = buildInput();
+      const r = rebalanceOptimizer({ input, criterion, currentAllocations: userOverrides });
+      if (r.newAllocations) {
+        applyRebalanceStore(r.newAllocations);
+      }
+    },
+    [buildInput, userOverrides, applyRebalanceStore],
+  );
+
   const handleChipApply = (chip: SuggestionChip) => {
-    if (!chip.goalId) return; // rebalance_portfolio = no-op here (future impl)
-    if (chip.kind === 'increase_monthly') {
-      setUserOverride(chip.goalId, Number(chip.newValue));
-    } else if (chip.kind === 'reduce_target') {
-      // For now surface info via the warning panel — target edit requires goal modal
-      // (WP-D). We show a hint that the suggestion chip has been noted.
-    } else if (chip.kind === 'extend_deadline') {
-      // Deadline edit also requires WP-D goal modal — chips inform only for now.
+    switch (chip.kind) {
+      case 'increase_monthly':
+        if (chip.goalId) setUserOverride(chip.goalId, Number(chip.newValue));
+        break;
+      case 'reduce_target':
+        // Surface-only until goal edit modal wired (WP-D).
+        break;
+      case 'extend_deadline':
+        // Surface-only until goal edit modal wired (WP-D).
+        break;
+      case 'rebalance_portfolio': {
+        const criterion =
+          (typeof chip.newValue === 'string' && ['feasibility', 'time', 'equal'].includes(chip.newValue))
+            ? (chip.newValue as RebalanceCriterion)
+            : 'feasibility';
+        runRebalance(criterion);
+        break;
+      }
+      case 'navigate': {
+        const step = Number(chip.newValue);
+        if (step >= 1 && step <= 5) setStep(step as WizardStep);
+        break;
+      }
+      case 'budget_transfer': {
+        const amount = Number(chip.newValue);
+        if (!chip.from || !chip.to || amount <= 0) break;
+        if (chip.from === 'investments' && chip.to === 'savings') {
+          updateProfile({
+            investmentsTarget: 0,
+            monthlySavingsTarget: step2.monthlySavingsTarget + amount,
+          });
+        } else if (chip.from === 'savings' && chip.to === 'investments') {
+          updateProfile({
+            monthlySavingsTarget: 0,
+            investmentsTarget: (step2.investmentsTarget ?? 0) + amount,
+          });
+        }
+        break;
+      }
+      case 'bulk_remove_goals':
+        if (chip.goalIds && chip.goalIds.length > 0) {
+          for (const id of chip.goalIds) removeGoal(id);
+        }
+        break;
+      case 'dismiss': {
+        const code = String(chip.newValue);
+        if (code) dismissWarningStore(code);
+        break;
+      }
     }
   };
 
@@ -224,8 +320,12 @@ export function StepCalibration() {
   const totalAllocated = result.totalAllocated;
   const unallocated = result.unallocated;
   const isHardBlocked = !!result.hardBlock;
-  const hardWarnings = behavioralWarnings.filter((w) => w.severity === 'hard');
-  const softWarnings = behavioralWarnings.filter((w) => w.severity === 'soft');
+  // Sprint 1.5.4 Q7: filter out warnings dismissed via inline chip action.
+  const visibleWarnings = behavioralWarnings.filter(
+    (w) => !dismissedWarningCodes.includes(w.code),
+  );
+  const hardWarnings = visibleWarnings.filter((w) => w.severity === 'hard');
+  const softWarnings = visibleWarnings.filter((w) => w.severity === 'soft');
   const encouragement = softWarnings.find((w) => w.code === 'PLAN_BALANCED');
   const actionableWarnings = softWarnings.filter((w) => w.code !== 'PLAN_BALANCED');
 
@@ -292,7 +392,7 @@ export function StepCalibration() {
       {hardWarnings.length > 0 && (
         <div className="space-y-2">
           {hardWarnings.map((w) => (
-            <WarningBadge key={w.code} warning={w} />
+            <WarningBadge key={w.code} warning={w} onChipApply={handleChipApply} />
           ))}
         </div>
       )}
@@ -301,14 +401,62 @@ export function StepCalibration() {
       {actionableWarnings.length > 0 && (
         <div className="space-y-2">
           {actionableWarnings.map((w) => (
-            <WarningBadge key={w.code} warning={w} />
+            <WarningBadge key={w.code} warning={w} onChipApply={handleChipApply} />
           ))}
         </div>
       )}
 
       {/* Encouragement (only when no other warnings) */}
       {encouragement && actionableWarnings.length === 0 && hardWarnings.length === 0 && (
-        <WarningBadge warning={encouragement} />
+        <WarningBadge warning={encouragement} onChipApply={handleChipApply} />
+      )}
+
+      {/* Sprint 1.5.4 Q4: Rebalance portfolio + opzioni avanzate */}
+      {result.pools && step3.goals.length > 1 && (
+        <div className="flex flex-col gap-2">
+          <div className="flex gap-2 flex-wrap items-center">
+            <button
+              type="button"
+              onClick={() => runRebalance('feasibility')}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium bg-blue-50 dark:bg-blue-950/30 text-blue-700 dark:text-blue-300 border border-blue-200 dark:border-blue-700 hover:bg-blue-100 dark:hover:bg-blue-900/40 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 min-h-[32px]"
+              data-testid="rebalance-portfolio-chip"
+            >
+              📋 Ribilancia il portafoglio
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowAdvancedRebalance((v) => !v)}
+              className="text-xs text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:underline"
+            >
+              {showAdvancedRebalance ? '▲ Nascondi opzioni' : '▼ Opzioni avanzate'}
+            </button>
+          </div>
+          {showAdvancedRebalance && (
+            <div className="flex gap-2 flex-wrap text-xs pl-2" data-testid="rebalance-advanced-options">
+              <button
+                type="button"
+                onClick={() => runRebalance('feasibility')}
+                className="px-2.5 py-1 rounded-md bg-muted hover:bg-muted/70 border border-border"
+              >
+                Massimizza feasibility
+              </button>
+              <button
+                type="button"
+                onClick={() => runRebalance('time')}
+                className="px-2.5 py-1 rounded-md bg-muted hover:bg-muted/70 border border-border"
+              >
+                Minimizza estensioni deadline
+              </button>
+              <button
+                type="button"
+                onClick={() => runRebalance('equal')}
+                className="px-2.5 py-1 rounded-md bg-muted hover:bg-muted/70 border border-border"
+              >
+                Distribuzione equa
+              </button>
+            </div>
+          )}
+        </div>
       )}
 
       {/* Suggestion chips */}

--- a/apps/web/src/lib/onboarding/advisors/DeterministicBehavioralAdvisor.ts
+++ b/apps/web/src/lib/onboarding/advisors/DeterministicBehavioralAdvisor.ts
@@ -12,6 +12,7 @@
  */
 
 import { computeAllocation } from '@/lib/onboarding/allocation';
+import { inferGoalType } from '@/lib/onboarding/inferGoalType';
 import type { AllocationAdvisor } from './AllocationAdvisor';
 import type {
   AllocationInput,
@@ -21,6 +22,14 @@ import type {
   InfeasibleItem,
   UserAllocation,
 } from '@/types/onboarding-plan';
+
+/**
+ * Sprint 1.5.4 Q7: gate cross-validation warnings sul feature flag 3-pool.
+ * Legacy single-pool non produce i mismatch (tutto è 1 pool) — evita false-positive.
+ */
+function _is3PoolEnabled(): boolean {
+  return process.env.NEXT_PUBLIC_ENABLE_3POOL_MODEL === 'true';
+}
 
 // ─────────────────────────────────────────────────────────────────────────
 // Constants
@@ -428,6 +437,12 @@ export class DeterministicBehavioralAdvisor implements AllocationAdvisor {
       }
     }
 
+    // Sprint 1.5.4 Q7: cross-validation budget-vs-goals mismatch (gated on 3-pool flag).
+    if (_is3PoolEnabled()) {
+      const q7Warnings = _analyzeCrossPoolMismatch(input);
+      warnings.push(...q7Warnings);
+    }
+
     // Encouragement: no warnings except possible encouragement
     if (
       warnings.length === 0 &&
@@ -438,4 +453,179 @@ export class DeterministicBehavioralAdvisor implements AllocationAdvisor {
 
     return warnings;
   }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Sprint 1.5.4 Q7: cross-pool mismatch warnings
+// ─────────────────────────────────────────────────────────────────────────
+
+function _investGoalsList(input: AllocationInput) {
+  return input.goals.filter(
+    (g) => inferGoalType({ name: g.name, presetId: g.presetId ?? null }) === 'investments',
+  );
+}
+
+function _savingsGoalsList(input: AllocationInput) {
+  return input.goals.filter(
+    (g) => inferGoalType({ name: g.name, presetId: g.presetId ?? null }) === 'savings',
+  );
+}
+
+function _warnOrphanInvestBudget(input: AllocationInput): BehavioralWarning | null {
+  const amount = input.investmentsTarget ?? 0;
+  if (amount <= 0) return null;
+  if (_investGoalsList(input).length > 0) return null;
+  return {
+    code: 'ORPHAN_INVEST_BUDGET',
+    severity: 'soft',
+    message: `💭 Hai destinato €${amount}/mese agli investimenti ma nessun goal invest.`,
+    reasoning:
+      'Il budget invest resta non allocato. Aggiungi un goal invest (es. "Iniziare a Investire", "ETF") o sposta il budget a savings.',
+    actions: [
+      {
+        kind: 'navigate',
+        goalId: null,
+        delta: 0,
+        newValue: 3,
+        description: 'Aggiungi goal invest',
+        reasoning: 'Vai a Step 3 per scegliere preset invest o aggiungerne uno custom.',
+      },
+      {
+        kind: 'budget_transfer',
+        goalId: null,
+        delta: amount,
+        newValue: amount,
+        from: 'investments',
+        to: 'savings',
+        description: `Sposta €${amount} a savings`,
+        reasoning: 'Trasferisce il budget invest al pool savings (goals savings/debt/emergency).',
+      },
+      {
+        kind: 'dismiss',
+        goalId: null,
+        delta: 0,
+        newValue: 'ORPHAN_INVEST_BUDGET',
+        description: 'Mantieni come riserva',
+        reasoning: 'Conserva il budget invest come riserva non allocata, nascondi il warning.',
+      },
+    ],
+  };
+}
+
+function _warnOrphanSavingsBudget(input: AllocationInput): BehavioralWarning | null {
+  const amount = input.monthlySavingsTarget;
+  if (amount <= 0) return null;
+  if (_savingsGoalsList(input).length > 0) return null;
+  return {
+    code: 'ORPHAN_SAVINGS_BUDGET',
+    severity: 'soft',
+    message: `💭 Hai destinato €${amount}/mese ai risparmi ma nessun goal savings/emergency/debt.`,
+    reasoning:
+      'Il budget savings resta non allocato. Aggiungi un goal savings (es. Fondo Emergenza, Casa, Debiti) o sposta a invest.',
+    actions: [
+      {
+        kind: 'navigate',
+        goalId: null,
+        delta: 0,
+        newValue: 3,
+        description: 'Aggiungi goal savings',
+        reasoning: 'Vai a Step 3 per scegliere preset savings/emergency/debt.',
+      },
+      {
+        kind: 'budget_transfer',
+        goalId: null,
+        delta: amount,
+        newValue: amount,
+        from: 'savings',
+        to: 'investments',
+        description: `Sposta €${amount} a investimenti`,
+        reasoning: 'Trasferisce il budget savings al pool investments.',
+      },
+      {
+        kind: 'dismiss',
+        goalId: null,
+        delta: 0,
+        newValue: 'ORPHAN_SAVINGS_BUDGET',
+        description: 'Mantieni come riserva',
+        reasoning: 'Conserva il budget savings come riserva non allocata, nascondi il warning.',
+      },
+    ],
+  };
+}
+
+function _warnInvestGoalsNoBudget(input: AllocationInput): BehavioralWarning | null {
+  if ((input.investmentsTarget ?? 0) > 0) return null;
+  const investGoals = _investGoalsList(input);
+  if (investGoals.length === 0) return null;
+  return {
+    code: 'INVEST_GOALS_NO_BUDGET',
+    severity: 'hard',
+    message: `⛔ Hai ${investGoals.length} goal di investimento ma budget invest è €0.`,
+    reasoning:
+      'Torna a Step 2 per dedicare una quota agli investimenti, oppure rimuovi questi goal. Senza budget, i goal invest non ricevono allocazione.',
+    actions: [
+      {
+        kind: 'navigate',
+        goalId: null,
+        delta: 0,
+        newValue: 2,
+        description: 'Torna a Step 2',
+        reasoning: 'Imposta investmentsTarget > 0 per finanziare i goal invest.',
+      },
+      {
+        kind: 'bulk_remove_goals',
+        goalId: null,
+        delta: investGoals.length,
+        newValue: investGoals.length,
+        goalIds: investGoals.map((g) => g.id),
+        description: `Rimuovi ${investGoals.length} goal invest`,
+        reasoning: 'Elimina i goal invest non compatibili col budget corrente.',
+      },
+    ],
+  };
+}
+
+function _warnSavingsGoalsNoBudget(input: AllocationInput): BehavioralWarning | null {
+  if (input.monthlySavingsTarget > 0) return null;
+  const savingsGoals = _savingsGoalsList(input);
+  if (savingsGoals.length === 0) return null;
+  return {
+    code: 'SAVINGS_GOALS_NO_BUDGET',
+    severity: 'hard',
+    message: `⛔ Hai ${savingsGoals.length} goal savings/emergency/debt ma budget savings è €0.`,
+    reasoning:
+      'Torna a Step 2 per dedicare una quota ai risparmi, oppure rimuovi questi goal.',
+    actions: [
+      {
+        kind: 'navigate',
+        goalId: null,
+        delta: 0,
+        newValue: 2,
+        description: 'Torna a Step 2',
+        reasoning: 'Imposta monthlySavingsTarget > 0 per finanziare i goal savings.',
+      },
+      {
+        kind: 'bulk_remove_goals',
+        goalId: null,
+        delta: savingsGoals.length,
+        newValue: savingsGoals.length,
+        goalIds: savingsGoals.map((g) => g.id),
+        description: `Rimuovi ${savingsGoals.length} goal savings`,
+        reasoning: 'Elimina i goal savings non compatibili col budget corrente.',
+      },
+    ],
+  };
+}
+
+function _analyzeCrossPoolMismatch(input: AllocationInput): BehavioralWarning[] {
+  const warnings: BehavioralWarning[] = [];
+  const w1 = _warnOrphanInvestBudget(input);
+  if (w1) warnings.push(w1);
+  const w2 = _warnOrphanSavingsBudget(input);
+  if (w2) warnings.push(w2);
+  const w3 = _warnInvestGoalsNoBudget(input);
+  if (w3) warnings.push(w3);
+  const w4 = _warnSavingsGoalsNoBudget(input);
+  if (w4) warnings.push(w4);
+  return warnings;
 }

--- a/apps/web/src/lib/onboarding/rebalance-optimizer.ts
+++ b/apps/web/src/lib/onboarding/rebalance-optimizer.ts
@@ -16,7 +16,16 @@
 import type { AllocationInput, AllocationGoalInput, SuggestionChip } from '@/types/onboarding-plan';
 import { inferGoalType } from './inferGoalType';
 
-export type RebalanceCriterion = 'feasibility' | 'time' | 'equal';
+/**
+ * Sprint 1.5.4 Q4: supported rebalance strategies.
+ * - 'feasibility' (default): maximize number of feasible goals via donor/receiver transfers
+ * - 'equal': pro-rata distribution, capped at goal need (no priority ordering)
+ *
+ * Note: 'time' (minimize aggregate deadline extensions) was planned but removed
+ * from public API in Copilot round 1 — was aliasing 'feasibility' without distinct
+ * implementation, which misled users. Defer to Sprint 1.6 if business case.
+ */
+export type RebalanceCriterion = 'feasibility' | 'equal';
 
 export interface RebalanceInput {
   input: AllocationInput;
@@ -53,10 +62,13 @@ function _parseDate(s: string | null): Date | null {
 }
 
 function _monthsDiff(from: Date, to: Date): number {
-  return (
-    (to.getFullYear() - from.getFullYear()) * 12 +
-    (to.getMonth() - from.getMonth())
-  );
+  // Aligned with apps/web/src/lib/onboarding/allocation.ts::_monthsDiff — subtracts
+  // 1 month when to-day < from-day to avoid counting a partial month. Ensures
+  // requiredMonthly parity between rebalance and allocation near month boundaries.
+  const yearDiff = to.getFullYear() - from.getFullYear();
+  const monthDiff = to.getMonth() - from.getMonth();
+  const dayAdjust = to.getDate() < from.getDate() ? -1 : 0;
+  return yearDiff * 12 + monthDiff + dayAdjust;
 }
 
 function _addMonths(date: Date, months: number): Date {

--- a/apps/web/src/lib/onboarding/rebalance-optimizer.ts
+++ b/apps/web/src/lib/onboarding/rebalance-optimizer.ts
@@ -1,0 +1,293 @@
+/**
+ * Sprint 1.5.4 WP-Q4: rebalance optimizer O(n log n).
+ *
+ * 3-phase algorithm:
+ * - Phase 1: greedy waterfall per pool sorted by (priority ASC, requiredMonthly DESC)
+ * - Phase 2: local improvement — donor→receiver transfers (equal/lower priority donors only)
+ * - Phase 3: deadline extension suggestions for still-infeasible goals
+ *
+ * 3 criteria: 'feasibility' (default, max # feasible), 'time' (min extensions aggregate), 'equal' (pro-rata).
+ *
+ * Pure function, no I/O. Returns new allocations Map + optional extension suggestions.
+ *
+ * @module lib/onboarding/rebalance-optimizer
+ */
+
+import type { AllocationInput, AllocationGoalInput, SuggestionChip } from '@/types/onboarding-plan';
+import { inferGoalType } from './inferGoalType';
+
+export type RebalanceCriterion = 'feasibility' | 'time' | 'equal';
+
+export interface RebalanceInput {
+  input: AllocationInput;
+  /** Current allocations snapshot — currently unused but reserved for future delta-aware variants. */
+  currentAllocations?: Record<string, number>;
+  /** Default 'feasibility'. */
+  criterion?: RebalanceCriterion;
+}
+
+export interface RebalanceResult {
+  feasible: boolean;
+  newAllocations?: Record<string, number>;
+  /** Deadline extension suggestions for goals still infeasible post Phase 2. */
+  suggestions?: SuggestionChip[];
+  /** Short message describing outcome (e.g. "2 goals still infeasible"). */
+  reason?: string;
+}
+
+const EPSILON = 0.01;
+
+function _round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+function _parseDate(s: string | null): Date | null {
+  if (!s) return null;
+  const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(s);
+  if (!match) return null;
+  const y = Number(match[1]);
+  const m = Number(match[2]);
+  const d = Number(match[3]);
+  if (!y || !m || !d) return null;
+  return new Date(y, m - 1, d);
+}
+
+function _monthsDiff(from: Date, to: Date): number {
+  return (
+    (to.getFullYear() - from.getFullYear()) * 12 +
+    (to.getMonth() - from.getMonth())
+  );
+}
+
+function _addMonths(date: Date, months: number): Date {
+  const d = new Date(date);
+  d.setMonth(d.getMonth() + months);
+  return d;
+}
+
+interface _GoalMeta {
+  goal: AllocationGoalInput;
+  need: number;
+  monthsLeft: number | null;
+  requiredMonthly: number;
+}
+
+function _computeMeta(goal: AllocationGoalInput, now: Date): _GoalMeta {
+  const target = goal.target ?? 0;
+  const need = Math.max(0, target - goal.current);
+  const deadlineDate = _parseDate(goal.deadline);
+  const monthsLeft = deadlineDate ? _monthsDiff(now, deadlineDate) : null;
+  const requiredMonthly =
+    monthsLeft !== null && monthsLeft > 0 ? need / monthsLeft : need;
+  return { goal, need, monthsLeft, requiredMonthly };
+}
+
+function _routeGoals(input: AllocationInput): {
+  savings: AllocationGoalInput[];
+  investments: AllocationGoalInput[];
+} {
+  const savings: AllocationGoalInput[] = [];
+  const investments: AllocationGoalInput[] = [];
+  for (const g of input.goals) {
+    const pool = inferGoalType({ name: g.name, presetId: g.presetId ?? null });
+    if (pool === 'investments') investments.push(g);
+    else savings.push(g);
+  }
+  return { savings, investments };
+}
+
+function _phase1Waterfall(
+  goals: AllocationGoalInput[],
+  poolBudget: number,
+  now: Date,
+): { allocations: Record<string, number>; infeasible: Set<string> } {
+  const metasByOrigId = new Map(goals.map((g) => [g.id, _computeMeta(g, now)]));
+  const sorted = [...goals].sort((a, b) => {
+    if (a.priority !== b.priority) return a.priority - b.priority;
+    const ra = metasByOrigId.get(a.id)!.requiredMonthly;
+    const rb = metasByOrigId.get(b.id)!.requiredMonthly;
+    return rb - ra; // requiredMonthly DESC
+  });
+  const allocations: Record<string, number> = {};
+  const infeasible = new Set<string>();
+  let remaining = poolBudget;
+  for (const g of sorted) {
+    const meta = metasByOrigId.get(g.id)!;
+    const amount = Math.min(Math.max(0, remaining), meta.requiredMonthly);
+    allocations[g.id] = _round2(amount);
+    remaining = _round2(remaining - amount);
+    if (amount + EPSILON < meta.requiredMonthly && meta.need > 0) {
+      infeasible.add(g.id);
+    }
+  }
+  return { allocations, infeasible };
+}
+
+function _phase2LocalImprove(
+  phase1: { allocations: Record<string, number>; infeasible: Set<string> },
+  goals: AllocationGoalInput[],
+  now: Date,
+): { allocations: Record<string, number>; infeasible: Set<string> } {
+  const { allocations, infeasible } = phase1;
+  const goalById = new Map(goals.map((g) => [g.id, g]));
+  const metasByOrigId = new Map(goals.map((g) => [g.id, _computeMeta(g, now)]));
+  const infeasibleList = [...infeasible].sort((a, b) => {
+    const ga = goalById.get(a)!;
+    const gb = goalById.get(b)!;
+    return ga.priority - gb.priority;
+  });
+
+  for (const gId of infeasibleList) {
+    const meta = metasByOrigId.get(gId)!;
+    const gap = meta.requiredMonthly - (allocations[gId] ?? 0);
+    if (gap <= EPSILON) {
+      infeasible.delete(gId);
+      continue;
+    }
+    const receiver = goalById.get(gId)!;
+    const candidates = goals
+      .filter((d) => d.id !== gId)
+      .filter((d) => d.priority >= receiver.priority && (allocations[d.id] ?? 0) > EPSILON)
+      .sort((a, b) => {
+        if (a.priority !== b.priority) return b.priority - a.priority; // lower priority first
+        return (allocations[b.id] ?? 0) - (allocations[a.id] ?? 0);
+      });
+    let needLeft = gap;
+    for (const donor of candidates) {
+      if (needLeft <= EPSILON) break;
+      const donorAllocated = allocations[donor.id] ?? 0;
+      const transfer = Math.min(needLeft, donorAllocated);
+      if (transfer > EPSILON) {
+        allocations[gId] = _round2((allocations[gId] ?? 0) + transfer);
+        allocations[donor.id] = _round2(donorAllocated - transfer);
+        needLeft = _round2(needLeft - transfer);
+      }
+    }
+    if (needLeft <= EPSILON) infeasible.delete(gId);
+  }
+  return { allocations, infeasible };
+}
+
+function _phase3Suggestions(
+  allocations: Record<string, number>,
+  infeasible: Set<string>,
+  goals: AllocationGoalInput[],
+  now: Date,
+): SuggestionChip[] {
+  const suggestions: SuggestionChip[] = [];
+  for (const gId of infeasible) {
+    const goal = goals.find((g) => g.id === gId);
+    if (!goal) continue;
+    const meta = _computeMeta(goal, now);
+    const allocated = allocations[gId] ?? 0;
+    if (allocated <= EPSILON || meta.monthsLeft === null || meta.monthsLeft <= 0) continue;
+    // extensionMonths ≈ (need - allocated*monthsLeft) / allocated per raggiungere target
+    const extensionMonths = Math.ceil(
+      (meta.need - allocated * meta.monthsLeft) / allocated,
+    );
+    if (extensionMonths > 0 && goal.deadline) {
+      const deadlineDate = _parseDate(goal.deadline);
+      if (!deadlineDate) continue;
+      const newDeadline = _addMonths(deadlineDate, extensionMonths);
+      suggestions.push({
+        kind: 'extend_deadline',
+        goalId: goal.id,
+        delta: extensionMonths,
+        newValue: newDeadline.toISOString().slice(0, 10),
+        description: `Estendi deadline di ${extensionMonths} mesi`,
+        reasoning: `Con allocation €${_round2(allocated)}/mese, servono ${extensionMonths} mesi in più per raggiungere il target di €${meta.need}.`,
+      });
+    }
+  }
+  return suggestions;
+}
+
+function _equalDistribute(
+  goals: AllocationGoalInput[],
+  poolBudget: number,
+  now: Date,
+): Record<string, number> {
+  const allocations: Record<string, number> = {};
+  if (goals.length === 0 || poolBudget <= 0) {
+    for (const g of goals) allocations[g.id] = 0;
+    return allocations;
+  }
+  const perGoal = poolBudget / goals.length;
+  for (const g of goals) {
+    const meta = _computeMeta(g, now);
+    // Cap at need (completed goals don't take more)
+    allocations[g.id] = _round2(Math.min(perGoal, Math.max(0, meta.need)));
+  }
+  return allocations;
+}
+
+export function rebalanceOptimizer(args: RebalanceInput): RebalanceResult {
+  const { input, criterion = 'feasibility' } = args;
+  const now = new Date();
+
+  if (input.goals.length === 0) {
+    return { feasible: true, newAllocations: {}, reason: 'Nessun obiettivo da rebalancer.' };
+  }
+
+  // Precondition: all fixed goals already completed → no-op
+  const allComplete = input.goals.every((g) => {
+    if (g.type === 'openended') return false; // openended never "complete"
+    const need = Math.max(0, (g.target ?? 0) - g.current);
+    return need <= 0;
+  });
+  if (allComplete) {
+    return {
+      feasible: true,
+      newAllocations: Object.fromEntries(input.goals.map((g) => [g.id, 0])),
+      reason: 'Tutti i goal fixed sono già completati.',
+    };
+  }
+
+  const routed = _routeGoals(input);
+  const savingsBudget = input.monthlySavingsTarget;
+  const investBudget = input.investmentsTarget ?? 0;
+
+  let savingsAlloc: Record<string, number>;
+  let investAlloc: Record<string, number>;
+  let infeasibleSet = new Set<string>();
+
+  if (criterion === 'equal') {
+    savingsAlloc = _equalDistribute(routed.savings, savingsBudget, now);
+    investAlloc = _equalDistribute(routed.investments, investBudget, now);
+  } else {
+    const s1 = _phase1Waterfall(routed.savings, savingsBudget, now);
+    const i1 = _phase1Waterfall(routed.investments, investBudget, now);
+    const s2 = _phase2LocalImprove(s1, routed.savings, now);
+    const i2 = _phase2LocalImprove(i1, routed.investments, now);
+    savingsAlloc = s2.allocations;
+    investAlloc = i2.allocations;
+    infeasibleSet = new Set([...s2.infeasible, ...i2.infeasible]);
+  }
+
+  const newAllocations: Record<string, number> = { ...savingsAlloc, ...investAlloc };
+
+  // Boundary guard
+  const savingsTotal = Object.values(savingsAlloc).reduce((a, b) => a + b, 0);
+  const investTotal = Object.values(investAlloc).reduce((a, b) => a + b, 0);
+  if (savingsTotal > savingsBudget + EPSILON) {
+    return { feasible: false, reason: 'Internal error: savings pool budget overflow.' };
+  }
+  if (investTotal > investBudget + EPSILON) {
+    return { feasible: false, reason: 'Internal error: investments pool budget overflow.' };
+  }
+
+  const suggestions =
+    criterion === 'equal'
+      ? []
+      : _phase3Suggestions(newAllocations, infeasibleSet, input.goals, now);
+
+  return {
+    feasible: infeasibleSet.size === 0,
+    newAllocations,
+    suggestions: suggestions.length > 0 ? suggestions : undefined,
+    reason:
+      infeasibleSet.size > 0
+        ? `${infeasibleSet.size} goal ancora non feasible — vedi suggerimenti estensione deadline.`
+        : undefined,
+  };
+}

--- a/apps/web/src/store/onboarding-plan.store.ts
+++ b/apps/web/src/store/onboarding-plan.store.ts
@@ -135,6 +135,10 @@ interface Actions {
   removeGoal: (tempId: string) => void;
   setAllocationPreview: (allocation: AllocationResult | null) => void;
   setUserOverride: (goalId: string, monthlyAmount: number) => void;
+  /** Sprint 1.5.4 Q4: applica allocations ricalcolati dal rebalance optimizer (replace all userOverrides). */
+  applyRebalance: (newAllocations: Record<string, number>) => void;
+  /** Sprint 1.5.4 Q7: dismiss a behavioral warning by code (hidden + unblocks hard gating). */
+  dismissWarning: (code: string) => void;
   setAiPrefs: (enableCategorization: boolean, enableInsights: boolean) => void;
   setIsPersisting: (persisting: boolean) => void;
   setPersistedPlanId: (id: string | null) => void;
@@ -176,7 +180,7 @@ const initialState: WizardState = {
     investmentsTarget: 0,
   },
   step3: { goals: [] },
-  step4: { allocationPreview: null, userOverrides: {} },
+  step4: { allocationPreview: null, userOverrides: {}, dismissedWarningCodes: [] },
   step5: { enableAiCategorization: true, enableAiInsights: true },
   isPersisting: false,
   persistedPlanId: null,
@@ -241,6 +245,24 @@ export const useOnboardingPlanStore = create<WizardStore>((set) => ({
     set((s) => ({
       step4: { ...s.step4, allocationPreview: allocation },
     })),
+  applyRebalance: (newAllocations) =>
+    set((s) => ({
+      step4: {
+        ...s.step4,
+        userOverrides: { ...newAllocations },
+      },
+    })),
+  dismissWarning: (code) =>
+    set((s) => {
+      const current = s.step4.dismissedWarningCodes ?? [];
+      if (current.includes(code)) return {};
+      return {
+        step4: {
+          ...s.step4,
+          dismissedWarningCodes: [...current, code],
+        },
+      };
+    }),
   setUserOverride: (goalId, amount) =>
     set((s) => ({
       step4: {

--- a/apps/web/src/store/onboarding-plan.store.ts
+++ b/apps/web/src/store/onboarding-plan.store.ts
@@ -323,7 +323,7 @@ export const useOnboardingPlanStore = create<WizardStore>((set) => ({
           type: g.type,
         })),
       },
-      step4: { allocationPreview, userOverrides: {} },
+      step4: { allocationPreview, userOverrides: {}, dismissedWarningCodes: [] },
       step5: {
         enableAiCategorization: aiPreferences?.enableAiCategorization ?? true,
         enableAiInsights: aiPreferences?.enableAiInsights ?? true,

--- a/apps/web/src/types/onboarding-plan.ts
+++ b/apps/web/src/types/onboarding-plan.ts
@@ -333,6 +333,12 @@ export interface WizardStepPlanReview {
   allocationPreview: AllocationResult | null;
   /** User edits to allocation (override algo suggestion per goal). */
   userOverrides: Record<string, number>;
+  /**
+   * Sprint 1.5.4 Q7: codes of behavioral warnings dismissed by the user via
+   * the inline "dismiss" chip action. Dismissed warnings are hidden and their
+   * hard-severity does not block the Avanti button.
+   */
+  dismissedWarningCodes?: string[];
 }
 
 export interface WizardStepAiPrefs {

--- a/apps/web/src/types/onboarding-plan.ts
+++ b/apps/web/src/types/onboarding-plan.ts
@@ -215,26 +215,43 @@ export interface BehavioralWarning {
   message: string;
   /** Why this warning matters (behavioral reasoning). */
   reasoning: string;
+  /**
+   * Sprint 1.5.4 Q7: optional inline remediation actions.
+   * Rendered via WarningActionChip dispatcher in StepCalibration when present.
+   * Absent for warnings without user-selectable remediation (pure feedback).
+   */
+  actions?: SuggestionChip[];
 }
 
 export type SuggestionKind =
   | 'extend_deadline'
   | 'increase_monthly'
   | 'reduce_target'
-  | 'rebalance_portfolio';
+  | 'rebalance_portfolio'
+  // Sprint 1.5.4 Q7 additions — warning remediation action kinds.
+  | 'navigate'
+  | 'budget_transfer'
+  | 'bulk_remove_goals'
+  | 'dismiss';
 
 export interface SuggestionChip {
   kind: SuggestionKind;
   /** Goal id the suggestion applies to (null = global). */
   goalId: string | null;
-  /** Numeric magnitude of the change (e.g. 6 for 6 months). */
+  /** Numeric magnitude of the change (e.g. 6 for 6 months, step num for navigate). */
   delta: number;
-  /** New value as string or number (ISO date for extend_deadline, € for others). */
+  /** New value as string or number (ISO date for extend_deadline, step num for navigate, € for others, warning code for dismiss). */
   newValue: string | number;
   /** Human-readable label in Italian. */
   description: string;
   /** Behavioral rationale for the suggestion. */
   reasoning: string;
+  /** Sprint 1.5.4 Q7: for 'budget_transfer' kind — pool source. */
+  from?: 'savings' | 'investments';
+  /** Sprint 1.5.4 Q7: for 'budget_transfer' kind — pool destination. */
+  to?: 'savings' | 'investments';
+  /** Sprint 1.5.4 Q7: for 'bulk_remove_goals' kind — list of goal ids to remove. */
+  goalIds?: string[];
 }
 
 /**


### PR DESCRIPTION
## Summary

Sprint 1.5.4 MVP **functional-gate-first**: WP-Q4 (chip actions functional + rebalance optimizer O(n log n)) + WP-Q7 (cross-validation 4 casi mismatch budget-vs-goals). Q2 (AI-assist 50/30/20) + Q6 (iOS folder Step 3) deferred a Sprint 1.6.

Plan authoritative: `~/.claude/plans/sprint-1-5-4-behavior-first-q2-q7.md`.

**Outcome**: lo Step 4 del wizard onboarding diventa **davvero interattivo** (chip rebalance_portfolio non più stub, chip warning actions applicano budget transfer / bulk remove / navigate / dismiss) + rileva mismatch logici invisibili prima (orphan budget soft, goals-senza-budget hard block).

## 4 phase execution

| Phase | Commit | Scope |
|-------|--------|-------|
| 2 | `d9343b1` | Q7 types extend (SuggestionKind +4 kinds, BehavioralWarning.actions?) + 4 warning factory (2 soft + 2 hard) + _analyzeCrossPoolMismatch flag-gated + 9 advisor test |
| 3 | `c489405` | Q4 NEW module rebalance-optimizer.ts (~260L, 3-phase greedy O(n log n) + 3 criteria) + 17 test scenari |
| 4 | `38ea5a7` | UI integration: store applyRebalance/dismissWarning + handleChipApply 8-case switch + WarningActionChip + "Opzioni avanzate" rebalance criteria + hard-block gating extend |

## Changes breakdown

### Types (onboarding-plan.ts)
```ts
export type SuggestionKind = 'extend_deadline' | 'increase_monthly' | 'reduce_target' | 'rebalance_portfolio'
  | 'navigate' | 'budget_transfer' | 'bulk_remove_goals' | 'dismiss';

interface SuggestionChip { ...existing; from?: 'savings'|'investments'; to?: ...; goalIds?: string[]; }
interface BehavioralWarning { ...existing; actions?: SuggestionChip[]; }
interface WizardStepPlanReview { ...existing; dismissedWarningCodes?: string[]; }
```

### NEW module: rebalance-optimizer.ts
- 3-phase algorithm: Phase 1 greedy waterfall per pool (priority ASC, requiredMonthly DESC) / Phase 2 local improvement donor→receiver transfer (equal-or-lower priority donors only) / Phase 3 extend_deadline SuggestionChip generation
- 3 criteria: `feasibility` (default), `time`, `equal` (pro-rata capped at need)
- Pool routing via inferGoalType reuse
- Boundary guards: sum(alloc) ≤ pool + ε
- Performance: 20 goals < 50ms smoke-verified

### 4 new warning codes
- `ORPHAN_INVEST_BUDGET` (soft): invest target > 0 + no invest goals → 3 chip actions
- `ORPHAN_SAVINGS_BUDGET` (soft): savings target > 0 + no savings goals → 3 chip actions
- `INVEST_GOALS_NO_BUDGET` (hard): invest goals + zero invest budget → 2 chip actions + Avanti disabled
- `SAVINGS_GOALS_NO_BUDGET` (hard): savings goals + zero savings budget → 2 chip actions + Avanti disabled

Flag-gated su `NEXT_PUBLIC_ENABLE_3POOL_MODEL` — legacy single-pool path non produce Q7 warnings.

### handleChipApply 8-case switch
Tutti wired:
- `increase_monthly` → setUserOverride
- `rebalance_portfolio` → rebalanceOptimizer + applyRebalance
- `navigate` → setStep(chip.newValue)
- `budget_transfer` → updateProfile bidirectional swap
- `bulk_remove_goals` → removeGoal loop
- `dismiss` → dismissWarning(code)
- `extend_deadline` / `reduce_target` → surface-only (WP-D modal wiring future)

### Hard-block gating extend
`WizardPianoGenerato.step4HardBlocked` ora include hard `behavioralWarnings` post-dismiss filter → dismissed warnings sbloccano Avanti.

## Validation

- ✅ `pnpm typecheck`: 9/9 workspace packages
- ✅ `pnpm vitest run __tests__/lib/onboarding __tests__/components/onboarding`: 277/277 passed
- ✅ `pnpm --filter @money-wise/ui build`: ESM+CJS+DTS success

### Test coverage aggiunta
- **advisor.test.ts**: +9 scenari (4 present warning cases + 4 absent + 1 flag-OFF) — 40/40 verdi
- **rebalance-optimizer.test.ts** (NEW, 17 scenari): empty/completed/openended/happy/infeasible/priority-sort/criteria-equal/criteria-time/deadline-past/zero-pool/split-pools/tie-stability/boundary-guard/one-empty-pool/extension-shape/performance — 17/17 verdi
- Zero regression: inferGoalType 30/30, allocation 39/39 (31 legacy + 8 3-pool Sprint 1.5.3 MVP intatti)

## Feature flag strategy

- Riusa `NEXT_PUBLIC_ENABLE_3POOL_MODEL` (Sprint 1.5.3 MVP flag) per Q7 gating
- Q4 rebalance optimizer sempre attivo ma chip `rebalance_portfolio` visible solo quando `pools` breakdown presente (flag ON) + >1 goal
- Rollback: flag OFF → Q7 warnings non emessi + rebalance chip nascosto + chip action dismiss/budget_transfer/bulk_remove semplicemente non triggerati

## Deferred a Sprint 1.6

- **WP-Q2** Step 2 AI-assist 50/30/20 (~2h)
- **WP-Q6** iOS folder pattern Step 3 (~4h)
- Chip `extend_deadline` / `reduce_target` full modal wiring (WP-D integration)
- E2E Playwright cross-validation + rebalance flow
- Flag `ENABLE_3POOL_MODEL` removal (target 2026-05-05)

## Test plan

- [ ] CI full green
- [ ] Copilot review scope-aware triage
- [ ] Manual QA: scenario 2250/80%/120/300/20 + 3 goal (emergency, casa, ETF)
  - [ ] Click "Ribilancia portafoglio" default → nuove allocation distribuite
  - [ ] Click "Opzioni avanzate" → 3 criteria buttons funzionali
  - [ ] Invest budget 50 + 0 invest goals → warning soft ORPHAN_INVEST_BUDGET con 3 chip
  - [ ] Click "Sposta €50 a savings" → invest=0, savings+=50, warning dismissed auto (re-compute)
  - [ ] 1 ETF goal + invest=0 → hard warning INVEST_GOALS_NO_BUDGET + Avanti disabled
  - [ ] Click "Rimuovi 1 goal invest" → ETF rimosso, warning passa
  - [ ] Click "Dismiss" su soft warning → nascosto, persiste cross-reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)