### PR TITLE
fix(goals): hide target+deadline fields for openended goals (#059)

### DIFF
--- a/apps/web/__tests__/components/goals/GoalEditModal.test.tsx
+++ b/apps/web/__tests__/components/goals/GoalEditModal.test.tsx
@@ -18,6 +18,19 @@ const mockGoal: Goal = {
   priority: 1,
   monthlyAllocation: 300,
   status: 'ACTIVE',
+  type: 'fixed',
+};
+
+const mockOpenendedGoal: Goal = {
+  id: 'goal-43',
+  name: 'Iniziare a Investire',
+  target: null,
+  current: 0,
+  deadline: null,
+  priority: 2,
+  monthlyAllocation: 90,
+  status: 'ACTIVE',
+  type: 'openended',
 };
 
 describe('GoalEditModal', () => {
@@ -142,6 +155,49 @@ describe('GoalEditModal', () => {
 
     expect(screen.getByTestId('goal-modal-target-error')).toBeInTheDocument();
     expect(onSave).not.toHaveBeenCalled();
+  });
+
+  // #059 fix: openended goal editing hides target/deadline fields
+  it('hides target + deadline fields when goal.type is openended', () => {
+    render(
+      <GoalEditModal
+        open={true}
+        mode="edit"
+        goal={mockOpenendedGoal}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId('goal-modal-target')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('goal-modal-deadline')).not.toBeInTheDocument();
+    expect(screen.getByTestId('goal-modal-openended-info')).toBeInTheDocument();
+    expect(screen.getByTestId('goal-modal-openended-info')).toHaveTextContent(/Obiettivo aperto/);
+  });
+
+  it('saves openended goal without target validation error', async () => {
+    const user = userEvent.setup({ delay: null });
+    const onSave = vi.fn();
+    render(
+      <GoalEditModal
+        open={true}
+        mode="edit"
+        goal={mockOpenendedGoal}
+        onSave={onSave}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByTestId('goal-modal-save'));
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'openended',
+          target: null,
+          name: 'Iniziare a Investire',
+        }),
+      );
+    });
   });
 
   it('calls onCancel when cancel button clicked', async () => {

--- a/apps/web/src/components/goals/GoalEditModal.tsx
+++ b/apps/web/src/components/goals/GoalEditModal.tsx
@@ -31,6 +31,7 @@ const EMPTY_DRAFT: GoalInput = {
   deadline: null,
   priority: 2,
   monthlyAllocation: 0,
+  type: 'fixed',
 };
 
 function goalToInput(goal: Goal): GoalInput {
@@ -42,6 +43,8 @@ function goalToInput(goal: Goal): GoalInput {
     monthlyAllocation: goal.monthlyAllocation,
     // Sprint 1.6 Fase 2C: current editable manual (fallback non-linked goals)
     current: goal.current,
+    // #059: preserve goal type (fixed | openended) — openended hides target field
+    type: goal.type,
   };
 }
 
@@ -61,10 +64,15 @@ export function GoalEditModal({ open, mode, goal, onSave, onCancel }: GoalEditMo
     }
   }, [open, mode, goal]);
 
+  const isOpenended = draft.type === 'openended';
+
   const validate = (): boolean => {
     const next: typeof errors = {};
     if (!draft.name.trim()) next.name = 'Il nome è obbligatorio';
-    if (draft.target <= 0) next.target = 'Il target deve essere > 0';
+    // #059: openended goals hanno target=null intrinseco, skip validation target
+    if (!isOpenended && (draft.target === null || draft.target <= 0)) {
+      next.target = 'Il target deve essere > 0';
+    }
     setErrors(next);
     return Object.keys(next).length === 0;
   };
@@ -134,50 +142,61 @@ export function GoalEditModal({ open, mode, goal, onSave, onCancel }: GoalEditMo
               )}
             </div>
 
-            {/* Target + Deadline */}
-            <div className="grid grid-cols-2 gap-3">
-              <div>
-                <label
-                  htmlFor="goal-edit-target"
-                  className="text-sm font-medium text-foreground block mb-1"
-                >
-                  Target (€)
-                </label>
-                <input
-                  id="goal-edit-target"
-                  type="number"
-                  min={0}
-                  data-testid="goal-modal-target"
-                  value={draft.target || ''}
-                  onChange={(e) => setDraft({ ...draft, target: Number(e.target.value) })}
-                  className="w-full bg-muted/50 border border-border rounded-xl px-3 py-2 text-sm text-foreground"
-                  placeholder="5000"
-                />
-                {errors.target && (
-                  <p data-testid="goal-modal-target-error" className="text-xs text-red-500 mt-1">
-                    {errors.target}
-                  </p>
-                )}
+            {/* Target + Deadline — #059: hidden per goal openended (no target concept) */}
+            {isOpenended ? (
+              <div
+                data-testid="goal-modal-openended-info"
+                role="note"
+                className="rounded-xl border border-border bg-muted/30 px-3 py-2.5 text-sm text-muted-foreground"
+              >
+                <span className="font-medium text-foreground">Obiettivo aperto</span>
+                <span className="ml-1">— senza target fisso né scadenza. Accumula risparmi senza vincoli.</span>
               </div>
-              <div>
-                <label
-                  htmlFor="goal-edit-deadline"
-                  className="text-sm font-medium text-foreground block mb-1"
-                >
-                  Scadenza
-                </label>
-                <input
-                  id="goal-edit-deadline"
-                  type="date"
-                  data-testid="goal-modal-deadline"
-                  value={draft.deadline ?? ''}
-                  onChange={(e) =>
-                    setDraft({ ...draft, deadline: e.target.value || null })
-                  }
-                  className="w-full bg-muted/50 border border-border rounded-xl px-3 py-2 text-sm text-foreground"
-                />
+            ) : (
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label
+                    htmlFor="goal-edit-target"
+                    className="text-sm font-medium text-foreground block mb-1"
+                  >
+                    Target (€)
+                  </label>
+                  <input
+                    id="goal-edit-target"
+                    type="number"
+                    min={0}
+                    data-testid="goal-modal-target"
+                    value={draft.target || ''}
+                    onChange={(e) => setDraft({ ...draft, target: Number(e.target.value) })}
+                    className="w-full bg-muted/50 border border-border rounded-xl px-3 py-2 text-sm text-foreground"
+                    placeholder="5000"
+                  />
+                  {errors.target && (
+                    <p data-testid="goal-modal-target-error" className="text-xs text-red-500 mt-1">
+                      {errors.target}
+                    </p>
+                  )}
+                </div>
+                <div>
+                  <label
+                    htmlFor="goal-edit-deadline"
+                    className="text-sm font-medium text-foreground block mb-1"
+                  >
+                    Scadenza
+                  </label>
+                  <input
+                    id="goal-edit-deadline"
+                    type="date"
+                    data-testid="goal-modal-deadline"
+                    value={draft.deadline ?? ''}
+                    onChange={(e) =>
+                      setDraft({ ...draft, deadline: e.target.value || null })
+                    }
+                    className="w-full bg-muted/50 border border-border rounded-xl px-3 py-2 text-sm text-foreground"
+                  />
+                </div>
               </div>
-            </div>
+            )}
 
             {/* Sprint 1.6 Fase 2C: Current progress editable (manual fallback) */}
             <div>


### PR DESCRIPTION
## Summary

Manual QA 2026-04-22: goal type=openended (target=null) aperto in edit modal mostrava comunque il campo "Target" con validation \`>= 0\` — funzionalmente scorretto.

GoalCard già aveva check \`isOpenended\`; GoalEditModal non aveva la simmetria view↔edit.

## Changes

- \`EMPTY_DRAFT\` default \`type: 'fixed'\`
- \`goalToInput()\` preserva \`goal.type\`
- Conditionally render Target+Deadline grid (solo \`type=fixed\`)
- Openended: placeholder info "Obiettivo aperto — senza target fisso né scadenza"
- \`validate()\` skip check target per openended
- Current progress (Fase 2C) disponibile per entrambi type

## Testing

- \`pnpm typecheck\`: ✅ green
- \`GoalEditModal.test.tsx\`: ✅ 11/11 (+2 scenari: hides openended fields + saves openended senza validation)

## Test plan

- [ ] Manual: goal openended → apri edit → no target/deadline visibile, solo info "Obiettivo aperto"
- [ ] Manual: goal fixed → target/deadline normali + validation attiva
- [ ] Copilot review clean

Closes [[059]]

🤖 Generated with [Claude Code](https://claude.com/claude-code)