### PR TITLE
feat(goals): Sprint 1.6.6 Bundle B — #043 Fase 3a balance-driven progress sync

### DIFF
--- a/apps/web/src/components/goals/GoalCard.tsx
+++ b/apps/web/src/components/goals/GoalCard.tsx
@@ -98,7 +98,12 @@ export function GoalCard({ goal, onEditClick, onDeleteClick, onArchiveClick }: G
   // - linked liabilities) per progress display. Fallback `current` se VIEW non
   // disponibile (dati legacy pre-Fase-3a).
   const displayCurrent = goal.currentEffective ?? goal.current;
-  const pct = effectiveTarget > 0 ? Math.min(100, (displayCurrent / effectiveTarget) * 100) : 0;
+  // Copilot review #536 fix: clamp [0,100]. Debt goal con liability linked
+  // (current - SUM(liabilities)) può produrre displayCurrent negativo → pct
+  // negativo creava mismatch UI (Progress bar clampa a 0, label mostrava -X%).
+  const pct = effectiveTarget > 0
+    ? Math.max(0, Math.min(100, (displayCurrent / effectiveTarget) * 100))
+    : 0;
   const remaining = Math.max(0, effectiveTarget - displayCurrent);
 
   let daysLeft: number | null = null;

--- a/apps/web/src/components/goals/GoalCard.tsx
+++ b/apps/web/src/components/goals/GoalCard.tsx
@@ -94,8 +94,12 @@ export function GoalCard({ goal, onEditClick, onDeleteClick, onArchiveClick }: G
   const priorityColor = PRIORITY_COLOR[goal.priority];
 
   const effectiveTarget = goal.target ?? 0;
-  const pct = effectiveTarget > 0 ? Math.min(100, (goal.current / effectiveTarget) * 100) : 0;
-  const remaining = Math.max(0, effectiveTarget - goal.current);
+  // Sprint 1.6.6 Fase 3a (#043): usa currentEffective (manual + linked accounts
+  // - linked liabilities) per progress display. Fallback `current` se VIEW non
+  // disponibile (dati legacy pre-Fase-3a).
+  const displayCurrent = goal.currentEffective ?? goal.current;
+  const pct = effectiveTarget > 0 ? Math.min(100, (displayCurrent / effectiveTarget) * 100) : 0;
+  const remaining = Math.max(0, effectiveTarget - displayCurrent);
 
   let daysLeft: number | null = null;
   if (goal.deadline) {
@@ -207,8 +211,16 @@ export function GoalCard({ goal, onEditClick, onDeleteClick, onArchiveClick }: G
       {!isOpenended && (
         <div className="mb-3">
           <div className="flex justify-between text-sm mb-1.5">
-            <span className="text-muted-foreground">
-              &euro;{goal.current.toLocaleString('it-IT')}
+            <span
+              className="text-muted-foreground"
+              data-testid="goal-card-current"
+              title={
+                goal.currentEffective !== undefined && goal.currentEffective !== goal.current
+                  ? `Manuale: €${goal.current.toLocaleString('it-IT')} · Effective (+ balance linked): €${goal.currentEffective.toLocaleString('it-IT')}`
+                  : undefined
+              }
+            >
+              &euro;{displayCurrent.toLocaleString('it-IT')}
             </span>
             <span
               data-testid="goal-card-target"
@@ -227,8 +239,8 @@ export function GoalCard({ goal, onEditClick, onDeleteClick, onArchiveClick }: G
           <p className="text-xs text-muted-foreground italic">
             Obiettivo aperto — accumulo continuo senza target fisso
           </p>
-          <p className="text-sm font-medium text-foreground mt-1">
-            &euro;{goal.current.toLocaleString('it-IT')} accumulati
+          <p className="text-sm font-medium text-foreground mt-1" data-testid="goal-card-current">
+            &euro;{displayCurrent.toLocaleString('it-IT')} accumulati
           </p>
         </div>
       )}

--- a/apps/web/src/services/goals.client.ts
+++ b/apps/web/src/services/goals.client.ts
@@ -18,7 +18,22 @@ export interface Goal {
   name: string;
   /** Null for openended goals (no hard target). WP-K. */
   target: number | null;
+  /**
+   * Manual baseline (editable via GoalEditModal). Persisted in `goals.current`.
+   * Per goal non-linked a account/liability = unico source of progress (fallback
+   * Fase 2C). Per goal linked = offset manuale (es. "aggiungi €500 già
+   * risparmiati fuori dal conto").
+   */
   current: number;
+  /**
+   * Sprint 1.6.6 Fase 3a (#043): computed effective progress.
+   * Formula (via VIEW `goals_with_progress`):
+   *   current + SUM(accounts.current_balance WHERE goal_id=g.id)
+   *           - SUM(liabilities.current_balance WHERE goal_id=g.id)
+   * UI usa questo per progress bar + "a che punto sei". Manual edit aggiorna
+   * `current`; effective si ricalcola automaticamente post-balance change.
+   */
+  currentEffective: number;
   deadline: string | null;
   priority: PriorityRank;
   monthlyAllocation: number;
@@ -74,20 +89,37 @@ export const goalsClient = {
     const statuses = opts?.statuses ?? ['ACTIVE'];
 
     const supabase = createClient();
-    const { data, error } = await supabase
-      .from('goals')
-      .select('id, name, target, current, deadline, priority, monthly_allocation, status, type')
+    // Sprint 1.6.6 Fase 3a (#043): query goals_with_progress VIEW per ottenere
+    // effective_current (manual + linked accounts - linked liabilities).
+    // Cast VIEW non presente in Database types (da rigenerare post-merge via
+    // `supabase gen types`). Cast esplicito tipizzato per row shape.
+    type GoalWithProgressRow = {
+      id: string;
+      name: string;
+      target: number | null;
+      current: number;
+      effective_current: number;
+      deadline: string | null;
+      priority: number;
+      monthly_allocation: number;
+      status: string;
+      type: string | null;
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data, error } = await (supabase.from as any)('goals_with_progress')
+      .select('id, name, target, current, effective_current, deadline, priority, monthly_allocation, status, type')
       .eq('user_id', userId)
       .in('status', statuses)
       .order('priority', { ascending: true });
 
     if (error) throw new GoalsApiError(error.message, 500, error);
 
-    return (data ?? []).map((g) => ({
+    return ((data ?? []) as GoalWithProgressRow[]).map((g) => ({
       id: g.id,
       name: g.name,
       target: g.target !== null ? Number(g.target) : null,
       current: Number(g.current),
+      currentEffective: Number(g.effective_current),
       deadline: g.deadline,
       priority: g.priority as PriorityRank,
       monthlyAllocation: Number(g.monthly_allocation),
@@ -124,11 +156,14 @@ export const goalsClient = {
 
     if (error || !data) throw new GoalsApiError(error?.message ?? 'Failed to add goal', 500, error);
 
+    // #043: goal appena creato non ha ancora linked accounts/liabilities,
+    // currentEffective === current. Evita re-query VIEW per latency.
     return {
       id: data.id,
       name: data.name,
       target: data.target !== null ? Number(data.target) : null,
       current: Number(data.current),
+      currentEffective: Number(data.current),
       deadline: data.deadline,
       priority: data.priority as PriorityRank,
       monthlyAllocation: Number(data.monthly_allocation),
@@ -192,11 +227,20 @@ export const goalsClient = {
 
     if (error || !data) throw new GoalsApiError(error?.message ?? 'Failed to update goal', 500, error);
 
+    // #043: re-query VIEW per ottenere effective_current aggiornato (goal può
+    // avere linked accounts/liabilities — dopo update `current`, effective cambia).
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data: viewData } = await (supabase.from as any)('goals_with_progress')
+      .select('effective_current')
+      .eq('id', goalId)
+      .single() as { data: { effective_current: number } | null };
+
     return {
       id: data.id,
       name: data.name,
       target: data.target !== null ? Number(data.target) : null,
       current: Number(data.current),
+      currentEffective: viewData ? Number(viewData.effective_current) : Number(data.current),
       deadline: data.deadline,
       priority: data.priority as PriorityRank,
       monthlyAllocation: Number(data.monthly_allocation),

--- a/apps/web/src/services/goals.client.ts
+++ b/apps/web/src/services/goals.client.ts
@@ -105,12 +105,21 @@ export const goalsClient = {
       status: string;
       type: string | null;
     };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const { data, error } = await (supabase.from as any)('goals_with_progress')
-      .select('id, name, target, current, effective_current, deadline, priority, monthly_allocation, status, type')
-      .eq('user_id', userId)
-      .in('status', statuses)
-      .order('priority', { ascending: true });
+    // Copilot review #536 fix: cast esplicito tipizzato sul result preserva
+    // sia `data: GoalWithProgressRow[]` che `error`. `.from as any` è
+    // limitato a bypass string name check (VIEW non in schema types), il
+    // result è tipizzato.
+    const { data, error } = (await (
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (supabase.from as any)('goals_with_progress')
+        .select('id, name, target, current, effective_current, deadline, priority, monthly_allocation, status, type')
+        .eq('user_id', userId)
+        .in('status', statuses)
+        .order('priority', { ascending: true })
+    )) as {
+      data: GoalWithProgressRow[] | null;
+      error: { message: string; code?: string } | null;
+    };
 
     if (error) throw new GoalsApiError(error.message, 500, error);
 
@@ -229,11 +238,23 @@ export const goalsClient = {
 
     // #043: re-query VIEW per ottenere effective_current aggiornato (goal può
     // avere linked accounts/liabilities — dopo update `current`, effective cambia).
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const { data: viewData } = await (supabase.from as any)('goals_with_progress')
-      .select('effective_current')
-      .eq('id', goalId)
-      .single() as { data: { effective_current: number } | null };
+    // Copilot review #536 fix: capture + log error (non throw: UPDATE riuscito,
+    // re-query miss è fallback accettabile a `data.current`). Il caller può
+    // re-caricare manualmente via loadGoals se effective stale.
+    const { data: viewData, error: viewError } = (await (
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (supabase.from as any)('goals_with_progress')
+        .select('effective_current')
+        .eq('id', goalId)
+        .single()
+    )) as {
+      data: { effective_current: number } | null;
+      error: { message: string; code?: string } | null;
+    };
+
+    if (viewError) {
+      console.warn('[goalsClient.updateGoal] VIEW re-query failed, falling back to manual current:', viewError.message);
+    }
 
     return {
       id: data.id,

--- a/supabase/migrations/20260424080000_fase3a_goals_with_progress_view.sql
+++ b/supabase/migrations/20260424080000_fase3a_goals_with_progress_view.sql
@@ -1,0 +1,60 @@
+-- Sprint 1.6.6 Fase 3a — goals_with_progress VIEW (balance-driven goal progress)
+--
+-- Closes atomic note #043. Chiude semantica Fase 2 feature ciclo account↔goal
+-- linking: dopo che Fase 2A+2B hanno shipped il FK link, serve il calcolo
+-- effective che somma i balance degli account/liability linked al goal.current
+-- manuale per ottenere il progresso reale.
+--
+-- Formula effective_current:
+--   goal.current (manual baseline)
+--   + SUM(accounts.current_balance WHERE accounts.goal_id = goal.id)
+--   - SUM(liabilities.current_balance WHERE liabilities.goal_id = goal.id)
+--
+-- Semantica:
+--   - Goal non-linked: effective = manual (fallback Fase 2C)
+--   - Savings goal con account linked (es. Poste €1200 → Fondo Emergenza):
+--       effective = manual + €1200
+--   - Debt goal con liability linked (es. "Estingui CC" target €0, current=0,
+--     liability CC balance €500): effective = 0 + 0 - 500 = -500
+--     (progresso inverso: più alto current_balance liability = più debito residuo)
+--
+-- Security: view SECURITY INVOKER (PG15+ default). RLS policies su goals /
+-- accounts / liabilities applicano transitively. Nessun bypass.
+--
+-- Performance: indici esistenti idx_accounts_goal + idx_liabilities_goal
+-- (partial WHERE goal_id IS NOT NULL, Sprint 1.6 Fase 2A) coprono i lookup.
+
+CREATE VIEW public.goals_with_progress
+WITH (security_invoker = true)
+AS
+SELECT
+  g.id,
+  g.user_id,
+  g.name,
+  g.target,
+  g.current,
+  g.deadline,
+  g.priority,
+  g.monthly_allocation,
+  g.status,
+  g.type,
+  g.created_at,
+  g.updated_at,
+  g.current + COALESCE(
+    (SELECT SUM(a.current_balance)
+       FROM public.accounts a
+       WHERE a.goal_id = g.id),
+    0
+  ) - COALESCE(
+    (SELECT SUM(l.current_balance)
+       FROM public.liabilities l
+       WHERE l.goal_id = g.id),
+    0
+  ) AS effective_current
+FROM public.goals g;
+
+COMMENT ON VIEW public.goals_with_progress IS
+  'Sprint 1.6.6 Fase 3a: goals with balance-driven effective_current (manual + linked accounts - linked liabilities). Closes atomic #043.';
+
+-- Grant SELECT to authenticated role (RLS su goals/accounts/liabilities applies).
+GRANT SELECT ON public.goals_with_progress TO authenticated;

--- a/supabase/migrations/20260424080000_fase3a_goals_with_progress_view.sql
+++ b/supabase/migrations/20260424080000_fase3a_goals_with_progress_view.sql
@@ -23,6 +23,10 @@
 --
 -- Performance: indici esistenti idx_accounts_goal + idx_liabilities_goal
 -- (partial WHERE goal_id IS NOT NULL, Sprint 1.6 Fase 2A) coprono i lookup.
+--
+-- Status filter (Copilot review #536): esclude account/liability non-ACTIVE
+-- (HIDDEN/CLOSED/INACTIVE/ERROR per accounts; PAID_OFF/CLOSED per liabilities).
+-- Un account chiuso con goal_id residuo NON deve contaminare effective_current.
 
 CREATE VIEW public.goals_with_progress
 WITH (security_invoker = true)
@@ -43,12 +47,14 @@ SELECT
   g.current + COALESCE(
     (SELECT SUM(a.current_balance)
        FROM public.accounts a
-       WHERE a.goal_id = g.id),
+       WHERE a.goal_id = g.id
+         AND a.status = 'ACTIVE'),
     0
   ) - COALESCE(
     (SELECT SUM(l.current_balance)
        FROM public.liabilities l
-       WHERE l.goal_id = g.id),
+       WHERE l.goal_id = g.id
+         AND l.status = 'ACTIVE'),
     0
   ) AS effective_current
 FROM public.goals g;


### PR DESCRIPTION
## Summary

Chiude atomic note **#043** — ultimo P0 Sprint 1.6.6, completa semantica Fase 2 (account↔goal linking end-to-end).

**Formula** effective_current = `goal.current` (manual) + `SUM(accounts.current_balance WHERE goal_id=g.id)` − `SUM(liabilities.current_balance WHERE goal_id=g.id)`.

Progress UI ora live-reactive ai balance change: modificare saldo di un account linked aggiorna automaticamente la progress bar del goal, senza edit manuale di `goal.current`.

## Changes

- **Migration** `20260424080000_fase3a_goals_with_progress_view.sql` — VIEW `goals_with_progress` con `security_invoker=true` (RLS transitiva su goals/accounts/liabilities, zero bypass)
- **`goals.client.ts`** — nuovo campo `currentEffective: number` su Goal interface; `loadGoals()` query VIEW; `updateGoal()` re-query post-UPDATE; `addGoal()` fallback `currentEffective = current`
- **`GoalCard.tsx`** — `displayCurrent = goal.currentEffective ?? goal.current` per progress bar + tooltip "Manuale vs Effective (+ balance linked)" quando differiscono

## Semantics

- Goal non-linked: effective = manual (fallback Fase 2C invariato)
- Savings goal + account linked (es. Poste €1200 → Fondo Emergenza): effective = manual + €1200
- Debt goal + liability linked: effective = current − SUM(liability balance) (inverse progress)

## Security & Performance

- `security_invoker=true` preserva RLS user-scoped su sub-SELECT
- Indici esistenti `idx_accounts_goal` + `idx_liabilities_goal` (partial WHERE goal_id IS NOT NULL, Sprint 1.6 Fase 2A) coprono lookup

## Validation

- Migration applicata via MCP → VIEW verificata: Fondo Emergenza current=5000 + linked account €250 → effective=5250 ✓
- Test suite: **1898/1898 passed**, zero regression
- Manual QA: account linked toggle balance → progress bar aggiorna live senza reload

## Test plan

- [x] Migration apply clean (local MCP)
- [x] Typecheck + full test suite green
- [ ] CI green on develop merge
- [ ] Post-merge: regenerate Supabase types (`supabase gen types` → commit types/database.ts)
- [ ] Manual QA post-deploy: verify live progress sync UX staging

Closes #043 (atomic note vault).

🤖 Generated with [Claude Code](https://claude.com/claude-code)