### PR TITLE
fix(onboarding): Sprint 1.6 Wave 4D — 7 fix manual QA feedback user

### DIFF
--- a/apps/web/__tests__/lib/onboarding/inferGoalType.test.ts
+++ b/apps/web/__tests__/lib/onboarding/inferGoalType.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { inferGoalType } from '@/lib/onboarding/inferGoalType';
+import { inferGoalType, inferPresetIdFromName } from '@/lib/onboarding/inferGoalType';
 
 describe('inferGoalType', () => {
   describe('presetId exact match (7 presets)', () => {
@@ -73,5 +73,47 @@ describe('inferGoalType', () => {
       // presetId savings even if name would suggest investments
       expect(inferGoalType({ presetId: 'comprare-casa', name: 'Crypto house' })).toBe('savings');
     });
+  });
+});
+
+// ─── Sprint 1.6.4D #032: inferPresetIdFromName reverse lookup ───────────
+describe('inferPresetIdFromName', () => {
+  const presetMatches: Array<[string, string]> = [
+    ['Fondo Emergenza', 'fondo-emergenza'],
+    ['Comprare Casa', 'comprare-casa'],
+    ['Iniziare a Investire', 'iniziare-a-investire'],
+    ['Eliminare Debiti', 'eliminare-debiti'],
+    ['Risparmiare di Più', 'risparmiare-di-piu'],
+    ['Viaggi / Vacanza', 'viaggi-vacanza'],
+    ['Far Crescere Patrimonio', 'far-crescere-patrimonio'],
+  ];
+
+  it.each(presetMatches)('exact name %s → presetId %s', (name, expected) => {
+    expect(inferPresetIdFromName(name)).toBe(expected);
+  });
+
+  it('returns null for null input', () => {
+    expect(inferPresetIdFromName(null)).toBeNull();
+  });
+
+  it('returns null for undefined input', () => {
+    expect(inferPresetIdFromName(undefined)).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(inferPresetIdFromName('')).toBeNull();
+  });
+
+  it('returns null for name not in preset map', () => {
+    expect(inferPresetIdFromName('Obiettivo Custom')).toBeNull();
+  });
+
+  it('case-sensitive match (no normalization)', () => {
+    expect(inferPresetIdFromName('fondo emergenza')).toBeNull();
+    expect(inferPresetIdFromName('FONDO EMERGENZA')).toBeNull();
+  });
+
+  it('does not match whitespace-padded names', () => {
+    expect(inferPresetIdFromName(' Fondo Emergenza ')).toBeNull();
   });
 });

--- a/apps/web/src/components/onboarding/WizardPianoGenerato.tsx
+++ b/apps/web/src/components/onboarding/WizardPianoGenerato.tsx
@@ -168,12 +168,17 @@ export function WizardPianoGenerato({ mode = 'create', onClose }: WizardPianoGen
 
   return (
     <Dialog.Portal>
-      {/* Dim overlay — click closes via Radix default onOpenChange */}
+      {/* Sprint 1.6.4D #036: dim overlay + blur app dietro visibile (NO nero opaco) */}
       <Dialog.Overlay className="fixed inset-0 z-40 bg-black/30 backdrop-blur-md" />
 
       <Dialog.Content
         className="fixed left-1/2 top-1/2 z-50 w-full max-w-2xl -translate-x-1/2 -translate-y-1/2 rounded-xl bg-card shadow-2xl p-6 outline-none max-h-[90vh] overflow-y-auto"
         aria-describedby="wizard-step-description"
+        // Sprint 1.6.4D #036: prevent close on outside click (user deve chiudere
+        // esplicitamente via X button o Esc → rispetta user intent, evita close
+        // accidentale perdita progresso wizard).
+        onPointerDownOutside={(e) => e.preventDefault()}
+        onInteractOutside={(e) => e.preventDefault()}
       >
         {/* Accessible title (Radix requirement) */}
         <Dialog.Title className="text-xl font-bold text-foreground pr-8">

--- a/apps/web/src/components/onboarding/steps/GoalPoolSection.tsx
+++ b/apps/web/src/components/onboarding/steps/GoalPoolSection.tsx
@@ -208,7 +208,7 @@ export function GoalPoolSection({
                         type="button"
                         onClick={() => onChipApply(chip)}
                         title={chip.reasoning}
-                        className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium bg-white dark:bg-blue-950/40 text-blue-700 dark:text-blue-300 border border-blue-300 dark:border-blue-700 hover:bg-blue-50 dark:hover:bg-blue-900/60 transition-colors"
+                        className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium bg-white dark:bg-blue-950/40 text-blue-700 dark:text-blue-300 border border-blue-300 dark:border-blue-700 hover:bg-blue-50 dark:hover:bg-blue-900/60 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1"
                       >
                         {chip.description}
                       </button>

--- a/apps/web/src/components/onboarding/steps/GoalPoolSection.tsx
+++ b/apps/web/src/components/onboarding/steps/GoalPoolSection.tsx
@@ -4,7 +4,7 @@ import { useId } from 'react';
 import * as SliderPrimitive from '@radix-ui/react-slider';
 import { AlertTriangle } from 'lucide-react';
 import { PRIORITY_LABEL_IT } from '@/types/onboarding-plan';
-import type { AllocationResultItem, PoolCategory } from '@/types/onboarding-plan';
+import type { AllocationResultItem, PoolCategory, SuggestionChip } from '@/types/onboarding-plan';
 import type { WizardGoalDraft } from '@/types/onboarding-plan';
 
 /**
@@ -24,6 +24,9 @@ interface GoalPoolSectionProps {
   userOverrides: Record<string, number>;
   onSliderChange: (goalId: string, value: number) => void;
   maxSlider: number;
+  /** Sprint 1.6.4D #030: per-goal suggestion chips rendered inline sotto ogni item */
+  suggestionsByGoalId?: Record<string, SuggestionChip[]>;
+  onChipApply?: (chip: SuggestionChip) => void;
 }
 
 const POOL_PALETTE: Record<
@@ -67,6 +70,8 @@ export function GoalPoolSection({
   userOverrides,
   onSliderChange,
   maxSlider,
+  suggestionsByGoalId,
+  onChipApply,
 }: GoalPoolSectionProps) {
   const headingId = useId();
   const palette = POOL_PALETTE[poolType];
@@ -192,6 +197,23 @@ export function GoalPoolSection({
                       </li>
                     ))}
                   </ul>
+                )}
+
+                {/* Sprint 1.6.4D #030: per-goal suggestion chips inline sotto item */}
+                {suggestionsByGoalId?.[item.goalId] && suggestionsByGoalId[item.goalId]!.length > 0 && onChipApply && (
+                  <div className="flex flex-wrap gap-1.5 mt-2">
+                    {suggestionsByGoalId[item.goalId]!.map((chip) => (
+                      <button
+                        key={`${chip.kind}-${chip.delta}`}
+                        type="button"
+                        onClick={() => onChipApply(chip)}
+                        title={chip.reasoning}
+                        className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium bg-white dark:bg-blue-950/40 text-blue-700 dark:text-blue-300 border border-blue-300 dark:border-blue-700 hover:bg-blue-50 dark:hover:bg-blue-900/60 transition-colors"
+                      >
+                        {chip.description}
+                      </button>
+                    ))}
+                  </div>
                 )}
               </li>
             );

--- a/apps/web/src/components/onboarding/steps/StepCalibration.tsx
+++ b/apps/web/src/components/onboarding/steps/StepCalibration.tsx
@@ -406,6 +406,19 @@ export function StepCalibration() {
 
   const hasPoolsBreakdown = !!result.pools;
   const lifestyleProtected = hasPoolsBreakdown ? result.pools!.lifestyle.budget : 0;
+
+  // Sprint 1.6.4D #030: split chip globali (goalId=null) vs per-goal (goalId set)
+  // per rendering per-goal inline sotto ciascun item in GoalPoolSection.
+  const suggestionsByGoalId = (result.suggestions ?? []).reduce<Record<string, SuggestionChip[]>>(
+    (acc, chip) => {
+      if (chip.goalId) {
+        if (!acc[chip.goalId]) acc[chip.goalId] = [];
+        acc[chip.goalId]!.push(chip);
+      }
+      return acc;
+    },
+    {},
+  );
   // Sprint 1.5.5 Phase 2: effective pool totals (reflect userOverrides live).
   const effectiveSavingsAllocated = hasPoolsBreakdown
     ? effectiveAllocatedFromItems(result.pools!.savings.items)
@@ -526,14 +539,16 @@ export function StepCalibration() {
               <button
                 type="button"
                 onClick={() => runRebalance('feasibility')}
-                className="px-2.5 py-1 rounded-md bg-muted hover:bg-muted/70 border border-border"
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium bg-blue-50 dark:bg-blue-950/30 text-blue-700 dark:text-blue-300 border border-blue-200 dark:border-blue-700 hover:bg-blue-100 dark:hover:bg-blue-900/40 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 min-h-[32px]"
+                aria-label="Priorità ai goal più urgenti e fattibili"
               >
-                Massimizza feasibility
+                Massimizza raggiungibilità
               </button>
               <button
                 type="button"
                 onClick={() => runRebalance('equal')}
-                className="px-2.5 py-1 rounded-md bg-muted hover:bg-muted/70 border border-border"
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium bg-blue-50 dark:bg-blue-950/30 text-blue-700 dark:text-blue-300 border border-blue-200 dark:border-blue-700 hover:bg-blue-100 dark:hover:bg-blue-900/40 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 min-h-[32px]"
+                aria-label="Distribuisci il budget equamente tra tutti gli obiettivi"
               >
                 Distribuzione equa
               </button>
@@ -542,18 +557,31 @@ export function StepCalibration() {
         </div>
       )}
 
-      {/* Suggestion chips */}
-      {(result.suggestions ?? []).length > 0 && (
-        <div className="flex flex-wrap gap-2">
-          {(result.suggestions ?? []).map((chip) => (
-            <SuggestionChipButton
-              key={`${chip.goalId ?? 'global'}-${chip.kind}`}
-              chip={chip}
-              onApply={handleChipApply}
-            />
-          ))}
-        </div>
-      )}
+      {/* Sprint 1.6.4D #030: split global chip (goalId=null) vs per-goal chip.
+          Per-goal chip passati a GoalPoolSection via prop suggestionsByGoalId → rendered
+          inline sotto ciascun item. Top block mostra global + fallback per-goal chip
+          non rendered in pool (edge case: flag 3-pool OFF, o goal non routed a pool). */}
+      {(() => {
+        const poolRenderedGoalIds = new Set<string>();
+        if (hasPoolsBreakdown && result.pools) {
+          for (const it of result.pools.savings.items) poolRenderedGoalIds.add(it.goalId);
+          for (const it of result.pools.investments.items) poolRenderedGoalIds.add(it.goalId);
+        }
+        const topChips = (result.suggestions ?? []).filter(
+          (c) => !c.goalId || !poolRenderedGoalIds.has(c.goalId),
+        );
+        return topChips.length > 0 ? (
+          <div className="flex flex-wrap gap-2">
+            {topChips.map((chip) => (
+              <SuggestionChipButton
+                key={`${chip.goalId ?? 'global'}-${chip.kind}`}
+                chip={chip}
+                onApply={handleChipApply}
+              />
+            ))}
+          </div>
+        ) : null;
+      })()}
 
       {/* 3-pool breakdown rendering (when pools present, Sprint 1.5.3 WP-Q5) */}
       {hasPoolsBreakdown && (
@@ -570,6 +598,8 @@ export function StepCalibration() {
               userOverrides={userOverrides}
               onSliderChange={(goalId, v) => setUserOverride(goalId, v)}
               maxSlider={Math.max(result.pools!.savings.budget, 1)}
+              suggestionsByGoalId={suggestionsByGoalId}
+              onChipApply={handleChipApply}
             />
           )}
           {(result.pools!.investments.items.length > 0 || result.pools!.investments.budget > 0) && (
@@ -584,6 +614,8 @@ export function StepCalibration() {
               userOverrides={userOverrides}
               onSliderChange={(goalId, v) => setUserOverride(goalId, v)}
               maxSlider={Math.max(result.pools!.investments.budget, 1)}
+              suggestionsByGoalId={suggestionsByGoalId}
+              onChipApply={handleChipApply}
             />
           )}
           <LifestyleInfoSection budget={result.pools!.lifestyle.budget} />

--- a/apps/web/src/components/onboarding/steps/StepReady.tsx
+++ b/apps/web/src/components/onboarding/steps/StepReady.tsx
@@ -23,6 +23,7 @@ export function StepReady() {
   const step5 = useOnboardingPlanStore((s) => s.step5);
   const setAiPrefs = useOnboardingPlanStore((s) => s.setAiPrefs);
   const allocationPreview = useOnboardingPlanStore((s) => s.step4.allocationPreview);
+  const userOverrides = useOnboardingPlanStore((s) => s.step4.userOverrides ?? {});
   const isPersisting = useOnboardingPlanStore((s) => s.isPersisting);
 
   const { monthlyIncome, essentialsPct, lifestyleBuffer, monthlySavingsTarget, investmentsTarget } =
@@ -167,7 +168,9 @@ export function StepReady() {
             <ul className="space-y-2" role="list" aria-label="Lista obiettivi">
               {step3.goals.map((goal) => {
                 const item = allocationPreview?.items.find((it) => it.goalId === goal.tempId);
-                const monthlyAmount = item?.monthlyAmount ?? 0;
+                // Sprint 1.6.4D #034: effective allocation (override ?? raw) coerente con Step 4 summary
+                const override = userOverrides[goal.tempId];
+                const monthlyAmount = override !== undefined ? override : (item?.monthlyAmount ?? 0);
                 const feasible = item?.deadlineFeasible ?? true;
                 return (
                   <li

--- a/apps/web/src/lib/onboarding/allocation.ts
+++ b/apps/web/src/lib/onboarding/allocation.ts
@@ -401,8 +401,13 @@ function _computeSinglePool(
         `${poolPrefix} di ${_fmtEur(unallocated)} non allocato. Alcuni obiettivi hanno deadline non raggiungibile con l'allocation corrente — considera di estendere deadline o ridurre target.`,
       );
     } else {
+      // Sprint 1.6.4D #028 Copilot round 1: nota "non va a lifestyle né altri pool"
+      // sensata SOLO in 3-pool mode (poolLabel valorizzato). Legacy single-pool no.
+      const extraNote = poolLabel
+        ? ` Il budget ${poolLabel} non utilizzato non va a lifestyle né ad altri pool.`
+        : '';
       globalWarnings.push(
-        `${poolPrefix} di ${_fmtEur(unallocated)} non allocato (tutti gli obiettivi sono stati finanziati per intero). Il budget ${poolLabel ?? 'del pool'} non utilizzato non va a lifestyle né ad altri pool.`,
+        `${poolPrefix} di ${_fmtEur(unallocated)} non allocato (tutti gli obiettivi sono stati finanziati per intero).${extraNote}`,
       );
     }
   }
@@ -466,7 +471,7 @@ export function computeAllocation(input: AllocationInput): AllocationResult {
     else savingsGoals.push(g);
   }
 
-  const savingsResult = _computeSinglePool(savingsGoals, savingsBudget, incomeAfterEssentials, false, now, 'Savings');
+  const savingsResult = _computeSinglePool(savingsGoals, savingsBudget, incomeAfterEssentials, false, now, 'Risparmi');
   const investResult = _computeSinglePool(investGoals, investBudget, incomeAfterEssentials, false, now, 'Investimenti');
 
   // Rebuild items[] preserving original goals[] order (cross-pool).

--- a/apps/web/src/lib/onboarding/allocation.ts
+++ b/apps/web/src/lib/onboarding/allocation.ts
@@ -150,6 +150,10 @@ function _computeSinglePool(
   incomeAfterEssentials: number,
   emitCapWarning: boolean,
   now: Date,
+  /** Sprint 1.6.4D #028: pool label per disambiguare warning text
+   * (es. "Budget residuo Savings €X" invece di generico "Budget residuo €X"
+   * che user confondeva con lifestyle budget quando coincidenza numerica). */
+  poolLabel?: string,
 ): {
   items: AllocationResultItem[];
   totalAllocated: number;
@@ -390,13 +394,15 @@ function _computeSinglePool(
 
   if (unallocated > 0) {
     const hasInfeasibleItem = items.some((it) => it.deadlineFeasible === false);
+    // Sprint 1.6.4D #028: pool label esplicito per evitare ambiguità con lifestyle budget
+    const poolPrefix = poolLabel ? `Budget residuo pool ${poolLabel}` : 'Budget residuo';
     if (hasInfeasibleItem) {
       globalWarnings.push(
-        `Budget residuo di ${_fmtEur(unallocated)} non allocato. Alcuni obiettivi hanno deadline non raggiungibile con l'allocation corrente — considera di estendere deadline o ridurre target.`,
+        `${poolPrefix} di ${_fmtEur(unallocated)} non allocato. Alcuni obiettivi hanno deadline non raggiungibile con l'allocation corrente — considera di estendere deadline o ridurre target.`,
       );
     } else {
       globalWarnings.push(
-        `Budget residuo di ${_fmtEur(unallocated)} non allocato (tutti gli obiettivi sono stati finanziati per intero).`,
+        `${poolPrefix} di ${_fmtEur(unallocated)} non allocato (tutti gli obiettivi sono stati finanziati per intero). Il budget ${poolLabel ?? 'del pool'} non utilizzato non va a lifestyle né ad altri pool.`,
       );
     }
   }
@@ -460,8 +466,8 @@ export function computeAllocation(input: AllocationInput): AllocationResult {
     else savingsGoals.push(g);
   }
 
-  const savingsResult = _computeSinglePool(savingsGoals, savingsBudget, incomeAfterEssentials, false, now);
-  const investResult = _computeSinglePool(investGoals, investBudget, incomeAfterEssentials, false, now);
+  const savingsResult = _computeSinglePool(savingsGoals, savingsBudget, incomeAfterEssentials, false, now, 'Savings');
+  const investResult = _computeSinglePool(investGoals, investBudget, incomeAfterEssentials, false, now, 'Investimenti');
 
   // Rebuild items[] preserving original goals[] order (cross-pool).
   const itemsById = new Map<string, AllocationResultItem>();

--- a/apps/web/src/lib/onboarding/inferGoalType.ts
+++ b/apps/web/src/lib/onboarding/inferGoalType.ts
@@ -21,6 +21,31 @@ const PRESET_TO_POOL: Record<string, PoolCategory> = {
   'far-crescere-patrimonio': 'investments',
 };
 
+/**
+ * Sprint 1.6.4D #032: exact name → presetId reverse lookup. Used by
+ * `hydrateFromPlan` in store per inferire presetId da goals legacy (pre-1.5.3
+ * schema non persisted presetId) → goal finisce in folder iOS pattern corretto
+ * Step 3 instead of "Obiettivi personalizzati". Exact match only: se user
+ * creato custom goal con nome identico, si pesca comunque il preset (acceptable
+ * trade-off, rari false positive).
+ */
+const PRESET_NAME_TO_ID: Record<string, string> = {
+  'Fondo Emergenza': 'fondo-emergenza',
+  'Comprare Casa': 'comprare-casa',
+  'Iniziare a Investire': 'iniziare-a-investire',
+  'Eliminare Debiti': 'eliminare-debiti',
+  'Risparmiare di Più': 'risparmiare-di-piu',
+  'Viaggi / Vacanza': 'viaggi-vacanza',
+  'Far Crescere Patrimonio': 'far-crescere-patrimonio',
+};
+
+export function inferPresetIdFromName(name: string | null | undefined): string | null {
+  if (!name) return null;
+  return Object.prototype.hasOwnProperty.call(PRESET_NAME_TO_ID, name)
+    ? PRESET_NAME_TO_ID[name]!
+    : null;
+}
+
 const INVEST_KEYWORDS =
   /\b(?:invest\w*|azion\w*|obbligazion\w*|etf|btp|pac|borsa|patrimonio|crypto|bitcoin|fondo comune)\b/i;
 

--- a/apps/web/src/store/onboarding-plan.store.ts
+++ b/apps/web/src/store/onboarding-plan.store.ts
@@ -14,6 +14,7 @@
  */
 
 import { create } from 'zustand';
+import { inferPresetIdFromName } from '@/lib/onboarding/inferGoalType';
 import type {
   WizardState,
   WizardStep,
@@ -349,6 +350,9 @@ export const useOnboardingPlanStore = create<WizardStore>((set) => ({
           deadline: g.deadline,
           priority: g.priority,
           type: g.type,
+          // Sprint 1.6.4D #032: infer presetId from name per permettere iOS folder
+          // pattern grouping dei goals hydrated (legacy schema non persiste presetId).
+          presetId: inferPresetIdFromName(g.name),
         })),
       },
       step4: { allocationPreview, userOverrides: {}, dismissedWarningCodes: [] },


### PR DESCRIPTION
## Summary

7 fix user-visible + internal cleanup da manual QA live test 2026-04-21:

- **#034 (CRITICAL)** Step 5 recap goal allocation invertita: applica userOverrides come Step 4
- **#028** Warning Budget residuo ambiguo → disambiguato con pool label esplicito
- **#036** Wizard modal: preventDefault click-outside (user deve chiudere via X o Esc)
- **#032** Step 3 folder: goals hydrated ora raccolti via `inferPresetIdFromName`
- **#031** Opzioni avanzate: style chip uniforme + "feasibility"→"raggiungibilità"
- **#030** Chip per-goal: rendered inline sotto item invece di top aggregate
- **#037** Dialog.Title a11y: già presente (warning residuo Radix strict-mode)

## Test plan

- [x] typecheck 9/9 green
- [x] vitest 1878 passed, 2 skipped, zero regression
- [ ] CI Development Pipeline green
- [ ] Manual QA user walkthrough scenari post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)