### PR TITLE
feat(goals): Sprint 1.6 Fase 2 — account↔goal linking schema + GoalEditModal.current

### DIFF
--- a/apps/web/src/components/goals/GoalEditModal.tsx
+++ b/apps/web/src/components/goals/GoalEditModal.tsx
@@ -40,6 +40,8 @@ function goalToInput(goal: Goal): GoalInput {
     deadline: goal.deadline,
     priority: goal.priority,
     monthlyAllocation: goal.monthlyAllocation,
+    // Sprint 1.6 Fase 2C: current editable manual (fallback non-linked goals)
+    current: goal.current,
   };
 }
 
@@ -175,6 +177,39 @@ export function GoalEditModal({ open, mode, goal, onSave, onCancel }: GoalEditMo
                   className="w-full bg-muted/50 border border-border rounded-xl px-3 py-2 text-sm text-foreground"
                 />
               </div>
+            </div>
+
+            {/* Sprint 1.6 Fase 2C: Current progress editable (manual fallback) */}
+            <div>
+              <label
+                htmlFor="goal-edit-current"
+                className="text-sm font-medium text-foreground block mb-1"
+              >
+                Risparmio attuale (€)
+                <span className="ml-1 text-xs text-muted-foreground font-normal">
+                  (quanto hai già messo da parte)
+                </span>
+              </label>
+              <input
+                id="goal-edit-current"
+                type="number"
+                min={0}
+                max={draft.target ?? undefined}
+                data-testid="goal-modal-current"
+                value={draft.current ?? 0}
+                onChange={(e) => {
+                  const v = Math.max(0, Number(e.target.value) || 0);
+                  const clamped = draft.target !== null && draft.target > 0 ? Math.min(v, draft.target) : v;
+                  setDraft({ ...draft, current: clamped });
+                }}
+                className="w-full bg-muted/50 border border-border rounded-xl px-3 py-2 text-sm text-foreground"
+                placeholder="0"
+              />
+              {draft.target !== null && draft.target > 0 && draft.current !== undefined && draft.current > 0 && (
+                <p className="text-xs text-muted-foreground mt-1">
+                  Progresso: {Math.round((draft.current / draft.target) * 100)}% di €{draft.target.toLocaleString('it-IT')}
+                </p>
+              )}
             </div>
 
             {/* Priority */}

--- a/apps/web/src/components/goals/GoalEditModal.tsx
+++ b/apps/web/src/components/goals/GoalEditModal.tsx
@@ -194,7 +194,10 @@ export function GoalEditModal({ open, mode, goal, onSave, onCancel }: GoalEditMo
                 id="goal-edit-current"
                 type="number"
                 min={0}
-                max={draft.target ?? undefined}
+                // Sprint 1.6 Fase 2C Copilot round 1: max solo se target > 0 —
+                // se target=0 (EMPTY_DRAFT iniziale o field clearato), max=0
+                // bloccherebbe input positivo via native number validation.
+                max={draft.target !== null && draft.target > 0 ? draft.target : undefined}
                 data-testid="goal-modal-current"
                 value={draft.current ?? 0}
                 onChange={(e) => {

--- a/apps/web/src/services/accounts.client.ts
+++ b/apps/web/src/services/accounts.client.ts
@@ -58,6 +58,8 @@ export interface Account {
   isManualAccount: boolean
   isSyncable: boolean
   needsSync: boolean
+  /** Sprint 1.6 Fase 2A: optional link to goal for auto-progress tracking */
+  goalId?: string | null
   createdAt: string
   updatedAt: string
 }
@@ -73,6 +75,8 @@ export interface CreateAccountRequest {
   creditLimit?: number
   userId?: string
   familyId?: string
+  /** Sprint 1.6 Fase 2A: optional link to goal */
+  goalId?: string | null
 }
 
 export interface UpdateAccountRequest {
@@ -84,6 +88,8 @@ export interface UpdateAccountRequest {
   institutionName?: string
   syncEnabled?: boolean
   settings?: { icon?: string; color?: string }
+  /** Sprint 1.6 Fase 2A: link/unlink to goal. null = unlink */
+  goalId?: string | null
 }
 
 // =============================================================================
@@ -179,6 +185,9 @@ function rowToAccount(row: AccountRow): Account {
     isManualAccount: isManual,
     isSyncable: !isManual && status === 'ACTIVE' && row.sync_enabled,
     needsSync: !isManual && status === 'ACTIVE' && row.sync_enabled && !row.last_sync_at,
+    // Sprint 1.6 Fase 2A: optional goal link (types.ts non ancora aggiornato via
+    // `supabase gen types` — cast difensivo finché migration applied + types regen)
+    goalId: (row as unknown as { goal_id?: string | null }).goal_id ?? null,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   }
@@ -219,7 +228,7 @@ export const accountsClient = {
     const { data: { user } } = await supabase.auth.getUser()
     if (!user) throw new AccountsApiError('Not authenticated', 401)
 
-    const insert: AccountInsert = {
+    const insert: AccountInsert & { goal_id?: string | null } = {
       name: input.name,
       type: input.type,
       source: input.source,
@@ -229,6 +238,8 @@ export const accountsClient = {
       credit_limit: input.creditLimit,
       user_id: input.familyId ? null : user.id,
       family_id: input.familyId ?? null,
+      // Sprint 1.6 Fase 2A: optional goal link
+      goal_id: input.goalId ?? null,
     }
 
     // XOR: if no familyId provided, set user_id (personal account)
@@ -250,7 +261,7 @@ export const accountsClient = {
 
   async updateAccount(accountId: string, input: UpdateAccountRequest): Promise<Account> {
     const supabase = createClient()
-    const update: Database['public']['Tables']['accounts']['Update'] = {}
+    const update: Database['public']['Tables']['accounts']['Update'] & { goal_id?: string | null } = {}
 
     if (input.name !== undefined) update.name = input.name
     if (input.status !== undefined) update.status = input.status as Database['public']['Enums']['account_status']
@@ -260,6 +271,8 @@ export const accountsClient = {
     if (input.institutionName !== undefined) update.institution_name = input.institutionName
     if (input.syncEnabled !== undefined) update.sync_enabled = input.syncEnabled
     if (input.settings !== undefined) update.settings = input.settings
+    // Sprint 1.6 Fase 2A: link/unlink goal
+    if (input.goalId !== undefined) update.goal_id = input.goalId
 
     // Type-safe update with explicit casting to avoid Next.js build type inference issues
     const { data, error } = await (supabase

--- a/apps/web/src/services/accounts.client.ts
+++ b/apps/web/src/services/accounts.client.ts
@@ -238,8 +238,13 @@ export const accountsClient = {
       credit_limit: input.creditLimit,
       user_id: input.familyId ? null : user.id,
       family_id: input.familyId ?? null,
-      // Sprint 1.6 Fase 2A: optional goal link
-      goal_id: input.goalId ?? null,
+    }
+
+    // Sprint 1.6 Fase 2A Copilot round 1: include goal_id SOLO se input.goalId
+    // defined — evita insert fail su DB pre-migration (colonna goal_id non esiste).
+    // Backward-compat: account creation legacy passa senza goal_id resta funzionante.
+    if (input.goalId !== undefined) {
+      insert.goal_id = input.goalId
     }
 
     // XOR: if no familyId provided, set user_id (personal account)

--- a/apps/web/src/services/goals.client.ts
+++ b/apps/web/src/services/goals.client.ts
@@ -101,7 +101,9 @@ export const goalsClient = {
         user_id: userId,
         name: goal.name.trim(),
         target: goal.target,
-        current: 0,
+        // Sprint 1.6 Fase 2C Copilot round 1: persist user-entered current (default 0
+        // per backward-compat). Clamp UI-side [0, target] già applicato in GoalEditModal.
+        current: Math.max(0, goal.current ?? 0),
         deadline: goal.deadline,
         priority: goal.priority,
         monthly_allocation: goal.monthlyAllocation ?? 0,

--- a/apps/web/src/services/goals.client.ts
+++ b/apps/web/src/services/goals.client.ts
@@ -35,6 +35,11 @@ export interface GoalInput {
   priority: PriorityRank;
   monthlyAllocation?: number;
   type?: GoalType;
+  /** Sprint 1.6 Fase 2C: current progress editable manual. Fallback quando
+   * goal non è linked a account (auto-sync da balance). Validation
+   * UI-side: 0 <= current <= target (se target non-null).
+   */
+  current?: number;
 }
 
 export class GoalsApiError extends Error {
@@ -138,6 +143,8 @@ export const goalsClient = {
         ...(patch.priority !== undefined ? { priority: patch.priority } : {}),
         ...(patch.monthlyAllocation !== undefined ? { monthly_allocation: patch.monthlyAllocation } : {}),
         ...(patch.type !== undefined ? { type: patch.type } : {}),
+        // Sprint 1.6 Fase 2C: current editable manual (fallback non-linked goals)
+        ...(patch.current !== undefined ? { current: patch.current } : {}),
       })
       .eq('id', goalId)
       .select('id, name, target, current, deadline, priority, monthly_allocation, status, type')

--- a/supabase/migrations/20260421221543_fase2a_accounts_liabilities_goal_link.sql
+++ b/supabase/migrations/20260421221543_fase2a_accounts_liabilities_goal_link.sql
@@ -1,0 +1,113 @@
+-- Sprint 1.6.5 Fase 2A — Account/Liability ↔ Goal linking (cardinality 1:N)
+--
+-- Abilita goal progress tracking via balance aggregation (Fase 3a successiva).
+-- Cardinality scelta (plan ultrathink 2026-04-21 Q4 approved):
+--   1 goal can have N accounts (savings distribuiti cross-banca)
+--   1 goal can have N liabilities (payoff multipli finanziamenti)
+--   1 account/liability has 0-1 goal (FK nullable)
+--
+-- Design decisions (ultrathink 2026-04-21):
+--   - FK NULL default: backward-compat zero breaking per dati esistenti
+--   - ON DELETE SET NULL: delete goal non distrugge account/liability, solo unlink
+--   - Partial index goal_id IS NOT NULL: performance query balance aggregation
+--   - RLS extension: goal_id ownership check consistency (prevent cross-user linking)
+--
+-- Scenarios abilitati:
+--   A) 1 savings dedicato → Fondo Emergenza
+--   E) CC → "Estingui debito CC" (liability_type CREDIT_CARD)
+--   F) Finanziamento → "Estingui debito auto" (liability_type LOAN)
+--   G) Transfer checking→savings tracked via linked savings account
+--   H) 1 goal Casa split su N accounts (savings + invest distribuiti)
+
+-- ============================================================================
+-- 1. Add accounts.goal_id + index
+-- ============================================================================
+ALTER TABLE accounts
+    ADD COLUMN goal_id UUID NULL REFERENCES goals(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_accounts_goal ON accounts(goal_id) WHERE goal_id IS NOT NULL;
+
+COMMENT ON COLUMN accounts.goal_id IS 'Optional link to goal for auto-progress tracking (Sprint 1.6 Fase 2). NULL = not linked (goal.current editable manual).';
+
+-- ============================================================================
+-- 2. Add liabilities.goal_id + index
+-- ============================================================================
+ALTER TABLE liabilities
+    ADD COLUMN goal_id UUID NULL REFERENCES goals(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_liabilities_goal ON liabilities(goal_id) WHERE goal_id IS NOT NULL;
+
+COMMENT ON COLUMN liabilities.goal_id IS 'Optional link to payoff goal. Goal.current = target - liability.current_balance formula (sign inversion per debt reduction semantics).';
+
+-- ============================================================================
+-- 3. RLS extension — accounts: goal_id ownership on INSERT/UPDATE
+-- ============================================================================
+-- Rationale: without check, authenticated user could link own account to another
+-- user's goal_id, creating cross-user data leak. Mirror of sprint 1.5
+-- goal_allocations RLS ownership fix.
+--
+-- Accounts dual ownership: personal (user_id) XOR family (family_id). goal_id is
+-- always personal (goals.user_id check). Member role gates write path.
+
+DROP POLICY IF EXISTS "Members can create accounts" ON accounts;
+DROP POLICY IF EXISTS "Members can update accessible accounts" ON accounts;
+
+CREATE POLICY "Members can create accounts"
+  ON accounts FOR INSERT
+  WITH CHECK (
+    (user_id = auth.uid() OR family_id = private.get_my_family_id())
+    AND private.get_my_role() IN ('ADMIN', 'MEMBER')
+    AND (
+      goal_id IS NULL
+      OR goal_id IN (SELECT id FROM goals WHERE user_id = auth.uid())
+    )
+  );
+
+CREATE POLICY "Members can update accessible accounts"
+  ON accounts FOR UPDATE
+  USING (
+    (user_id = auth.uid() OR family_id = private.get_my_family_id())
+    AND private.get_my_role() IN ('ADMIN', 'MEMBER')
+  )
+  WITH CHECK (
+    (user_id = auth.uid() OR family_id = private.get_my_family_id())
+    AND (
+      goal_id IS NULL
+      OR goal_id IN (SELECT id FROM goals WHERE user_id = auth.uid())
+    )
+  );
+
+-- ============================================================================
+-- 4. RLS extension — liabilities: goal_id ownership check
+-- ============================================================================
+-- Liabilities family-scoped. goal_id check via goals.user_id (personal goals
+-- linked to family liability è acceptable — user owns the goal + è member della
+-- family che possiede liability).
+
+DROP POLICY IF EXISTS "Members can create liabilities" ON liabilities;
+DROP POLICY IF EXISTS "Members can update family liabilities" ON liabilities;
+
+CREATE POLICY "Members can create liabilities"
+  ON liabilities FOR INSERT
+  WITH CHECK (
+    family_id = private.get_my_family_id()
+    AND private.get_my_role() IN ('ADMIN', 'MEMBER')
+    AND (
+      goal_id IS NULL
+      OR goal_id IN (SELECT id FROM goals WHERE user_id = auth.uid())
+    )
+  );
+
+CREATE POLICY "Members can update family liabilities"
+  ON liabilities FOR UPDATE
+  USING (
+    family_id = private.get_my_family_id()
+    AND private.get_my_role() IN ('ADMIN', 'MEMBER')
+  )
+  WITH CHECK (
+    family_id = private.get_my_family_id()
+    AND (
+      goal_id IS NULL
+      OR goal_id IN (SELECT id FROM goals WHERE user_id = auth.uid())
+    )
+  );


### PR DESCRIPTION
## Summary

Fase 2 architectural feature account↔goal linking (piano ultrathink 2026-04-21):

- **#038 Fase 2A migration**: \`accounts.goal_id\` + \`liabilities.goal_id\` FK nullable (cardinality 1:N). RLS extension policies con goal_id ownership check.
- **#040 Fase 2C GoalEditModal.current editable**: manual fallback per goals non linked. Validation clamp [0, target], progress % display.
- Service extension: \`accounts.client.ts\` + \`goals.client.ts\` support goalId/current patch.

## Out of scope (deferred)

- **#039 Fase 2B UI account/liability form dropdown "Collega a obiettivo"** → Wave successivo
- **Fase 3a auto-progress balance-driven** → Sprint 2.2 (dopo Fase 2B)
- **Fase 3b interest calculation + payoff advisor** → Sprint 2.3 differentiator

## Apply migration

Post-merge: `supabase db push` per applicare schema + RLS al DB remoto.

## Test plan

- [x] typecheck 9/9 green
- [x] vitest 1891 passed, 2 skipped, zero regression
- [ ] CI Development Pipeline green
- [ ] Post-merge: migration applied + types regenerated
- [ ] Manual QA: GoalEditModal current editable + progress % visible

## Manual QA scenarios consolidati

Vault: [manual-qa-wave-4c-4d-scenarios.md](~/vault/moneywise/planning/manual-qa-wave-4c-4d-scenarios.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)