### PR TITLE
fix(transactions): #044 hide stub action buttons in account detail view

### DIFF
--- a/apps/web/__tests__/components/transactions/TransactionRow.test.tsx
+++ b/apps/web/__tests__/components/transactions/TransactionRow.test.tsx
@@ -87,6 +87,7 @@ describe('TransactionRow', () => {
       isSelectable: boolean;
       isUpdating: boolean;
       isDeleting: boolean;
+      showActions: boolean;
       categoryName?: string;
       categoryIcon?: string;
       accountName?: string;
@@ -102,6 +103,7 @@ describe('TransactionRow', () => {
         isSelectable={props.isSelectable ?? true}
         isUpdating={props.isUpdating ?? false}
         isDeleting={props.isDeleting ?? false}
+        showActions={props.showActions ?? true}
         categoryName={props.categoryName}
         categoryIcon={props.categoryIcon}
         accountName={props.accountName}
@@ -248,6 +250,17 @@ describe('TransactionRow', () => {
     it('should disable delete button while deleting', () => {
       renderRow(mockTransaction, { isDeleting: true });
       expect(screen.getByRole('button', { name: /elimina transazione/i })).toBeDisabled();
+    });
+
+    // #044: read-only mode — hide action buttons entirely
+    it('should NOT render edit + delete buttons when showActions=false', () => {
+      renderRow(mockTransaction, { showActions: false });
+      expect(
+        screen.queryByRole('button', { name: /modifica transazione/i })
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /elimina transazione/i })
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/apps/web/app/dashboard/accounts/[id]/page.tsx
+++ b/apps/web/app/dashboard/accounts/[id]/page.tsx
@@ -398,7 +398,11 @@ export default function AccountDetailsPage() {
                   key={tx.id}
                   transaction={tx}
                   isSelectable={false}
+                  showActions={false}
                   categoryName={tx.categoryId ? categoryMap.get(tx.categoryId) : undefined}
+                  // #044: stub handlers richiesti da TransactionRow signature ma bottoni
+                  // nascosti via showActions=false. View read-only in account detail —
+                  // per Modifica/Elimina naviga a /dashboard/transactions.
                   onSelect={() => {}}
                   onEdit={() => {}}
                   onDelete={() => {}}

--- a/apps/web/src/components/transactions/TransactionRow.tsx
+++ b/apps/web/src/components/transactions/TransactionRow.tsx
@@ -20,6 +20,12 @@ export interface TransactionRowProps {
   categoryName?: string;
   categoryIcon?: string;
   accountName?: string;
+  /**
+   * #044: controlla visibilità bottoni Modifica/Elimina inline.
+   * Default true (backward-compat). Pass false in contesti read-only (es.
+   * account detail view) dove non vogliamo azioni per-row.
+   */
+  showActions?: boolean;
 }
 
 // =============================================================================
@@ -62,6 +68,7 @@ export const TransactionRow = memo(function TransactionRow({
   isSelectable = true,
   isUpdating = false,
   isDeleting = false,
+  showActions = true,
   categoryName,
   categoryIcon,
   accountName,
@@ -177,26 +184,29 @@ export const TransactionRow = memo(function TransactionRow({
       </div>
 
       {/* Actions — always visible on small screens, visible on hover/focus on larger screens */}
-      <div className="flex-shrink-0 flex items-center gap-0.5 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100 transition-opacity">
-        <button
-          type="button"
-          onClick={handleEdit}
-          disabled={isUpdating || isDeleting}
-          aria-label="Modifica transazione"
-          className="p-1.5 rounded-lg text-muted-foreground/40 hover:text-foreground hover:bg-muted/50 focus-visible:text-foreground focus-visible:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50 transition-colors"
-        >
-          {isUpdating ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Pencil className="w-3.5 h-3.5" />}
-        </button>
-        <button
-          type="button"
-          onClick={handleDelete}
-          disabled={isUpdating || isDeleting}
-          aria-label="Elimina transazione"
-          className="p-1.5 rounded-lg text-muted-foreground/40 hover:text-rose-600 hover:bg-rose-500/10 focus-visible:text-rose-600 focus-visible:bg-rose-500/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50 transition-colors"
-        >
-          {isDeleting ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Trash2 className="w-3.5 h-3.5" />}
-        </button>
-      </div>
+      {/* #044: `showActions=false` nasconde bottoni in contesti read-only (evita stub no-op handlers) */}
+      {showActions && (
+        <div className="flex-shrink-0 flex items-center gap-0.5 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100 transition-opacity">
+          <button
+            type="button"
+            onClick={handleEdit}
+            disabled={isUpdating || isDeleting}
+            aria-label="Modifica transazione"
+            className="p-1.5 rounded-lg text-muted-foreground/40 hover:text-foreground hover:bg-muted/50 focus-visible:text-foreground focus-visible:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50 transition-colors"
+          >
+            {isUpdating ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Pencil className="w-3.5 h-3.5" />}
+          </button>
+          <button
+            type="button"
+            onClick={handleDelete}
+            disabled={isUpdating || isDeleting}
+            aria-label="Elimina transazione"
+            className="p-1.5 rounded-lg text-muted-foreground/40 hover:text-rose-600 hover:bg-rose-500/10 focus-visible:text-rose-600 focus-visible:bg-rose-500/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50 transition-colors"
+          >
+            {isDeleting ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Trash2 className="w-3.5 h-3.5" />}
+          </button>
+        </div>
+      )}
     </article>
   );
 });


### PR DESCRIPTION
## Summary

Closes [[044]]. Manual QA scan identifica \`accounts/[id]/page.tsx:402-404\` con handler no-op \`onEdit/onDelete={() => {}}\`. Buttons Modifica/Elimina visibili ma click produce nothing.

## Changes

### \`TransactionRow.tsx\`
- New prop \`showActions?: boolean\` (default true — backward-compat)
- Wrap action buttons in conditional render

### \`accounts/[id]/page.tsx\`
- Pass \`showActions={false}\` → buttons hidden
- Inline doc comment per futuro reader

### Test
- renderRow helper extend
- +1 test: \`should NOT render edit + delete buttons when showActions=false\`

## Testing

- \`pnpm typecheck\`: ✅ green
- TransactionRow test: ✅ 25/25 (was 24/24, +1 new scenario)

## Rationale (Opzione A vs B)

Chosen: **A) hide buttons** (scelta conservativa, read-only context).

Alternative: B) wire a full handlers (router.push edit + deleteTransaction)
rigettata per scope — l'account detail è designed read-only, pattern coerente
con resto pagina (azioni via menu top, non inline).

## Test plan

- [ ] Manual QA: \`/dashboard/accounts/[id]\` non mostra Modifica/Elimina inline
- [ ] Manual QA: \`/dashboard/transactions\` ancora mostra + azioni funzionano
- [ ] Copilot review clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)