### PR TITLE
chore(types): regenerate Supabase types + simplify goals.client post-VIEW

### DIFF
--- a/apps/web/src/services/goals.client.ts
+++ b/apps/web/src/services/goals.client.ts
@@ -90,49 +90,27 @@ export const goalsClient = {
 
     const supabase = createClient();
     // Sprint 1.6.6 Fase 3a (#043): query goals_with_progress VIEW per ottenere
-    // effective_current (manual + linked accounts - linked liabilities).
-    // Cast VIEW non presente in Database types (da rigenerare post-merge via
-    // `supabase gen types`). Cast esplicito tipizzato per row shape.
-    type GoalWithProgressRow = {
-      id: string;
-      name: string;
-      target: number | null;
-      current: number;
-      effective_current: number;
-      deadline: string | null;
-      priority: number;
-      monthly_allocation: number;
-      status: string;
-      type: string | null;
-    };
-    // Copilot review #536 fix: cast esplicito tipizzato sul result preserva
-    // sia `data: GoalWithProgressRow[]` che `error`. `.from as any` è
-    // limitato a bypass string name check (VIEW non in schema types), il
-    // result è tipizzato.
-    const { data, error } = (await (
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (supabase.from as any)('goals_with_progress')
-        .select('id, name, target, current, effective_current, deadline, priority, monthly_allocation, status, type')
-        .eq('user_id', userId)
-        .in('status', statuses)
-        .order('priority', { ascending: true })
-    )) as {
-      data: GoalWithProgressRow[] | null;
-      error: { message: string; code?: string } | null;
-    };
+    // effective_current (manual + linked accounts - linked liabilities active only).
+    // Types post-regen 2026-04-24: VIEW ora in Database types → query fully typed.
+    const { data, error } = await supabase
+      .from('goals_with_progress')
+      .select('id, name, target, current, effective_current, deadline, priority, monthly_allocation, status, type')
+      .eq('user_id', userId)
+      .in('status', statuses)
+      .order('priority', { ascending: true });
 
     if (error) throw new GoalsApiError(error.message, 500, error);
 
-    return ((data ?? []) as GoalWithProgressRow[]).map((g) => ({
-      id: g.id,
-      name: g.name,
-      target: g.target !== null ? Number(g.target) : null,
-      current: Number(g.current),
-      currentEffective: Number(g.effective_current),
+    return (data ?? []).map((g) => ({
+      id: g.id ?? '',
+      name: g.name ?? '',
+      target: g.target !== null && g.target !== undefined ? Number(g.target) : null,
+      current: Number(g.current ?? 0),
+      currentEffective: Number(g.effective_current ?? g.current ?? 0),
       deadline: g.deadline,
-      priority: g.priority as PriorityRank,
-      monthlyAllocation: Number(g.monthly_allocation),
-      status: g.status,
+      priority: (g.priority ?? 2) as PriorityRank,
+      monthlyAllocation: Number(g.monthly_allocation ?? 0),
+      status: g.status ?? 'ACTIVE',
       type: (g.type ?? 'fixed') as GoalType,
     }));
   },
@@ -238,19 +216,13 @@ export const goalsClient = {
 
     // #043: re-query VIEW per ottenere effective_current aggiornato (goal può
     // avere linked accounts/liabilities — dopo update `current`, effective cambia).
-    // Copilot review #536 fix: capture + log error (non throw: UPDATE riuscito,
-    // re-query miss è fallback accettabile a `data.current`). Il caller può
-    // re-caricare manualmente via loadGoals se effective stale.
-    const { data: viewData, error: viewError } = (await (
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (supabase.from as any)('goals_with_progress')
-        .select('effective_current')
-        .eq('id', goalId)
-        .single()
-    )) as {
-      data: { effective_current: number } | null;
-      error: { message: string; code?: string } | null;
-    };
+    // Types post-regen 2026-04-24: VIEW tipizzata, no cast. Se re-query fallisce
+    // (raro: RLS, VIEW missing), fallback `data.current` (UPDATE già persistito).
+    const { data: viewData, error: viewError } = await supabase
+      .from('goals_with_progress')
+      .select('effective_current')
+      .eq('id', goalId)
+      .single();
 
     if (viewError) {
       console.warn('[goalsClient.updateGoal] VIEW re-query failed, falling back to manual current:', viewError.message);
@@ -261,7 +233,10 @@ export const goalsClient = {
       name: data.name,
       target: data.target !== null ? Number(data.target) : null,
       current: Number(data.current),
-      currentEffective: viewData ? Number(viewData.effective_current) : Number(data.current),
+      currentEffective:
+        viewData?.effective_current != null
+          ? Number(viewData.effective_current)
+          : Number(data.current),
       deadline: data.deadline,
       priority: data.priority as PriorityRank,
       monthlyAllocation: Number(data.monthly_allocation),

--- a/apps/web/src/services/goals.client.ts
+++ b/apps/web/src/services/goals.client.ts
@@ -101,18 +101,33 @@ export const goalsClient = {
 
     if (error) throw new GoalsApiError(error.message, 500, error);
 
-    return (data ?? []).map((g) => ({
-      id: g.id ?? '',
-      name: g.name ?? '',
-      target: g.target !== null && g.target !== undefined ? Number(g.target) : null,
-      current: Number(g.current ?? 0),
-      currentEffective: Number(g.effective_current ?? g.current ?? 0),
-      deadline: g.deadline,
-      priority: (g.priority ?? 2) as PriorityRank,
-      monthlyAllocation: Number(g.monthly_allocation ?? 0),
-      status: g.status ?? 'ACTIVE',
-      type: (g.type ?? 'fixed') as GoalType,
-    }));
+    // Copilot review #538 fix: required fields (id/name/status) sono NOT NULL
+    // nella tabella goals → via VIEW devono sempre essere populated. Null qui
+    // indicherebbe corruption o RLS filtering imprevisto — fail-visible via
+    // filter-out + console.error invece di fail-silent con magic defaults
+    // (`id: ''` ruppe downstream updates/routes).
+    // Numeric fields (target, current, monthly_allocation) e priority/type
+    // restano con fallback safe (truly optional).
+    return (data ?? [])
+      .filter((g): g is typeof g & { id: string; name: string; status: string } => {
+        if (g.id === null || g.name === null || g.status === null) {
+          console.error('[goalsClient.loadGoals] Skipping invalid row with null required field:', { id: g.id, name: g.name, status: g.status });
+          return false;
+        }
+        return true;
+      })
+      .map((g) => ({
+        id: g.id,
+        name: g.name,
+        target: g.target !== null && g.target !== undefined ? Number(g.target) : null,
+        current: Number(g.current ?? 0),
+        currentEffective: Number(g.effective_current ?? g.current ?? 0),
+        deadline: g.deadline,
+        priority: (g.priority ?? 2) as PriorityRank,
+        monthlyAllocation: Number(g.monthly_allocation ?? 0),
+        status: g.status,
+        type: (g.type ?? 'fixed') as GoalType,
+      }));
   },
 
   /**

--- a/apps/web/src/utils/supabase/database.types.ts
+++ b/apps/web/src/utils/supabase/database.types.ts
@@ -26,6 +26,7 @@ export type Database = {
           currency: string
           current_balance: number
           family_id: string | null
+          goal_id: string | null
           id: string
           institution_name: string | null
           is_active: boolean
@@ -61,6 +62,7 @@ export type Database = {
           currency?: string
           current_balance?: number
           family_id?: string | null
+          goal_id?: string | null
           id?: string
           institution_name?: string | null
           is_active?: boolean
@@ -96,6 +98,7 @@ export type Database = {
           currency?: string
           current_balance?: number
           family_id?: string | null
+          goal_id?: string | null
           id?: string
           institution_name?: string | null
           is_active?: boolean
@@ -126,6 +129,20 @@ export type Database = {
             columns: ["family_id"]
             isOneToOne: false
             referencedRelation: "families"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "accounts_goal_id_fkey"
+            columns: ["goal_id"]
+            isOneToOne: false
+            referencedRelation: "goals"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "accounts_goal_id_fkey"
+            columns: ["goal_id"]
+            isOneToOne: false
+            referencedRelation: "goals_with_progress"
             referencedColumns: ["id"]
           },
           {
@@ -615,6 +632,13 @@ export type Database = {
             referencedColumns: ["id"]
           },
           {
+            foreignKeyName: "goal_allocations_goal_id_fkey"
+            columns: ["goal_id"]
+            isOneToOne: false
+            referencedRelation: "goals_with_progress"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "goal_allocations_plan_id_fkey"
             columns: ["plan_id"]
             isOneToOne: false
@@ -793,6 +817,7 @@ export type Database = {
           current_balance: number
           external_id: string | null
           family_id: string
+          goal_id: string | null
           id: string
           interest_rate: number | null
           last_statement_date: string | null
@@ -817,6 +842,7 @@ export type Database = {
           current_balance?: number
           external_id?: string | null
           family_id: string
+          goal_id?: string | null
           id?: string
           interest_rate?: number | null
           last_statement_date?: string | null
@@ -841,6 +867,7 @@ export type Database = {
           current_balance?: number
           external_id?: string | null
           family_id?: string
+          goal_id?: string | null
           id?: string
           interest_rate?: number | null
           last_statement_date?: string | null
@@ -869,6 +896,20 @@ export type Database = {
             columns: ["family_id"]
             isOneToOne: false
             referencedRelation: "families"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "liabilities_goal_id_fkey"
+            columns: ["goal_id"]
+            isOneToOne: false
+            referencedRelation: "goals"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "liabilities_goal_id_fkey"
+            columns: ["goal_id"]
+            isOneToOne: false
+            referencedRelation: "goals_with_progress"
             referencedColumns: ["id"]
           },
         ]
@@ -1458,7 +1499,62 @@ export type Database = {
       }
     }
     Views: {
-      [_ in never]: never
+      goals_with_progress: {
+        Row: {
+          created_at: string | null
+          current: number | null
+          deadline: string | null
+          effective_current: number | null
+          id: string | null
+          monthly_allocation: number | null
+          name: string | null
+          priority: number | null
+          status: Database["public"]["Enums"]["goal_status"] | null
+          target: number | null
+          type: string | null
+          updated_at: string | null
+          user_id: string | null
+        }
+        Insert: {
+          created_at?: string | null
+          current?: number | null
+          deadline?: string | null
+          effective_current?: never
+          id?: string | null
+          monthly_allocation?: number | null
+          name?: string | null
+          priority?: number | null
+          status?: Database["public"]["Enums"]["goal_status"] | null
+          target?: number | null
+          type?: string | null
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Update: {
+          created_at?: string | null
+          current?: number | null
+          deadline?: string | null
+          effective_current?: never
+          id?: string | null
+          monthly_allocation?: number | null
+          name?: string | null
+          priority?: number | null
+          status?: Database["public"]["Enums"]["goal_status"] | null
+          target?: number | null
+          type?: string | null
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "goals_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
     }
     Functions: {
       get_balance_summary: {


### PR DESCRIPTION
## Summary

Post-merge follow-up PR #536 (Bundle B Fase 3a). **C2 tech debt** della review post-merge 2026-04-24.

### Motivazione

VIEW `public.goals_with_progress` introdotta da PR #536 non era presente nei Database types generated, forzando workaround \`(supabase.from as any)('goals_with_progress')\` + eslint-disable + cast manuali sul result.

### Changes

1. **Regen Supabase types** via MCP \`generate_typescript_types\` (no local CLI). VIEW ora in \`Database[\"public\"][\"Tables\"][\"goals_with_progress\"]\`:
   - Row: \`{id, name, target, current, effective_current, deadline, priority, monthly_allocation, status, type, user_id, created_at, updated_at}\` (tutti \`T | null\`, limite PG su sub-SELECT non-null inference)
   - +96 linee \`database.types.ts\`

2. **Simplify `goals.client.ts`**:
   - \`loadGoals()\`: query fully typed, rimosso \`GoalWithProgressRow\` local alias
   - \`updateGoal()\` re-query: typed, rimosso cast esplicito
   - Defensive nullable handling: \`?? fallback\` espliciti (e.g., \`Number(g.current ?? 0)\`)
   - \`viewData?.effective_current != null\` check esplicito (evita \`Number(null) === 0\` bug silente)

### Validation

- Typecheck: 0 error
- Test suite: **1898/1898 passed**, zero regression
- ESLint: rimossi 2 \`eslint-disable @typescript-eslint/no-explicit-any\` annotations

### Refs

Review session 2026-04-24 post-Bundle B merge → C2 item. Closes tech debt documentato in PR #536 body ("Supabase types regen post-merge").

🤖 Generated with [Claude Code](https://claude.com/claude-code)