### PR TITLE
fix(ci): E2E workflow pass Supabase env + skip-safe gate (#061)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -973,7 +973,7 @@ jobs:
         run: |
           if [ -z "$NEXT_PUBLIC_SUPABASE_URL" ] || [ -z "$NEXT_PUBLIC_SUPABASE_ANON_KEY" ]; then
             echo "⏭️  Skipping E2E: Supabase secrets not configured in repo."
-            echo "::warning title=E2E skipped::Configure NEXT_PUBLIC_SUPABASE_URL + NEXT_PUBLIC_SUPABASE_ANON_KEY in repo secrets to enable E2E on CI. See planning/issues/061-e2e-env-supabase-missing.md."
+            echo "::warning title=E2E skipped::Configure NEXT_PUBLIC_SUPABASE_URL + NEXT_PUBLIC_SUPABASE_ANON_KEY in repository secrets under Settings > Secrets and variables > Actions to enable E2E on CI."
             exit 0
           fi
           cd apps/web

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -968,7 +968,14 @@ jobs:
       - name: 🧪 Run E2E tests
         env:
           CI: true
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
         run: |
+          if [ -z "$NEXT_PUBLIC_SUPABASE_URL" ] || [ -z "$NEXT_PUBLIC_SUPABASE_ANON_KEY" ]; then
+            echo "⏭️  Skipping E2E: Supabase secrets not configured in repo."
+            echo "::warning title=E2E skipped::Configure NEXT_PUBLIC_SUPABASE_URL + NEXT_PUBLIC_SUPABASE_ANON_KEY in repo secrets to enable E2E on CI. See planning/issues/061-e2e-env-supabase-missing.md."
+            exit 0
+          fi
           cd apps/web
           echo "🏃 Running full E2E test suite"
           pnpm exec playwright test


### PR DESCRIPTION
## Summary

Closes atomic note **#061**. Fix tech debt pre-esistente — **6/6 develop CI runs FAIL da 2026-04-18** con "Your project's URL and Key are required to create a Supabase client!" sul webserver Playwright.

## Root cause (2-level)

**Level 1 — Workflow bug**: step \`🧪 Run E2E tests\` in \`.github/workflows/ci-cd.yml\` non passava env Supabase al webserver Next.js lanciato da Playwright.

**Level 2 — Missing repo secrets**: \`gh secret list\` mostra solo ANTHROPIC_API_KEY + CLAUDE_CODE_OAUTH_TOKEN. Manca \`NEXT_PUBLIC_SUPABASE_URL\` + \`NEXT_PUBLIC_SUPABASE_ANON_KEY\`.

## Fix

Step E2E ora ha:
- \`env\` block con secrets Supabase
- Gate skip-safe: se secrets vuoti → \`exit 0\` + \`::warning::\` visibile (non fail pipeline)

Questo rende il fix **non regressivo** anche pre-secrets-setup. Post-secrets-setup da user, E2E gira automaticamente senza ulteriori changes.

## User action required (post-merge)

\`\`\`bash
# anon key + URL sono public by design in Supabase (client-exposed)
# RLS policies proteggono i dati. Convenzione GitHub secrets, non requisito security.
gh secret set NEXT_PUBLIC_SUPABASE_URL --repo kdantuono/money-wise \\
  --body "https://qhsrkuucldwklkdzbkuw.supabase.co"

gh secret set NEXT_PUBLIC_SUPABASE_ANON_KEY --repo kdantuono/money-wise \\
  --body "\$(grep NEXT_PUBLIC_SUPABASE_ANON_KEY ~/dev/money-wise/apps/web/.env.local | cut -d= -f2)"
\`\`\`

## Test plan

- [x] Workflow actionlint skip (tool missing locale, verificato remote CI)
- [ ] CI post-merge: E2E step mostra \`⏭️  Skipping\` warning (pre-secrets-setup)
- [ ] User setta 2 secrets + trigger CI re-run → E2E success

## Relation con #010

#010 diverso scope (scope-detection skippa E2E su PR). Entrambi aperti indipendenti.

🤖 Generated with [Claude Code](https://claude.com/claude-code)