### PR TITLE
feat(goals): #058 archive/completed flow — auto-completion + UI

### DIFF
--- a/apps/web/app/dashboard/goals/page.tsx
+++ b/apps/web/app/dashboard/goals/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useEffect, useState, useCallback } from 'react';
-import { Plus, Target, Loader2 } from 'lucide-react';
+import { useEffect, useState, useCallback, useMemo } from 'react';
+import { Plus, Target, Loader2, Archive, ArchiveRestore, ChevronDown, ChevronUp } from 'lucide-react';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { useAuthStore } from '@/store/auth.store';
@@ -14,16 +14,22 @@ import type { GoalType } from '@/components/goals/GoalTypeFilter';
 import * as Dialog from '@radix-ui/react-dialog';
 
 // =============================================================================
-// GoalsPage
+// GoalsPage — #058 archive/completed flow
 // =============================================================================
 
 export default function GoalsPage() {
   const userId = useAuthStore((s) => s.user?.id);
 
-  // Goals data
+  // Goals data — ora include COMPLETED oltre a ACTIVE
   const [goals, setGoals] = useState<Goal[]>([]);
+  const [archivedGoals, setArchivedGoals] = useState<Goal[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingArchived, setIsLoadingArchived] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // #058 view toggles
+  const [showArchived, setShowArchived] = useState(false);
+  const [showCompletedSection, setShowCompletedSection] = useState(true);
 
   // Filter
   const [selectedType, setSelectedType] = useState<GoalType>('all');
@@ -38,6 +44,10 @@ export default function GoalsPage() {
   const [deletingGoalId, setDeletingGoalId] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
 
+  // #058 bulk archive confirm
+  const [bulkArchiveConfirmOpen, setBulkArchiveConfirmOpen] = useState(false);
+  const [isBulkArchiving, setIsBulkArchiving] = useState(false);
+
   // ---------------------------------------------------------------------------
   // Load
   // ---------------------------------------------------------------------------
@@ -50,7 +60,8 @@ export default function GoalsPage() {
     setIsLoading(true);
     setError(null);
     try {
-      const data = await goalsClient.loadGoals(userId);
+      // #058: fetch ACTIVE + COMPLETED together per view unificata
+      const data = await goalsClient.loadGoals(userId, { statuses: ['ACTIVE', 'COMPLETED'] });
       setGoals(data);
     } catch (err) {
       setError(
@@ -63,18 +74,41 @@ export default function GoalsPage() {
     }
   }, [userId]);
 
+  const loadArchived = useCallback(async () => {
+    if (!userId) return;
+    setIsLoadingArchived(true);
+    try {
+      const data = await goalsClient.loadGoals(userId, { statuses: ['ARCHIVED'] });
+      setArchivedGoals(data);
+    } catch (err) {
+      console.error('Failed to load archived goals:', err);
+    } finally {
+      setIsLoadingArchived(false);
+    }
+  }, [userId]);
+
   useEffect(() => {
     loadGoals();
   }, [loadGoals]);
 
+  // Lazy-load archived quando user attiva toggle
+  useEffect(() => {
+    if (showArchived) {
+      loadArchived();
+    }
+  }, [showArchived, loadArchived]);
+
   // ---------------------------------------------------------------------------
-  // Filtered goals
+  // Split goals by status
   // ---------------------------------------------------------------------------
 
-  const filteredGoals =
+  const activeGoals = useMemo(() => goals.filter((g) => g.status === 'ACTIVE'), [goals]);
+  const completedGoals = useMemo(() => goals.filter((g) => g.status === 'COMPLETED'), [goals]);
+
+  const filteredActiveGoals =
     selectedType === 'all'
-      ? goals
-      : goals.filter((g) => inferGoalType(g.name) === selectedType);
+      ? activeGoals
+      : activeGoals.filter((g) => inferGoalType(g.name) === selectedType);
 
   // ---------------------------------------------------------------------------
   // Handlers
@@ -128,6 +162,7 @@ export default function GoalsPage() {
     try {
       await goalsClient.deleteGoal(deletingGoalId);
       setGoals((prev) => prev.filter((g) => g.id !== deletingGoalId));
+      setArchivedGoals((prev) => prev.filter((g) => g.id !== deletingGoalId));
     } catch (err) {
       setError(
         err instanceof GoalsApiError || err instanceof Error
@@ -141,7 +176,64 @@ export default function GoalsPage() {
     }
   };
 
-  const deletingGoalName = goals.find((g) => g.id === deletingGoalId)?.name ?? 'questo obiettivo';
+  // #058 archive single goal
+  const handleArchiveClick = async (goalId: string) => {
+    try {
+      await goalsClient.archiveGoal(goalId);
+      // Move goal da active/completed list → archived (se visible)
+      const archivedGoal = goals.find((g) => g.id === goalId);
+      setGoals((prev) => prev.filter((g) => g.id !== goalId));
+      if (showArchived && archivedGoal) {
+        setArchivedGoals((prev) => [{ ...archivedGoal, status: 'ARCHIVED' }, ...prev]);
+      }
+    } catch (err) {
+      setError(
+        err instanceof GoalsApiError || err instanceof Error
+          ? err.message
+          : 'Errore durante l\'archiviazione',
+      );
+    }
+  };
+
+  // #058 reactivate archived goal
+  const handleReactivateClick = async (goalId: string) => {
+    try {
+      await goalsClient.reactivateGoal(goalId);
+      const reactivatedGoal = archivedGoals.find((g) => g.id === goalId);
+      setArchivedGoals((prev) => prev.filter((g) => g.id !== goalId));
+      if (reactivatedGoal) {
+        setGoals((prev) => [...prev, { ...reactivatedGoal, status: 'ACTIVE' }]);
+      }
+    } catch (err) {
+      setError(
+        err instanceof GoalsApiError || err instanceof Error
+          ? err.message
+          : 'Errore durante la riattivazione',
+      );
+    }
+  };
+
+  // #058 bulk archive all completed
+  const handleBulkArchive = async () => {
+    if (!userId) return;
+    setIsBulkArchiving(true);
+    try {
+      await goalsClient.archiveAllCompleted(userId);
+      // Remove completed goals from state
+      setGoals((prev) => prev.filter((g) => g.status !== 'COMPLETED'));
+    } catch (err) {
+      setError(
+        err instanceof GoalsApiError || err instanceof Error
+          ? err.message
+          : 'Errore durante l\'archiviazione bulk',
+      );
+    } finally {
+      setIsBulkArchiving(false);
+      setBulkArchiveConfirmOpen(false);
+    }
+  };
+
+  const deletingGoalName = [...goals, ...archivedGoals].find((g) => g.id === deletingGoalId)?.name ?? 'questo obiettivo';
 
   // ---------------------------------------------------------------------------
   // Render states
@@ -157,7 +249,7 @@ export default function GoalsPage() {
     );
   }
 
-  if (error) {
+  if (error && goals.length === 0) {
     return (
       <div className="p-6 max-w-7xl mx-auto" data-testid="goals-error">
         <Card className="p-6 border-l-4 border-l-red-500">
@@ -184,15 +276,39 @@ export default function GoalsPage() {
         <div>
           <h1 className="text-3xl font-bold text-foreground">Obiettivi</h1>
           <p className="text-muted-foreground mt-1">
-            {goals.length > 0
-              ? `${goals.length} obiettiv${goals.length === 1 ? 'o attivo' : 'i attivi'}`
+            {activeGoals.length > 0
+              ? `${activeGoals.length} obiettiv${activeGoals.length === 1 ? 'o attivo' : 'i attivi'}${
+                  completedGoals.length > 0
+                    ? ` · ${completedGoals.length} completat${completedGoals.length === 1 ? 'o' : 'i'}`
+                    : ''
+                }`
               : 'Crea il tuo primo obiettivo finanziario'}
           </p>
         </div>
+        {/* #058 archived toggle */}
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setShowArchived((v) => !v)}
+          data-testid="goals-archived-toggle"
+        >
+          <Archive className="w-4 h-4 mr-2" />
+          {showArchived ? 'Nascondi archiviati' : 'Mostra archiviati'}
+        </Button>
       </div>
 
-      {/* Filter chips */}
-      {goals.length > 0 && (
+      {/* Error banner (non-blocking) */}
+      {error && goals.length > 0 && (
+        <Card className="p-4 border-l-4 border-l-red-500">
+          <p className="text-sm text-foreground">{error}</p>
+          <Button variant="outline" size="sm" className="mt-2" onClick={() => setError(null)}>
+            Chiudi
+          </Button>
+        </Card>
+      )}
+
+      {/* Filter chips (solo goal attivi) */}
+      {activeGoals.length > 0 && (
         <GoalTypeFilter selected={selectedType} onTypeSelect={setSelectedType} />
       )}
 
@@ -221,8 +337,8 @@ export default function GoalsPage() {
         </Card>
       ) : (
         <>
-          {/* Filtered empty */}
-          {filteredGoals.length === 0 && (
+          {/* Active goals grid */}
+          {filteredActiveGoals.length === 0 && activeGoals.length > 0 && (
             <p
               data-testid="goals-filter-empty"
               className="text-sm text-muted-foreground py-6 text-center"
@@ -231,20 +347,114 @@ export default function GoalsPage() {
             </p>
           )}
 
-          {/* Goals grid */}
-          <div
-            className="grid grid-cols-1 md:grid-cols-2 gap-4"
-            data-testid="goals-grid"
-          >
-            {filteredGoals.map((goal) => (
-              <GoalCard
-                key={goal.id}
-                goal={goal}
-                onEditClick={handleEditClick}
-                onDeleteClick={handleDeleteClick}
-              />
-            ))}
-          </div>
+          {activeGoals.length > 0 && (
+            <div
+              className="grid grid-cols-1 md:grid-cols-2 gap-4"
+              data-testid="goals-grid"
+            >
+              {filteredActiveGoals.map((goal) => (
+                <GoalCard
+                  key={goal.id}
+                  goal={goal}
+                  onEditClick={handleEditClick}
+                  onDeleteClick={handleDeleteClick}
+                />
+              ))}
+            </div>
+          )}
+
+          {/* #058: Completed section (collapsible) */}
+          {completedGoals.length > 0 && (
+            <section className="space-y-3 pt-4 border-t border-border" data-testid="goals-completed-section">
+              <div className="flex items-center justify-between">
+                <button
+                  type="button"
+                  onClick={() => setShowCompletedSection((v) => !v)}
+                  className="flex items-center gap-2 text-sm font-semibold text-foreground hover:text-muted-foreground transition-colors"
+                  data-testid="goals-completed-toggle"
+                >
+                  {showCompletedSection ? (
+                    <ChevronUp className="w-4 h-4" />
+                  ) : (
+                    <ChevronDown className="w-4 h-4" />
+                  )}
+                  Obiettivi completati ({completedGoals.length})
+                </button>
+                {showCompletedSection && completedGoals.length > 0 && (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => setBulkArchiveConfirmOpen(true)}
+                    data-testid="goals-bulk-archive-btn"
+                  >
+                    <Archive className="w-4 h-4 mr-2" />
+                    Archivia tutti
+                  </Button>
+                )}
+              </div>
+
+              {showCompletedSection && (
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4" data-testid="goals-completed-grid">
+                  {completedGoals.map((goal) => (
+                    <GoalCard
+                      key={goal.id}
+                      goal={goal}
+                      onEditClick={handleEditClick}
+                      onDeleteClick={handleDeleteClick}
+                      onArchiveClick={handleArchiveClick}
+                    />
+                  ))}
+                </div>
+              )}
+            </section>
+          )}
+
+          {/* #058: Archived section (toggle-gated) */}
+          {showArchived && (
+            <section className="space-y-3 pt-4 border-t border-border" data-testid="goals-archived-section">
+              <h2 className="text-sm font-semibold text-foreground flex items-center gap-2">
+                <Archive className="w-4 h-4" />
+                Obiettivi archiviati ({archivedGoals.length})
+              </h2>
+              {isLoadingArchived ? (
+                <div className="flex items-center justify-center py-8">
+                  <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+                </div>
+              ) : archivedGoals.length === 0 ? (
+                <p className="text-sm text-muted-foreground py-6 text-center">
+                  Nessun obiettivo archiviato.
+                </p>
+              ) : (
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4" data-testid="goals-archived-grid">
+                  {archivedGoals.map((goal) => (
+                    <Card
+                      key={goal.id}
+                      className="p-5 opacity-70 hover:opacity-100 transition-opacity"
+                      data-testid={`archived-goal-card-${goal.id}`}
+                    >
+                      <div className="flex items-start justify-between mb-2">
+                        <h3 className="font-semibold text-foreground truncate">{goal.name}</h3>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => handleReactivateClick(goal.id)}
+                          data-testid={`goal-reactivate-${goal.id}`}
+                        >
+                          <ArchiveRestore className="w-4 h-4 mr-1.5" />
+                          Riattiva
+                        </Button>
+                      </div>
+                      <p className="text-xs text-muted-foreground">
+                        {goal.target !== null && goal.target > 0
+                          ? `€${goal.current.toLocaleString('it-IT')} / €${goal.target.toLocaleString('it-IT')}`
+                          : 'Obiettivo aperto'}
+                      </p>
+                    </Card>
+                  ))}
+                </div>
+              )}
+            </section>
+          )}
         </>
       )}
 
@@ -305,6 +515,43 @@ export default function GoalsPage() {
                   <Loader2 className="w-4 h-4 animate-spin mr-2" />
                 ) : null}
                 Elimina
+              </Button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+
+      {/* #058 Bulk Archive Confirm Dialog */}
+      <Dialog.Root open={bulkArchiveConfirmOpen} onOpenChange={setBulkArchiveConfirmOpen}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+          <Dialog.Content
+            data-testid="bulk-archive-confirm-dialog"
+            className="fixed left-1/2 top-1/2 z-50 w-full max-w-sm -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-border bg-background p-6 shadow-xl focus:outline-none data-[state=open]:animate-in data-[state=closed]:animate-out"
+            aria-describedby={undefined}
+          >
+            <Dialog.Title className="text-base font-semibold text-foreground mb-2">
+              Archivia tutti i completati
+            </Dialog.Title>
+            <p className="text-sm text-muted-foreground mb-5">
+              Archivia {completedGoals.length} obiettiv{completedGoals.length === 1 ? 'o' : 'i'} completat{completedGoals.length === 1 ? 'o' : 'i'}. Potrai sempre riattivarl{completedGoals.length === 1 ? 'o' : 'i'} dalla vista Archiviati.
+            </p>
+            <div className="flex justify-end gap-2">
+              <Dialog.Close asChild>
+                <Button variant="outline" disabled={isBulkArchiving}>
+                  Annulla
+                </Button>
+              </Dialog.Close>
+              <Button
+                onClick={handleBulkArchive}
+                data-testid="bulk-archive-confirm-ok"
+                className="bg-blue-600 hover:bg-blue-700 text-white"
+                disabled={isBulkArchiving}
+              >
+                {isBulkArchiving ? (
+                  <Loader2 className="w-4 h-4 animate-spin mr-2" />
+                ) : null}
+                Archivia tutti
               </Button>
             </div>
           </Dialog.Content>

--- a/apps/web/src/components/goals/GoalCard.tsx
+++ b/apps/web/src/components/goals/GoalCard.tsx
@@ -9,6 +9,8 @@ import {
   Trash2,
   Calendar,
   Infinity as InfinityIcon,
+  Check,
+  Archive,
 } from 'lucide-react';
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -78,9 +80,11 @@ interface GoalCardProps {
   goal: Goal;
   onEditClick: (goal: Goal) => void;
   onDeleteClick: (goalId: string) => void;
+  /** #058: optional archive handler, rendered as secondary action per goal COMPLETED */
+  onArchiveClick?: (goalId: string) => void;
 }
 
-export function GoalCard({ goal, onEditClick, onDeleteClick }: GoalCardProps) {
+export function GoalCard({ goal, onEditClick, onDeleteClick, onArchiveClick }: GoalCardProps) {
   // WP-K: use goal.type (DB field) for openended-specific display logic.
   // Use inferGoalCategory for icon/color (name heuristic — independent of type).
   const isOpenended = goal.type === 'openended';
@@ -142,22 +146,61 @@ export function GoalCard({ goal, onEditClick, onDeleteClick }: GoalCardProps) {
                   Aperto
                 </Badge>
               )}
+              {/* #058: COMPLETED status badge */}
+              {goal.status === 'COMPLETED' && (
+                <Badge
+                  className="text-xs gap-1 bg-emerald-500/10 border border-emerald-500/20 text-emerald-700 dark:text-emerald-400 hover:bg-emerald-500/10"
+                  data-testid="goal-card-completed-badge"
+                >
+                  <Check className="w-3 h-3" />
+                  Completato
+                </Badge>
+              )}
+              {/* #058: ARCHIVED status badge */}
+              {goal.status === 'ARCHIVED' && (
+                <Badge
+                  variant="outline"
+                  className="text-xs gap-1 text-muted-foreground"
+                  data-testid="goal-card-archived-badge"
+                >
+                  <Archive className="w-3 h-3" />
+                  Archiviato
+                </Badge>
+              )}
             </div>
           </div>
         </div>
 
-        <button
-          type="button"
-          data-testid={`goal-delete-${goal.id}`}
-          onClick={(e) => {
-            e.stopPropagation();
-            onDeleteClick(goal.id);
-          }}
-          className="shrink-0 p-1.5 rounded-lg hover:bg-red-50 dark:hover:bg-red-950/30 transition-colors ml-2"
-          aria-label={`Elimina ${goal.name}`}
-        >
-          <Trash2 className="w-4 h-4 text-muted-foreground hover:text-red-500 transition-colors" />
-        </button>
+        <div className="flex items-center gap-1 shrink-0 ml-2">
+          {/* #058: archive button (rendered only if handler passed + goal non-ARCHIVED) */}
+          {onArchiveClick && goal.status !== 'ARCHIVED' && (
+            <button
+              type="button"
+              data-testid={`goal-archive-${goal.id}`}
+              onClick={(e) => {
+                e.stopPropagation();
+                onArchiveClick(goal.id);
+              }}
+              className="p-1.5 rounded-lg hover:bg-muted transition-colors"
+              aria-label={`Archivia ${goal.name}`}
+              title="Archivia"
+            >
+              <Archive className="w-4 h-4 text-muted-foreground hover:text-foreground transition-colors" />
+            </button>
+          )}
+          <button
+            type="button"
+            data-testid={`goal-delete-${goal.id}`}
+            onClick={(e) => {
+              e.stopPropagation();
+              onDeleteClick(goal.id);
+            }}
+            className="p-1.5 rounded-lg hover:bg-red-50 dark:hover:bg-red-950/30 transition-colors"
+            aria-label={`Elimina ${goal.name}`}
+          >
+            <Trash2 className="w-4 h-4 text-muted-foreground hover:text-red-500 transition-colors" />
+          </button>
+        </div>
       </div>
 
       {/* Target/progress: hidden for openended goals (no concrete target) */}

--- a/apps/web/src/services/goals.client.ts
+++ b/apps/web/src/services/goals.client.ts
@@ -7,7 +7,7 @@
  */
 
 import { createClient } from '@/utils/supabase/client';
-import type { PriorityRank, GoalType } from '@/types/onboarding-plan';
+import type { PriorityRank, GoalType, GoalStatus } from '@/types/onboarding-plan';
 
 // =============================================================================
 // Types
@@ -59,17 +59,26 @@ export class GoalsApiError extends Error {
 
 export const goalsClient = {
   /**
-   * Load all ACTIVE goals for a user.
+   * Load goals for a user, filtered by status.
+   *
+   * Default filter = ['ACTIVE'] per backward-compat con caller legacy.
+   * Per #058 archive/completed flow: pass ['ACTIVE','COMPLETED'] per mostrare
+   * entrambi nella dashboard principale, o ['ARCHIVED'] per view archivio.
    */
-  async loadGoals(userId: string): Promise<Goal[]> {
+  async loadGoals(
+    userId: string,
+    opts?: { statuses?: GoalStatus[] },
+  ): Promise<Goal[]> {
     if (!userId) throw new GoalsApiError('userId is required', 400);
+
+    const statuses = opts?.statuses ?? ['ACTIVE'];
 
     const supabase = createClient();
     const { data, error } = await supabase
       .from('goals')
       .select('id, name, target, current, deadline, priority, monthly_allocation, status, type')
       .eq('user_id', userId)
-      .eq('status', 'ACTIVE')
+      .in('status', statuses)
       .order('priority', { ascending: true });
 
     if (error) throw new GoalsApiError(error.message, 500, error);
@@ -130,24 +139,53 @@ export const goalsClient = {
 
   /**
    * Update fields on an existing goal.
+   *
+   * #058: auto-completion detection — se patch causes `current >= target` e
+   * status era ACTIVE e target non-null → mark COMPLETED. Trigger lato client
+   * (no DB trigger richiesto). L'utente può poi archiviare manualmente.
    */
   async updateGoal(goalId: string, patch: Partial<GoalInput>): Promise<Goal> {
     if (!goalId) throw new GoalsApiError('goalId is required', 400);
 
     const supabase = createClient();
 
-    const { data, error } = await supabase
+    // Fetch current state per evaluate auto-completion
+    const { data: existing, error: fetchErr } = await supabase
       .from('goals')
-      .update({
-        ...(patch.name !== undefined ? { name: patch.name.trim() } : {}),
-        ...(patch.target !== undefined ? { target: patch.target } : {}),
-        ...(patch.deadline !== undefined ? { deadline: patch.deadline } : {}),
-        ...(patch.priority !== undefined ? { priority: patch.priority } : {}),
-        ...(patch.monthlyAllocation !== undefined ? { monthly_allocation: patch.monthlyAllocation } : {}),
-        ...(patch.type !== undefined ? { type: patch.type } : {}),
-        // Sprint 1.6 Fase 2C: current editable manual (fallback non-linked goals)
-        ...(patch.current !== undefined ? { current: patch.current } : {}),
-      })
+      .select('status, target, current')
+      .eq('id', goalId)
+      .single();
+
+    if (fetchErr || !existing) throw new GoalsApiError(fetchErr?.message ?? 'Goal not found', 404, fetchErr);
+
+    const updatePayload: Record<string, unknown> = {
+      ...(patch.name !== undefined ? { name: patch.name.trim() } : {}),
+      ...(patch.target !== undefined ? { target: patch.target } : {}),
+      ...(patch.deadline !== undefined ? { deadline: patch.deadline } : {}),
+      ...(patch.priority !== undefined ? { priority: patch.priority } : {}),
+      ...(patch.monthlyAllocation !== undefined ? { monthly_allocation: patch.monthlyAllocation } : {}),
+      ...(patch.type !== undefined ? { type: patch.type } : {}),
+      // Sprint 1.6 Fase 2C: current editable manual
+      ...(patch.current !== undefined ? { current: patch.current } : {}),
+    };
+
+    // #058: auto-completion — trigger solo se ACTIVE + target fixed + nuovo current >= target
+    const newCurrent = patch.current ?? (existing.current as number);
+    const newTarget = patch.target !== undefined ? patch.target : existing.target;
+    if (
+      existing.status === 'ACTIVE' &&
+      newTarget !== null &&
+      (newTarget as number) > 0 &&
+      newCurrent >= (newTarget as number)
+    ) {
+      updatePayload.status = 'COMPLETED';
+    }
+
+    // Type-safe update with explicit cast (mirror pattern accounts.client.ts)
+    const { data, error } = await (supabase
+      .from('goals')
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .update as any)(updatePayload)
       .eq('id', goalId)
       .select('id, name, target, current, deadline, priority, monthly_allocation, status, type')
       .single();
@@ -169,6 +207,7 @@ export const goalsClient = {
 
   /**
    * Soft-delete: set status to ARCHIVED.
+   * #058: kept as primary "delete" — semantically equivalent to archive.
    */
   async deleteGoal(goalId: string): Promise<void> {
     if (!goalId) throw new GoalsApiError('goalId is required', 400);
@@ -180,5 +219,56 @@ export const goalsClient = {
       .eq('id', goalId);
 
     if (error) throw new GoalsApiError(error.message, 500, error);
+  },
+
+  /**
+   * #058: Archive a goal (typically used per goal COMPLETED → ARCHIVED
+   * transition, o user click "Archivia").
+   */
+  async archiveGoal(goalId: string): Promise<void> {
+    if (!goalId) throw new GoalsApiError('goalId is required', 400);
+
+    const supabase = createClient();
+    const { error } = await supabase
+      .from('goals')
+      .update({ status: 'ARCHIVED' as const })
+      .eq('id', goalId);
+
+    if (error) throw new GoalsApiError(error.message, 500, error);
+  },
+
+  /**
+   * #058: Reactivate an archived goal → ACTIVE.
+   */
+  async reactivateGoal(goalId: string): Promise<void> {
+    if (!goalId) throw new GoalsApiError('goalId is required', 400);
+
+    const supabase = createClient();
+    const { error } = await supabase
+      .from('goals')
+      .update({ status: 'ACTIVE' as const })
+      .eq('id', goalId);
+
+    if (error) throw new GoalsApiError(error.message, 500, error);
+  },
+
+  /**
+   * #058: Archive all COMPLETED goals for a user in bulk.
+   * Returns count archived.
+   */
+  async archiveAllCompleted(userId: string): Promise<number> {
+    if (!userId) throw new GoalsApiError('userId is required', 400);
+
+    const supabase = createClient();
+    const { data, error } = await supabase
+      .from('goals')
+      .update({ status: 'ARCHIVED' as const })
+      .eq('user_id', userId)
+      .eq('status', 'COMPLETED')
+      .select('id');
+
+    if (error) throw new GoalsApiError(error.message, 500, error);
+
+    return (data ?? []).length;
   },
 };


### PR DESCRIPTION
## Summary

Closes [[058]]. Manual QA 4D-5 rileva flow archive mancante: DB schema supporta \`goal_status: ACTIVE|COMPLETED|ARCHIVED\` ma UI wired solo per ACTIVE.

## Changes

### Service (goals.client.ts)
- \`loadGoals(userId, opts?: { statuses? })\` — filter estensibile
- \`updateGoal\` — auto-completion: \`current >= target\` + ACTIVE + target non-null → status COMPLETED automatic
- \`archiveGoal\` / \`reactivateGoal\` / \`archiveAllCompleted(userId)\` — new methods

### UI GoalCard
- Prop opzionale \`onArchiveClick\`
- Badge "✓ Completato" e "📦 Archiviato"

### UI /dashboard/goals
- Load unified ACTIVE + COMPLETED
- Sezione collapsible "Obiettivi completati (N)" + bulk "Archivia tutti"
- Toggle "Mostra archiviati" + lazy load + "Riattiva" button per goal ARCHIVED
- Confirm dialog bulk archive con pluralization italiana

## Testing

- \`pnpm typecheck\`: ✅ green
- \`pnpm test\` goals + dashboard: ✅ 93/93 (zero regression)

## Scope NON incluso

- Step 5 wizard onboarding bulk archive (scope Sprint 1.7)
- Auto-archive dopo N giorni (feature opt-in futuro)

## Test plan

- [ ] Manual QA: edit goal current>=target → auto-badge Completato
- [ ] Manual QA: archive completed → toggle archiviati mostra goal
- [ ] Manual QA: bulk archive multipli con conferma
- [ ] Manual QA: reactivate da archiviati → torna in attivi

🤖 Generated with [Claude Code](https://claude.com/claude-code)