### PR TITLE
chore(tech-debt): Sprint 1.6 Wave 4A — postcss dedup + pre-commit scope root package.json

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -48,6 +48,22 @@ if echo "$STAGED" | grep -qE '^(apps/web|packages)/'; then
   NEEDS_PNPM=true
 fi
 
+# Sprint 1.6 #011: root package.json overrides/workspaces changes e
+# pnpm-workspace.yaml triggerano full pnpm gate. Meta-lesson Dependabot batch
+# 2026-04-20: `pnpm.overrides` root precede workspace deps, quindi bump override
+# root richiede test full (non solo workspace scope).
+if echo "$STAGED" | grep -q '^package\.json$'; then
+  if git diff --cached -- package.json | grep -qE '^[+-].*(overrides|workspaces|pnpm)'; then
+    NEEDS_PNPM=true
+    echo "  📦 Root package.json overrides/workspaces change → full pnpm gate"
+  fi
+fi
+
+if echo "$STAGED" | grep -q '^pnpm-workspace\.yaml$'; then
+  NEEDS_PNPM=true
+  echo "  📦 pnpm-workspace.yaml change → full pnpm gate"
+fi
+
 TOUCHES_FUNCTIONS=false
 if echo "$STAGED" | grep -q '^supabase/functions/'; then
   TOUCHES_FUNCTIONS=true

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -48,14 +48,17 @@ if echo "$STAGED" | grep -qE '^(apps/web|packages)/'; then
   NEEDS_PNPM=true
 fi
 
-# Sprint 1.6 #011: root package.json overrides/workspaces changes e
-# pnpm-workspace.yaml triggerano full pnpm gate. Meta-lesson Dependabot batch
-# 2026-04-20: `pnpm.overrides` root precede workspace deps, quindi bump override
-# root richiede test full (non solo workspace scope).
+# Sprint 1.6 #011: root dependency-management changes must trigger full pnpm gate.
+# Include root package.json updates to `overrides`, `workspaces`, or `pnpm` keys
+# + pnpm-workspace.yaml changes — affettano dependency resolution monorepo-wide.
+# Meta-lesson Dependabot batch 2026-04-20: root `pnpm.overrides` precede workspace
+# deps, quindi bump richiede test full (TS2742 osservato su override @types/react).
+# Regex stretto a JSON key syntax `"overrides":` per evitare match su script lines
+# che contengono la parola "pnpm" (es. `"test": "pnpm run test"`).
 if echo "$STAGED" | grep -q '^package\.json$'; then
-  if git diff --cached -- package.json | grep -qE '^[+-].*(overrides|workspaces|pnpm)'; then
+  if git diff --cached -- package.json | grep -qE '^[+-][[:space:]]*"(overrides|workspaces|pnpm)"[[:space:]]*:'; then
     NEEDS_PNPM=true
-    echo "  📦 Root package.json overrides/workspaces change → full pnpm gate"
+    echo "  📦 Root package.json overrides/workspaces/pnpm key change → full pnpm gate"
   fi
 fi
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -82,7 +82,6 @@
     "@next/bundle-analyzer": "^15.2.4",
     "@next/eslint-plugin-next": "^16.0.6",
     "@playwright/test": "^1.57.0",
-    "@tailwindcss/postcss": "^4.0.0",
     "@testing-library/dom": "^10.0.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",


### PR DESCRIPTION
## Summary

2 tech-debt quick wins:

- **#009** `@tailwindcss/postcss` dedup `apps/web`: rimosso duplicato `^4.0.0` in devDeps, mantenuto `^4.1.17` in deps.
- **#011** pre-commit scope-gap root `package.json`: hook ora scala detection a root `package.json` overrides/workspaces/pnpm changes + pnpm-workspace.yaml → full pnpm gate (evita regressioni come TS2742 su override bump).

## Test plan

- [x] typecheck 9/9 green
- [x] vitest 1877 passed 2 skipped zero regression
- [x] pnpm install + lockfile verified
- [ ] CI Development Pipeline green

🤖 Generated with [Claude Code](https://claude.com/claude-code)