### PR TITLE
feat(onboarding): Sprint 1.5.5 — Step 4 bug batch + Q2 AI-assist reactive

### DIFF
--- a/apps/web/__tests__/components/onboarding/StepProfile.test.tsx
+++ b/apps/web/__tests__/components/onboarding/StepProfile.test.tsx
@@ -11,6 +11,8 @@ import type { WizardState } from '@/types/onboarding-plan';
 import {
   selectCanAdvanceFromStep2,
   calcLifestyleDefault,
+  calcSavingsDefault,
+  calcInvestDefault,
   INCOME_MIN,
   INCOME_MAX,
   LIFESTYLE_SOFT_MIN,
@@ -85,24 +87,56 @@ function makeState(overrides: Partial<MockState> = {}): MockState {
 // calcLifestyleDefault unit tests
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe('calcLifestyleDefault', () => {
+describe('calcLifestyleDefault (Sprint 1.5.5: upgrade 15% → 30% Warren)', () => {
   it('returns LIFESTYLE_SOFT_MIN when income = 0', () => {
     expect(calcLifestyleDefault(0, 50)).toBe(LIFESTYLE_SOFT_MIN);
   });
 
-  it('returns max(50, min(500, disposable*0.15)) for typical income', () => {
-    // income=3000, ess=50% → disposable=1500 → 1500*0.15=225 → clamped to [50,500]
-    expect(calcLifestyleDefault(3000, 50)).toBe(225);
+  it('returns max(50, min(500, disposable*0.30)) for typical income', () => {
+    // income=3000, ess=50% → disposable=1500 → 1500*0.30=450 → clamped to [50,500]
+    expect(calcLifestyleDefault(3000, 50)).toBe(450);
   });
 
-  it('clamps to LIFESTYLE_SOFT_MIN (50) when disposable*0.15 < 50', () => {
-    // income=200, ess=90% → disposable=20 → 20*0.15=3 → clamped to 50
-    expect(calcLifestyleDefault(200, 90)).toBe(LIFESTYLE_SOFT_MIN);
+  it('clamps to LIFESTYLE_SOFT_MIN (50) when disposable*0.30 < 50', () => {
+    // income=100, ess=90% → disposable=10 → 10*0.30=3 → clamped to 50
+    expect(calcLifestyleDefault(100, 90)).toBe(LIFESTYLE_SOFT_MIN);
   });
 
-  it('clamps to 500 when disposable*0.15 > 500', () => {
-    // income=50000, ess=10% → disposable=45000 → 45000*0.15=6750 → clamped to 500
-    expect(calcLifestyleDefault(50_000, 10)).toBe(500);
+  it('clamps to 500 when disposable*0.30 > 500', () => {
+    // income=5000, ess=10% → disposable=4500 → 4500*0.30=1350 → clamped to 500
+    expect(calcLifestyleDefault(5000, 10)).toBe(500);
+  });
+});
+
+describe('calcSavingsDefault (Sprint 1.5.5: Warren 50%)', () => {
+  it('returns SAVINGS_MIN when income = 0', () => {
+    expect(calcSavingsDefault(0, 50)).toBe(SAVINGS_MIN);
+  });
+
+  it('returns disposable*0.50 for typical income', () => {
+    // income=3000, ess=50% → disposable=1500 → 1500*0.50=750
+    expect(calcSavingsDefault(3000, 50)).toBe(750);
+  });
+
+  it('clamps to SAVINGS_MIN when disposable*0.50 < SAVINGS_MIN', () => {
+    // income=100, ess=95% → disposable=5 → 5*0.50=2.5 → clamped to 10
+    expect(calcSavingsDefault(100, 95)).toBe(SAVINGS_MIN);
+  });
+});
+
+describe('calcInvestDefault (Sprint 1.5.5: Warren 20%)', () => {
+  it('returns 0 when income = 0', () => {
+    expect(calcInvestDefault(0, 50)).toBe(0);
+  });
+
+  it('returns disposable*0.20 for typical income', () => {
+    // income=3000, ess=50% → disposable=1500 → 1500*0.20=300
+    expect(calcInvestDefault(3000, 50)).toBe(300);
+  });
+
+  it('floors to 0 when disposable*0.20 rounds below 1', () => {
+    // income=100, ess=99% → disposable=1 → 1*0.20=0.2 → rounds to 0
+    expect(calcInvestDefault(100, 99)).toBe(0);
   });
 });
 

--- a/apps/web/__tests__/lib/onboarding/rebalance-optimizer.test.ts
+++ b/apps/web/__tests__/lib/onboarding/rebalance-optimizer.test.ts
@@ -12,12 +12,14 @@ function monthsFromNow(n: number): string {
 
 let _id = 0;
 function makeGoal(partial: Partial<AllocationGoalInput> = {}): AllocationGoalInput {
+  // Sprint 1.5.5 Copilot round 1: use `in` check per preservare null esplicito
+  // (openended goals hanno target=null / deadline=null; `?? 1000` li sovrascriveva).
   return {
     id: partial.id ?? `g${++_id}`,
     name: partial.name ?? 'Goal',
-    target: partial.target ?? 1000,
+    target: 'target' in partial ? (partial.target as number) : 1000,
     current: partial.current ?? 0,
-    deadline: partial.deadline ?? monthsFromNow(12),
+    deadline: 'deadline' in partial ? (partial.deadline as string) : monthsFromNow(12),
     priority: (partial.priority ?? 2) as PriorityRank,
     type: partial.type,
     presetId: partial.presetId,

--- a/apps/web/__tests__/lib/onboarding/rebalance-optimizer.test.ts
+++ b/apps/web/__tests__/lib/onboarding/rebalance-optimizer.test.ts
@@ -222,4 +222,39 @@ describe('rebalanceOptimizer', () => {
     // Returned allocations shape intact for all 20 inputs
     expect(Object.keys(r.newAllocations!).length).toBe(20);
   });
+
+  // ─── Sprint 1.5.5 Phase 1: openended residual split ───────────────────
+  describe('openended residual split (Sprint 1.5.5 Bug #1)', () => {
+    it('1 openended solo + pool 300 → riceve tutto residual', () => {
+      const g = makeGoal({ id: 'emergency', type: 'openended', target: null as unknown as number, deadline: null, priority: 1 });
+      const r = rebalanceOptimizer({ input: input({ monthlySavingsTarget: 300, goals: [g] }) });
+      expect(r.feasible).toBe(true);
+      expect(r.newAllocations![g.id]).toBeCloseTo(300, 1);
+    });
+
+    it('1 fixed need 100/mo + 1 openended + pool 300 → fixed 100, openended 200', () => {
+      const fixed = makeGoal({ id: 'fixed', target: 1200, deadline: monthsFromNow(12), priority: 1 }); // 100/mo
+      const open = makeGoal({ id: 'open', type: 'openended', target: null as unknown as number, deadline: null, priority: 2 });
+      const r = rebalanceOptimizer({ input: input({ monthlySavingsTarget: 300, goals: [fixed, open] }) });
+      expect(r.feasible).toBe(true);
+      expect(r.newAllocations!['fixed']).toBeCloseTo(100, 1);
+      expect(r.newAllocations!['open']).toBeCloseTo(200, 1);
+    });
+
+    it('2 openended stesso pool + pool 300 → split equo 150 ciascuno', () => {
+      const a = makeGoal({ id: 'a', type: 'openended', target: null as unknown as number, deadline: null, priority: 1 });
+      const b = makeGoal({ id: 'b', type: 'openended', target: null as unknown as number, deadline: null, priority: 2 });
+      const r = rebalanceOptimizer({ input: input({ monthlySavingsTarget: 300, goals: [a, b] }) });
+      expect(r.feasible).toBe(true);
+      expect(r.newAllocations!['a']).toBeCloseTo(150, 1);
+      expect(r.newAllocations!['b']).toBeCloseTo(150, 1);
+    });
+
+    it("criterion 'equal' con openended non ha cap → riceve perGoal pieno", () => {
+      const g = makeGoal({ id: 'em', type: 'openended', target: null as unknown as number, deadline: null, priority: 1 });
+      const r = rebalanceOptimizer({ input: input({ monthlySavingsTarget: 250, goals: [g] }), criterion: 'equal' });
+      expect(r.feasible).toBe(true);
+      expect(r.newAllocations!['em']).toBeCloseTo(250, 1);
+    });
+  });
 });

--- a/apps/web/src/components/onboarding/steps/StepCalibration.tsx
+++ b/apps/web/src/components/onboarding/steps/StepCalibration.tsx
@@ -322,8 +322,14 @@ export function StepCalibration() {
   }
 
   const incomeAfterEssentials = result.incomeAfterEssentials;
-  const totalAllocated = result.totalAllocated;
-  const unallocated = result.unallocated;
+  // Sprint 1.5.5 Phase 2: effective totals UI-aware — summary bar + pool header
+  // reflect userOverrides post-rebalance/slider. computeAllocation ignora
+  // userOverrides by design; computiamo effective on-the-fly dagli items.
+  const effectiveAllocatedFromItems = (items: { goalId: string; monthlyAmount: number }[]) =>
+    Math.round(
+      items.reduce((sum, it) => sum + (userOverrides[it.goalId] ?? it.monthlyAmount), 0) * 100,
+    ) / 100;
+  const totalAllocated = effectiveAllocatedFromItems(result.items ?? []);
   const isHardBlocked = !!result.hardBlock;
   // Sprint 1.5.4 Q7: filter out warnings dismissed via inline chip action.
   const visibleWarnings = behavioralWarnings.filter(
@@ -339,6 +345,24 @@ export function StepCalibration() {
 
   const hasPoolsBreakdown = !!result.pools;
   const lifestyleProtected = hasPoolsBreakdown ? result.pools!.lifestyle.budget : 0;
+  // Sprint 1.5.5 Phase 2: effective pool totals (reflect userOverrides live).
+  const effectiveSavingsAllocated = hasPoolsBreakdown
+    ? effectiveAllocatedFromItems(result.pools!.savings.items)
+    : totalAllocated;
+  const effectiveSavingsResidual = hasPoolsBreakdown
+    ? Math.round((result.pools!.savings.budget - effectiveSavingsAllocated) * 100) / 100
+    : 0;
+  const effectiveInvestAllocated = hasPoolsBreakdown
+    ? effectiveAllocatedFromItems(result.pools!.investments.items)
+    : 0;
+  const effectiveInvestResidual = hasPoolsBreakdown
+    ? Math.round((result.pools!.investments.budget - effectiveInvestAllocated) * 100) / 100
+    : 0;
+  // Unallocated top-level: per pools 3-pool, residuo dopo lifestyle+savings+invest.
+  // Per legacy flat, residuo totale post-savings.
+  const unallocated = hasPoolsBreakdown
+    ? Math.round((effectiveSavingsResidual + effectiveInvestResidual) * 100) / 100
+    : Math.round((savingsPool - totalAllocated) * 100) / 100;
 
   return (
     <div className="space-y-4" data-testid="step-calibration">
@@ -478,8 +502,8 @@ export function StepCalibration() {
               poolType="savings"
               title="Savings"
               budget={result.pools!.savings.budget}
-              allocated={result.pools!.savings.allocated}
-              residual={result.pools!.savings.residual}
+              allocated={effectiveSavingsAllocated}
+              residual={effectiveSavingsResidual}
               items={result.pools!.savings.items}
               goals={step3.goals}
               userOverrides={userOverrides}
@@ -492,8 +516,8 @@ export function StepCalibration() {
               poolType="investments"
               title="Investimenti"
               budget={result.pools!.investments.budget}
-              allocated={result.pools!.investments.allocated}
-              residual={result.pools!.investments.residual}
+              allocated={effectiveInvestAllocated}
+              residual={effectiveInvestResidual}
               items={result.pools!.investments.items}
               goals={step3.goals}
               userOverrides={userOverrides}

--- a/apps/web/src/components/onboarding/steps/StepProfile.tsx
+++ b/apps/web/src/components/onboarding/steps/StepProfile.tsx
@@ -12,6 +12,8 @@ import {
   ESSENTIALS_MIN_PCT,
   ESSENTIALS_MAX_PCT,
   calcLifestyleDefault,
+  calcSavingsDefault,
+  calcInvestDefault,
 } from '@/store/onboarding-plan.store';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -55,8 +57,10 @@ export function StepProfile() {
   const incomeError = validateIncome(rawIncome);
   const showIncomeError = incomeBlurred && incomeError !== null && rawIncome.trim() !== '';
 
-  // ── Lifestyle buffer: track whether user has manually touched it ──
+  // ── Touched refs: track user manual edits to protect against AI override (Sprint 1.5.5 Phase 3) ──
   const lifestyleTouchedRef = useRef(step2.lifestyleBuffer > 0);
+  const savingsTouchedRef = useRef(step2.monthlySavingsTarget > 0);
+  const investTouchedRef = useRef(step2.investmentsTarget > 0);
 
   const incomeInputId = useId();
   const essentialsId = useId();
@@ -69,12 +73,20 @@ export function StepProfile() {
   const essentialsPct = step2.essentialsPct;
   const essentialsEuros = income > 0 ? income * (essentialsPct / 100) : 0;
 
-  // ── Lifestyle AI default auto-fill (only while untouched) ──
+  // ── AI defaults reactive: Sprint 1.5.5 Phase 3 — Warren 50/30/20 ──
+  // lifestyle 30%, savings 50%, invest 20% on disposable post-essenziali.
+  // Batch update solo se almeno un campo non è touched, per evitare re-render spuri.
   useEffect(() => {
-    if (income > 0 && !lifestyleTouchedRef.current) {
-      const aiDefault = calcLifestyleDefault(income, essentialsPct);
-      updateProfile({ lifestyleBuffer: aiDefault });
-    }
+    if (income <= 0) return;
+    const patch: {
+      lifestyleBuffer?: number;
+      monthlySavingsTarget?: number;
+      investmentsTarget?: number;
+    } = {};
+    if (!lifestyleTouchedRef.current) patch.lifestyleBuffer = calcLifestyleDefault(income, essentialsPct);
+    if (!savingsTouchedRef.current) patch.monthlySavingsTarget = calcSavingsDefault(income, essentialsPct);
+    if (!investTouchedRef.current) patch.investmentsTarget = calcInvestDefault(income, essentialsPct);
+    if (Object.keys(patch).length > 0) updateProfile(patch);
   }, [income, essentialsPct, updateProfile]);
 
   // ── Sum constraint ──
@@ -276,6 +288,11 @@ export function StepProfile() {
       <div>
         <label htmlFor={savingsId} className="text-sm font-medium text-foreground block mb-1">
           Risparmio mensile target (€) <span className="text-red-500" aria-hidden>*</span>
+          {income > 0 && (
+            <span className="ml-1 text-xs text-muted-foreground font-normal">
+              (AI default: €{formatEuro(calcSavingsDefault(income, essentialsPct))})
+            </span>
+          )}
         </label>
         <input
           id={savingsId}
@@ -283,7 +300,10 @@ export function StepProfile() {
           min={SAVINGS_MIN}
           step={50}
           value={step2.monthlySavingsTarget || ''}
-          onChange={(e) => updateProfile({ monthlySavingsTarget: Number(e.target.value) || 0 })}
+          onChange={(e) => {
+            savingsTouchedRef.current = true;
+            updateProfile({ monthlySavingsTarget: Number(e.target.value) || 0 });
+          }}
           placeholder="es. 500"
           className="w-full bg-muted/50 border border-border rounded-xl px-3 py-2.5 text-sm outline-none focus:ring-2 focus:ring-blue-500 text-foreground"
           suppressHydrationWarning
@@ -306,6 +326,11 @@ export function StepProfile() {
         <label htmlFor={investId} className="text-sm font-medium text-foreground block mb-1">
           Investimenti mensili (€){' '}
           <span className="text-xs text-muted-foreground font-normal">(opzionale)</span>
+          {income > 0 && (
+            <span className="ml-1 text-xs text-muted-foreground font-normal">
+              (AI default: €{formatEuro(calcInvestDefault(income, essentialsPct))})
+            </span>
+          )}
         </label>
         <input
           id={investId}
@@ -313,7 +338,10 @@ export function StepProfile() {
           min={0}
           step={25}
           value={step2.investmentsTarget || ''}
-          onChange={(e) => updateProfile({ investmentsTarget: Number(e.target.value) || 0 })}
+          onChange={(e) => {
+            investTouchedRef.current = true;
+            updateProfile({ investmentsTarget: Number(e.target.value) || 0 });
+          }}
           placeholder="es. 150 (opzionale)"
           className="w-full bg-muted/50 border border-border rounded-xl px-3 py-2.5 text-sm outline-none focus:ring-2 focus:ring-blue-500 text-foreground"
           suppressHydrationWarning

--- a/apps/web/src/components/onboarding/steps/StepProfile.tsx
+++ b/apps/web/src/components/onboarding/steps/StepProfile.tsx
@@ -58,9 +58,24 @@ export function StepProfile() {
   const showIncomeError = incomeBlurred && incomeError !== null && rawIncome.trim() !== '';
 
   // ── Touched refs: track user manual edits to protect against AI override (Sprint 1.5.5 Phase 3) ──
-  const lifestyleTouchedRef = useRef(step2.lifestyleBuffer > 0);
-  const savingsTouchedRef = useRef(step2.monthlySavingsTarget > 0);
-  const investTouchedRef = useRef(step2.investmentsTarget > 0);
+  // Copilot round 1 fix: init ref=true SOLO se valore differisce dall'AI default
+  // (altrimenti post-remount un AI-autofilled non-zero verrebbe trattato come touched,
+  // bloccando reactive updates). Income=0 → ref=false (reactive attivo quando income arriva).
+  const _initLifestyleTouched =
+    step2.monthlyIncome > 0 &&
+    step2.lifestyleBuffer > 0 &&
+    step2.lifestyleBuffer !== calcLifestyleDefault(step2.monthlyIncome, step2.essentialsPct);
+  const _initSavingsTouched =
+    step2.monthlyIncome > 0 &&
+    step2.monthlySavingsTarget > 0 &&
+    step2.monthlySavingsTarget !== calcSavingsDefault(step2.monthlyIncome, step2.essentialsPct);
+  const _initInvestTouched =
+    step2.monthlyIncome > 0 &&
+    step2.investmentsTarget > 0 &&
+    step2.investmentsTarget !== calcInvestDefault(step2.monthlyIncome, step2.essentialsPct);
+  const lifestyleTouchedRef = useRef(_initLifestyleTouched);
+  const savingsTouchedRef = useRef(_initSavingsTouched);
+  const investTouchedRef = useRef(_initInvestTouched);
 
   const incomeInputId = useId();
   const essentialsId = useId();

--- a/apps/web/src/lib/onboarding/rebalance-optimizer.ts
+++ b/apps/web/src/lib/onboarding/rebalance-optimizer.ts
@@ -243,6 +243,11 @@ function _equalDistribute(
  * (budget - allocations fixed) viene splittato equamente tra openended goals
  * del pool. Risolve caso Fondo Emergenza openended che riceve 0 perché
  * _computeMeta(target=null).need = 0 → requiredMonthly = 0 → Phase 1 alloca 0.
+ *
+ * Copilot round 1 fix: cent-integer math per evitare overflow boundary guard.
+ * Es. residual=100, n=6 → perGoal=16.67 × 6 = 100.02 > 100 farebbe fallire
+ * `sum(allocations) > budget + EPSILON` check. Distribuiamo in centesimi interi
+ * con first `remainderCents` goals che ricevono +1 cent per compensare resto.
  */
 function _residualSplitOpenended(
   allocations: Record<string, number>,
@@ -254,10 +259,14 @@ function _residualSplitOpenended(
   if (residual <= EPSILON) return allocations;
   const openended = goals.filter((g) => g.type === 'openended');
   if (openended.length === 0) return allocations;
-  const perGoal = _round2(residual / openended.length);
+  const residualCents = Math.round(residual * 100);
+  const perGoalCents = Math.floor(residualCents / openended.length);
+  const remainderCents = residualCents - perGoalCents * openended.length;
   const result = { ...allocations };
-  for (const g of openended) {
-    result[g.id] = _round2((result[g.id] ?? 0) + perGoal);
+  for (let i = 0; i < openended.length; i++) {
+    const g = openended[i];
+    const sharesCents = perGoalCents + (i < remainderCents ? 1 : 0);
+    result[g.id] = _round2((result[g.id] ?? 0) + sharesCents / 100);
   }
   return result;
 }

--- a/apps/web/src/lib/onboarding/rebalance-optimizer.ts
+++ b/apps/web/src/lib/onboarding/rebalance-optimizer.ts
@@ -226,11 +226,40 @@ function _equalDistribute(
   }
   const perGoal = poolBudget / goals.length;
   for (const g of goals) {
+    if (g.type === 'openended') {
+      // Openended goals non hanno cap (target=null, need=0 spurious)
+      allocations[g.id] = _round2(perGoal);
+      continue;
+    }
     const meta = _computeMeta(g, now);
     // Cap at need (completed goals don't take more)
     allocations[g.id] = _round2(Math.min(perGoal, Math.max(0, meta.need)));
   }
   return allocations;
+}
+
+/**
+ * Sprint 1.5.5 Bug #1: dopo waterfall + local improve, il residual del pool
+ * (budget - allocations fixed) viene splittato equamente tra openended goals
+ * del pool. Risolve caso Fondo Emergenza openended che riceve 0 perché
+ * _computeMeta(target=null).need = 0 → requiredMonthly = 0 → Phase 1 alloca 0.
+ */
+function _residualSplitOpenended(
+  allocations: Record<string, number>,
+  goals: AllocationGoalInput[],
+  poolBudget: number,
+): Record<string, number> {
+  const totalAllocated = Object.values(allocations).reduce((a, b) => a + b, 0);
+  const residual = _round2(poolBudget - totalAllocated);
+  if (residual <= EPSILON) return allocations;
+  const openended = goals.filter((g) => g.type === 'openended');
+  if (openended.length === 0) return allocations;
+  const perGoal = _round2(residual / openended.length);
+  const result = { ...allocations };
+  for (const g of openended) {
+    result[g.id] = _round2((result[g.id] ?? 0) + perGoal);
+  }
+  return result;
 }
 
 export function rebalanceOptimizer(args: RebalanceInput): RebalanceResult {
@@ -271,8 +300,8 @@ export function rebalanceOptimizer(args: RebalanceInput): RebalanceResult {
     const i1 = _phase1Waterfall(routed.investments, investBudget, now);
     const s2 = _phase2LocalImprove(s1, routed.savings, now);
     const i2 = _phase2LocalImprove(i1, routed.investments, now);
-    savingsAlloc = s2.allocations;
-    investAlloc = i2.allocations;
+    savingsAlloc = _residualSplitOpenended(s2.allocations, routed.savings, savingsBudget);
+    investAlloc = _residualSplitOpenended(i2.allocations, routed.investments, investBudget);
     infeasibleSet = new Set([...s2.infeasible, ...i2.infeasible]);
   }
 

--- a/apps/web/src/store/onboarding-plan.store.ts
+++ b/apps/web/src/store/onboarding-plan.store.ts
@@ -46,13 +46,34 @@ export const ESSENTIALS_MIN_PCT = 10;
 export const ESSENTIALS_MAX_PCT = 90;
 
 /**
- * AI default lifestyle buffer: max(50, min(500, disposable * 0.15)).
+ * AI default lifestyle buffer (Sprint 1.5.5 Phase 3: upgrade 15% → 30% Warren
+ * canonical 50/30/20 rule). Max(50, min(500, disposable * 0.30)).
  * Exported for tests.
  */
 export function calcLifestyleDefault(monthlyIncome: number, essentialsPct: number): number {
   if (monthlyIncome <= 0) return LIFESTYLE_SOFT_MIN;
   const disposable = monthlyIncome * (1 - essentialsPct / 100);
-  return Math.max(LIFESTYLE_SOFT_MIN, Math.min(500, Math.round(disposable * 0.15)));
+  return Math.max(LIFESTYLE_SOFT_MIN, Math.min(500, Math.round(disposable * 0.3)));
+}
+
+/**
+ * Sprint 1.5.5 Phase 3: AI default savings (Warren 50% del disposable post-essenziali).
+ * max(SAVINGS_MIN, disposable * 0.50).
+ */
+export function calcSavingsDefault(monthlyIncome: number, essentialsPct: number): number {
+  if (monthlyIncome <= 0) return SAVINGS_MIN;
+  const disposable = monthlyIncome * (1 - essentialsPct / 100);
+  return Math.max(SAVINGS_MIN, Math.round(disposable * 0.5));
+}
+
+/**
+ * Sprint 1.5.5 Phase 3: AI default investments (Warren 20% del disposable post-essenziali).
+ * max(0, disposable * 0.20). Zero floor consentito (user può non investire).
+ */
+export function calcInvestDefault(monthlyIncome: number, essentialsPct: number): number {
+  if (monthlyIncome <= 0) return 0;
+  const disposable = monthlyIncome * (1 - essentialsPct / 100);
+  return Math.max(0, Math.round(disposable * 0.2));
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Phase 1**: rebalance optimizer openended fix (residual-split post waterfall + `_equalDistribute` no-cap per openended)
- **Phase 2**: effective totals UI-aware (summary bar + pool header reflect userOverrides post-rebalance/slider, zero refactor computeAllocation)
- **Phase 3**: Q2 AI-assist reactive (Warren 50/30/20 — `calcSavingsDefault`/`calcInvestDefault` + upgrade `calcLifestyleDefault` 15%→30%; 3 touched refs paralleli + hint UI)

## Test plan

- [x] typecheck 9/9 green
- [x] vitest full suite: 1875 passed (+8 new), 2 skipped, zero regression
- [x] UI tsup build green
- [ ] CI Development Pipeline green
- [ ] Manual QA dev server smoke 6 scenari (income reactive, touched-preserve, summary coerenza, rebalance openended, equal distribution, Sprint 1.5.4 Q7 regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)