### PR TITLE
feat(patrimonio): ADR-005 Fase 2.1 — unified financial instruments view

### DIFF
--- a/apps/web/app/dashboard/accounts/page.tsx
+++ b/apps/web/app/dashboard/accounts/page.tsx
@@ -31,6 +31,7 @@ import { initiateLink } from '@/services/banking.client';
 import { ManualAccountForm } from '@/components/accounts';
 import { EditAccountForm } from '@/components/accounts/EditAccountForm';
 import { useActiveGoals } from '@/hooks/useActiveGoals';
+import { NewFeatureBanner } from '@/components/ui/new-feature-banner';
 
 // ---------------------------------------------------------------------------
 // Helpers — 1:1 from Figma Accounts.tsx styling
@@ -191,6 +192,13 @@ export default function AccountsPage() {
 
   return (
     <div className="p-6 md:p-8 max-w-7xl mx-auto space-y-8">
+      {/* ADR-005 Fase 2.1: deprecation hint verso unified Patrimonio */}
+      <NewFeatureBanner
+        href="/dashboard/patrimonio"
+        message="Conti + investimenti + debiti in un'unica vista unificata."
+        testId="accounts-patrimonio-banner"
+      />
+
       {/* Header — 1:1 Figma */}
       <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
         <div>

--- a/apps/web/app/dashboard/liabilities/page.tsx
+++ b/apps/web/app/dashboard/liabilities/page.tsx
@@ -21,6 +21,7 @@ import {
   type Liability,
   type CreateLiabilityRequest,
 } from '@/services/liabilities.client';
+import { NewFeatureBanner } from '@/components/ui/new-feature-banner';
 
 // =============================================================================
 // Component
@@ -107,6 +108,12 @@ export default function LiabilitiesPage() {
 
   return (
     <div className="p-6 md:p-8 max-w-7xl mx-auto space-y-6" data-testid="liabilities-container">
+      {/* ADR-005 Fase 2.1: deprecation hint verso unified Patrimonio */}
+      <NewFeatureBanner
+        href="/dashboard/patrimonio"
+        message="Conti + investimenti + debiti in un'unica vista unificata."
+        testId="liabilities-patrimonio-banner"
+      />
       {/* Page Header — Figma pattern 1:1 con Accounts/Goals */}
       <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
         <div className="flex items-center gap-3">

--- a/apps/web/app/dashboard/patrimonio/page.tsx
+++ b/apps/web/app/dashboard/patrimonio/page.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { AlertCircle } from 'lucide-react';
+import { Card } from '@/components/ui/card';
+import { usePatrimonio } from '@/hooks/usePatrimonio';
+import { useActiveGoals } from '@/hooks/useActiveGoals';
+import { computeNetWorth, type FinancialInstrument } from '@/services/financial-instruments.client';
+import { PatrimonioHeader } from '@/components/patrimonio/PatrimonioHeader';
+import {
+  PatrimonioTabs,
+  type PatrimonioTab,
+} from '@/components/patrimonio/PatrimonioTabs';
+import { InstrumentGroup } from '@/components/patrimonio/InstrumentGroup';
+import { EmptyState } from '@/components/patrimonio/EmptyState';
+
+// =============================================================================
+// Grouping semantics (design doc §3.4)
+// =============================================================================
+
+const GROUP_LABELS: Record<string, string> = {
+  CHECKING: 'Banche',
+  SAVINGS: 'Banche',
+  INVESTMENT: 'Investimenti',
+  CASH: 'Contanti',
+  OTHER: 'Altri',
+  CREDIT_CARD: 'Carte di credito',
+  LOAN: 'Finanziamenti',
+  MORTGAGE: 'Mutui',
+  BNPL: 'BNPL',
+};
+
+const GROUP_ORDER = [
+  'Banche',
+  'Investimenti',
+  'Contanti',
+  'Altri',
+  'Carte di credito',
+  'Finanziamenti',
+  'Mutui',
+  'BNPL',
+];
+
+function groupInstruments(items: FinancialInstrument[]): Map<string, FinancialInstrument[]> {
+  const groups = new Map<string, FinancialInstrument[]>();
+  for (const label of GROUP_ORDER) groups.set(label, []);
+  for (const item of items) {
+    const label = GROUP_LABELS[item.type.toUpperCase()] ?? 'Altri';
+    const existing = groups.get(label) ?? [];
+    existing.push(item);
+    groups.set(label, existing);
+  }
+  return groups;
+}
+
+// =============================================================================
+// Page
+// =============================================================================
+
+export default function PatrimonioPage() {
+  const [tab, setTab] = useState<PatrimonioTab>('all');
+
+  const { data: instruments, isLoading, error } = usePatrimonio();
+  const { data: goals = [] } = useActiveGoals();
+
+  // Memoized derived state
+  const allNetWorth = useMemo(
+    () => (instruments ? computeNetWorth(instruments) : null),
+    [instruments],
+  );
+
+  const tabCounts = useMemo(() => {
+    const all = instruments ?? [];
+    return {
+      total: all.length,
+      assets: all.filter((i) => i.class === 'ASSET').length,
+      liabilities: all.filter((i) => i.class === 'LIABILITY').length,
+      byGoal: all.filter((i) => i.goalId !== null).length,
+    };
+  }, [instruments]);
+
+  const filteredInstruments = useMemo(() => {
+    const all = instruments ?? [];
+    if (tab === 'assets') return all.filter((i) => i.class === 'ASSET');
+    if (tab === 'liabilities') return all.filter((i) => i.class === 'LIABILITY');
+    if (tab === 'by-goal') return all.filter((i) => i.goalId !== null);
+    return all;
+  }, [instruments, tab]);
+
+  const grouped = useMemo(() => groupInstruments(filteredInstruments), [filteredInstruments]);
+
+  // Error state
+  if (error) {
+    return (
+      <div className="space-y-6">
+        <h1 className="text-2xl font-bold">Patrimonio</h1>
+        <Card className="p-6 border-red-200 dark:border-red-900/50 bg-red-50/50 dark:bg-red-950/20">
+          <div className="flex items-start gap-3">
+            <AlertCircle className="w-5 h-5 text-red-600 dark:text-red-400 shrink-0 mt-0.5" />
+            <div>
+              <p className="font-semibold text-red-900 dark:text-red-100">
+                Errore nel caricamento del patrimonio
+              </p>
+              <p className="text-sm text-red-700 dark:text-red-300 mt-1">
+                {error.message}
+              </p>
+            </div>
+          </div>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6" data-testid="patrimonio-page">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">Patrimonio</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Vista unificata di tutti i tuoi conti, investimenti e debiti.
+        </p>
+      </div>
+
+      <PatrimonioHeader
+        netWorth={
+          allNetWorth ?? {
+            assets: 0,
+            liabilities: 0,
+            netWorth: 0,
+            currency: 'EUR',
+            count: { asset: 0, liability: 0 },
+          }
+        }
+        isLoading={isLoading}
+      />
+
+      {!isLoading && instruments && instruments.length === 0 ? (
+        <EmptyState />
+      ) : (
+        <>
+          <PatrimonioTabs value={tab} onChange={setTab} counts={tabCounts} />
+
+          {isLoading ? (
+            <div className="space-y-2" data-testid="patrimonio-loading-skeleton">
+              {[1, 2, 3].map((i) => (
+                <div
+                  key={i}
+                  className="h-16 bg-muted/40 animate-pulse rounded-lg"
+                />
+              ))}
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {Array.from(grouped.entries()).map(([label, items]) => (
+                <InstrumentGroup
+                  key={label}
+                  label={label}
+                  instruments={items}
+                  goals={goals}
+                />
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/dashboard-layout.tsx
+++ b/apps/web/src/components/layout/dashboard-layout.tsx
@@ -22,6 +22,7 @@ import {
   FileText,
   Sparkles,
   CreditCard,
+  Coins,
 } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useAuthStore } from '@/store/auth.store';
@@ -31,8 +32,12 @@ import { TopBar } from './top-bar';
 // Navigation config — mapped to Next.js App Router paths
 // ---------------------------------------------------------------------------
 
+// ADR-005 Fase 2.1: "Patrimonio" nuova entry sopra Conti/Debiti (Q1 lock
+// coexistenza 1 sprint). Badge "Nuovo" soft-deprecate /accounts e
+// /liabilities in Fase 2.2. TODO remove badge post-Fase-2.2.
 const mainNav = [
   { name: 'Dashboard', href: '/dashboard', icon: LayoutDashboard },
+  { name: 'Patrimonio', href: '/dashboard/patrimonio', icon: Coins, badge: 'Nuovo' },
   { name: 'Conti', href: '/dashboard/accounts', icon: Wallet },
   { name: 'Debiti', href: '/dashboard/liabilities', icon: CreditCard },
   { name: 'Investimenti', href: '/dashboard/investments', icon: TrendingUp },
@@ -92,6 +97,11 @@ function NavLink({
         />
         <span className={active ? 'tracking-[-0.01em]' : ''}>{item.name}</span>
       </div>
+      {'badge' in item && item.badge && (
+        <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded-full bg-blue-500/15 text-blue-600 dark:bg-blue-400/20 dark:text-blue-300 uppercase tracking-wide">
+          {item.badge}
+        </span>
+      )}
     </Link>
   );
 }

--- a/apps/web/src/components/patrimonio/EmptyState.tsx
+++ b/apps/web/src/components/patrimonio/EmptyState.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { Card } from '@/components/ui/card';
+import { Coins, Plus } from 'lucide-react';
+import Link from 'next/link';
+
+/**
+ * Empty state: zero instrument tracked. CTA verso /dashboard/accounts (legacy add).
+ * Usa `Link` con stile inline anziché Button (local Button non supporta asChild).
+ */
+export function EmptyState() {
+  return (
+    <Card
+      data-testid="patrimonio-empty-state"
+      className="p-10 text-center space-y-4"
+    >
+      <div className="mx-auto w-16 h-16 rounded-2xl bg-blue-100 dark:bg-blue-950/40 flex items-center justify-center">
+        <Coins className="w-8 h-8 text-blue-600 dark:text-blue-400" />
+      </div>
+      <div className="space-y-1">
+        <h2 className="text-lg font-semibold text-foreground">
+          Nessuno strumento ancora
+        </h2>
+        <p className="text-sm text-muted-foreground max-w-md mx-auto">
+          Aggiungi conti, investimenti o debiti per vedere il tuo patrimonio
+          unificato. Il patrimonio netto si aggiorna automaticamente.
+        </p>
+      </div>
+      <div className="flex flex-wrap gap-2 justify-center">
+        <Link
+          href="/dashboard/accounts"
+          className="inline-flex items-center gap-1.5 rounded-md bg-primary text-primary-foreground px-3 py-2 text-sm font-medium hover:bg-primary/90 transition-colors"
+        >
+          <Plus className="w-4 h-4" />
+          Aggiungi conto
+        </Link>
+        <Link
+          href="/dashboard/liabilities"
+          className="inline-flex items-center gap-1.5 rounded-md border border-input bg-background px-3 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground transition-colors"
+        >
+          <Plus className="w-4 h-4" />
+          Aggiungi debito
+        </Link>
+      </div>
+    </Card>
+  );
+}

--- a/apps/web/src/components/patrimonio/InstrumentGroup.tsx
+++ b/apps/web/src/components/patrimonio/InstrumentGroup.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { ChevronDown } from 'lucide-react';
+import { useState } from 'react';
+import type { FinancialInstrument } from '@/services/financial-instruments.client';
+import type { Goal } from '@/services/goals.client';
+import { InstrumentRow } from './InstrumentRow';
+
+interface InstrumentGroupProps {
+  label: string;
+  instruments: FinancialInstrument[];
+  goals?: Goal[];
+  defaultOpen?: boolean;
+}
+
+/**
+ * Collapsible group di instruments con label. Client-side grouping per type.
+ */
+export function InstrumentGroup({
+  label,
+  instruments,
+  goals = [],
+  defaultOpen = true,
+}: InstrumentGroupProps) {
+  const [open, setOpen] = useState(defaultOpen);
+
+  if (instruments.length === 0) return null;
+
+  const groupTotal = instruments.reduce(
+    (sum, i) => sum + Number(i.currentBalance),
+    0,
+  );
+
+  return (
+    <section
+      data-testid={`instrument-group-${label.toLowerCase().replace(/\s/g, '-')}`}
+      className="space-y-2"
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="w-full flex items-center justify-between gap-2 px-2 py-1.5 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+        aria-expanded={open}
+      >
+        <div className="flex items-center gap-1.5">
+          <ChevronDown
+            className={`w-4 h-4 transition-transform ${open ? '' : '-rotate-90'}`}
+          />
+          <span>{label}</span>
+          <span className="text-xs opacity-60">({instruments.length})</span>
+        </div>
+        <span className="text-xs font-semibold">
+          &euro;{groupTotal.toLocaleString('it-IT', {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+          })}
+        </span>
+      </button>
+      {open && (
+        <div className="space-y-1.5 pl-6">
+          {instruments.map((i) => (
+            <InstrumentRow key={i.id} instrument={i} goals={goals} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/patrimonio/InstrumentRow.tsx
+++ b/apps/web/src/components/patrimonio/InstrumentRow.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import {
+  Wallet,
+  PiggyBank,
+  CreditCard,
+  Banknote,
+  TrendingUp,
+  Home,
+  ShoppingBag,
+  Target,
+} from 'lucide-react';
+import type { FinancialInstrument } from '@/services/financial-instruments.client';
+import type { Goal } from '@/services/goals.client';
+
+interface InstrumentRowProps {
+  instrument: FinancialInstrument;
+  goals?: Goal[];
+}
+
+/**
+ * Render icona per type+class. Ritorna JSX direttamente invece della component
+ * reference per evitare `react-hooks/static-components` lint warning.
+ */
+function renderInstrumentIcon(
+  type: string,
+  cls: 'ASSET' | 'LIABILITY',
+  className: string,
+) {
+  const t = type.toUpperCase();
+  if (cls === 'LIABILITY') {
+    if (t === 'MORTGAGE') return <Home className={className} />;
+    if (t === 'BNPL') return <ShoppingBag className={className} />;
+    return <CreditCard className={className} />;
+  }
+  if (t === 'SAVINGS') return <PiggyBank className={className} />;
+  if (t === 'INVESTMENT') return <TrendingUp className={className} />;
+  if (t === 'CASH') return <Banknote className={className} />;
+  return <Wallet className={className} />;
+}
+
+function getTypeLabel(type: string, cls: 'ASSET' | 'LIABILITY'): string {
+  const t = type.toUpperCase();
+  if (cls === 'LIABILITY') {
+    if (t === 'CREDIT_CARD') return 'Carta di credito';
+    if (t === 'MORTGAGE') return 'Mutuo';
+    if (t === 'LOAN') return 'Finanziamento';
+    if (t === 'BNPL') return 'BNPL';
+    return t;
+  }
+  if (t === 'CHECKING') return 'Conto corrente';
+  if (t === 'SAVINGS') return 'Risparmio';
+  if (t === 'INVESTMENT') return 'Investimento';
+  if (t === 'CASH') return 'Contante';
+  return t;
+}
+
+/**
+ * Row unified asset/liability. Layout identico, colore differenzia classe.
+ */
+export function InstrumentRow({ instrument, goals = [] }: InstrumentRowProps) {
+  const isLiability = instrument.class === 'LIABILITY';
+  const linkedGoal = instrument.goalId
+    ? goals.find((g) => g.id === instrument.goalId)
+    : null;
+
+  return (
+    <div
+      data-testid={`instrument-row-${instrument.id}`}
+      data-class={instrument.class}
+      className="flex items-center gap-3 p-3 rounded-lg hover:bg-muted/50 transition-colors border border-border/40"
+    >
+      <div
+        className={`shrink-0 p-2.5 rounded-xl ${
+          isLiability
+            ? 'bg-red-100 dark:bg-red-950/40'
+            : 'bg-emerald-100 dark:bg-emerald-950/40'
+        }`}
+      >
+        {renderInstrumentIcon(
+          instrument.type,
+          instrument.class,
+          `w-5 h-5 ${
+            isLiability
+              ? 'text-red-700 dark:text-red-400'
+              : 'text-emerald-700 dark:text-emerald-400'
+          }`,
+        )}
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2 flex-wrap">
+          <p className="font-medium text-foreground truncate">{instrument.name}</p>
+          {linkedGoal && (
+            <span
+              data-testid={`instrument-goal-badge-${instrument.id}`}
+              className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-blue-100 dark:bg-blue-950/40 text-blue-700 dark:text-blue-400"
+              title={`Linkato a goal: ${linkedGoal.name}`}
+            >
+              <Target className="w-3 h-3" />
+              {linkedGoal.name}
+            </span>
+          )}
+        </div>
+        <p className="text-xs text-muted-foreground mt-0.5">
+          {getTypeLabel(instrument.type, instrument.class)}
+          {instrument.institutionName && ` · ${instrument.institutionName}`}
+        </p>
+      </div>
+      <div className="shrink-0 text-right">
+        <p
+          data-testid={`instrument-balance-${instrument.id}`}
+          className={`font-semibold ${
+            isLiability
+              ? 'text-red-700 dark:text-red-400'
+              : 'text-foreground'
+          }`}
+        >
+          &euro;{instrument.currentBalance.toLocaleString('it-IT', {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+          })}
+        </p>
+        {isLiability && (
+          <p className="text-xs text-muted-foreground">debito</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/patrimonio/PatrimonioHeader.tsx
+++ b/apps/web/src/components/patrimonio/PatrimonioHeader.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { Card } from '@/components/ui/card';
+import { TrendingUp } from 'lucide-react';
+import type { NetWorthResult } from '@/services/financial-instruments.client';
+
+interface PatrimonioHeaderProps {
+  netWorth: NetWorthResult;
+  isLoading: boolean;
+}
+
+/**
+ * Header card con net worth display + conteggi asset/debiti.
+ * Fase 2.1: no trend (Q2 lock ADR-005).
+ */
+export function PatrimonioHeader({ netWorth, isLoading }: PatrimonioHeaderProps) {
+  if (isLoading) {
+    return (
+      <Card className="p-6 bg-gradient-to-br from-blue-50 to-indigo-50 dark:from-blue-950/30 dark:to-indigo-950/30 border-blue-200/50 dark:border-blue-800/50">
+        <div className="animate-pulse space-y-3">
+          <div className="h-4 bg-blue-200/50 dark:bg-blue-800/30 rounded w-32" />
+          <div className="h-10 bg-blue-200/50 dark:bg-blue-800/30 rounded w-48" />
+          <div className="h-3 bg-blue-200/50 dark:bg-blue-800/30 rounded w-64" />
+        </div>
+      </Card>
+    );
+  }
+
+  const positive = netWorth.netWorth >= 0;
+
+  return (
+    <Card
+      data-testid="patrimonio-header"
+      className="p-6 bg-gradient-to-br from-blue-50 to-indigo-50 dark:from-blue-950/30 dark:to-indigo-950/30 border-blue-200/50 dark:border-blue-800/50"
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          <p className="text-sm text-muted-foreground font-medium mb-1">
+            Patrimonio Netto
+          </p>
+          <p
+            data-testid="net-worth-value"
+            className={`text-3xl font-bold tracking-tight ${
+              positive
+                ? 'text-blue-900 dark:text-blue-100'
+                : 'text-red-700 dark:text-red-300'
+            }`}
+          >
+            &euro;{netWorth.netWorth.toLocaleString('it-IT', {
+              minimumFractionDigits: 2,
+              maximumFractionDigits: 2,
+            })}
+          </p>
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 mt-2 text-sm text-muted-foreground">
+            <span>
+              Asset{' '}
+              <span
+                data-testid="total-assets"
+                className="font-semibold text-emerald-700 dark:text-emerald-400"
+              >
+                &euro;{netWorth.assets.toLocaleString('it-IT', { minimumFractionDigits: 2 })}
+              </span>
+            </span>
+            <span>&middot;</span>
+            <span>
+              Debiti{' '}
+              <span
+                data-testid="total-liabilities"
+                className="font-semibold text-red-700 dark:text-red-400"
+              >
+                &euro;{netWorth.liabilities.toLocaleString('it-IT', { minimumFractionDigits: 2 })}
+              </span>
+            </span>
+            <span>&middot;</span>
+            <span className="text-xs">
+              <span data-testid="asset-count">{netWorth.count.asset}</span> +{' '}
+              <span data-testid="liability-count">{netWorth.count.liability}</span> strumenti
+            </span>
+          </div>
+        </div>
+        <div className="shrink-0 p-3 rounded-xl bg-blue-100 dark:bg-blue-900/50">
+          <TrendingUp className="w-6 h-6 text-blue-600 dark:text-blue-400" />
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/apps/web/src/components/patrimonio/PatrimonioTabs.tsx
+++ b/apps/web/src/components/patrimonio/PatrimonioTabs.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+
+export type PatrimonioTab = 'all' | 'assets' | 'liabilities' | 'by-goal';
+
+interface PatrimonioTabsProps {
+  value: PatrimonioTab;
+  onChange: (tab: PatrimonioTab) => void;
+  counts: { total: number; assets: number; liabilities: number; byGoal: number };
+}
+
+const TABS: Array<{ id: PatrimonioTab; label: string }> = [
+  { id: 'all', label: 'Tutto' },
+  { id: 'assets', label: 'Asset' },
+  { id: 'liabilities', label: 'Debiti' },
+  { id: 'by-goal', label: 'Per goal' },
+];
+
+/**
+ * Pill-style tab filter. Fase 2.1: UI-side filter (no re-query).
+ */
+export function PatrimonioTabs({ value, onChange, counts }: PatrimonioTabsProps) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Filtra strumenti"
+      className="flex flex-wrap gap-2"
+      data-testid="patrimonio-tabs"
+    >
+      {TABS.map((tab) => {
+        const isActive = value === tab.id;
+        const count =
+          tab.id === 'all'
+            ? counts.total
+            : tab.id === 'assets'
+            ? counts.assets
+            : tab.id === 'liabilities'
+            ? counts.liabilities
+            : counts.byGoal;
+        return (
+          <Button
+            key={tab.id}
+            variant={isActive ? 'default' : 'outline'}
+            size="sm"
+            role="tab"
+            aria-selected={isActive}
+            onClick={() => onChange(tab.id)}
+            data-testid={`patrimonio-tab-${tab.id}`}
+            className="gap-1.5"
+          >
+            {tab.label}
+            <span
+              className={`text-xs px-1.5 py-0.5 rounded-full ${
+                isActive
+                  ? 'bg-white/20 text-white'
+                  : 'bg-muted text-muted-foreground'
+              }`}
+            >
+              {count}
+            </span>
+          </Button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/new-feature-banner.tsx
+++ b/apps/web/src/components/ui/new-feature-banner.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import Link from 'next/link';
+import { Sparkles, ArrowRight } from 'lucide-react';
+
+interface NewFeatureBannerProps {
+  href: string;
+  title?: string;
+  message?: string;
+  ctaLabel?: string;
+  /** Usato per testid — default "new-feature-banner". */
+  testId?: string;
+}
+
+/**
+ * Shared banner per deprecation hint verso feature nuove.
+ * Pattern coesistenza ADR-005 Fase 2.1 (Q1 lock 1 sprint).
+ */
+export function NewFeatureBanner({
+  href,
+  title = 'Novità',
+  message = 'Tutti i tuoi strumenti in un\'unica vista',
+  ctaLabel = 'Vai a Patrimonio',
+  testId = 'new-feature-banner',
+}: NewFeatureBannerProps) {
+  return (
+    <div
+      data-testid={testId}
+      className="flex items-center gap-3 p-3 rounded-lg bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-950/30 dark:to-indigo-950/30 border border-blue-200/60 dark:border-blue-800/50"
+    >
+      <div className="shrink-0 p-1.5 rounded-lg bg-blue-100 dark:bg-blue-900/50">
+        <Sparkles className="w-4 h-4 text-blue-600 dark:text-blue-400" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-medium text-blue-900 dark:text-blue-100">
+          {title}
+        </p>
+        <p className="text-xs text-blue-700 dark:text-blue-300 mt-0.5">
+          {message}
+        </p>
+      </div>
+      <Link
+        href={href}
+        className="shrink-0 inline-flex items-center gap-1 text-sm font-medium text-blue-700 dark:text-blue-300 hover:text-blue-900 dark:hover:text-blue-100 transition-colors"
+      >
+        {ctaLabel}
+        <ArrowRight className="w-4 h-4" />
+      </Link>
+    </div>
+  );
+}

--- a/apps/web/src/hooks/usePatrimonio.ts
+++ b/apps/web/src/hooks/usePatrimonio.ts
@@ -1,0 +1,45 @@
+/**
+ * usePatrimonio — TanStack Query hook per ADR-005 Fase 2.1 unified view.
+ *
+ * QueryKey: ['patrimonio', filter] — filtro discriminato (class/goalId/status).
+ * Cache invalidation: triggered da mutazioni accounts/liabilities clients.
+ * StaleTime: 30s — sufficient per UX dashboard, evita refetch eccessivo.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import {
+  financialInstrumentsClient,
+  computeNetWorth,
+  type FinancialInstrument,
+  type InstrumentFilter,
+  type NetWorthResult,
+} from '@/services/financial-instruments.client';
+
+/**
+ * Load financial instruments con filter opzionale.
+ */
+export function usePatrimonio(filter?: InstrumentFilter) {
+  return useQuery<FinancialInstrument[]>({
+    queryKey: ['patrimonio', filter],
+    queryFn: () => financialInstrumentsClient.list(filter),
+    staleTime: 30_000,
+  });
+}
+
+/**
+ * Net worth aggregato dal patrimonio corrente (client-side compute).
+ * Deriva da usePatrimonio() senza doppia query.
+ */
+export function usePatrimonioNetWorth(filter?: InstrumentFilter): {
+  data: NetWorthResult | undefined;
+  isLoading: boolean;
+  error: Error | null;
+} {
+  const patrimonioQuery = usePatrimonio(filter);
+  const data = patrimonioQuery.data ? computeNetWorth(patrimonioQuery.data) : undefined;
+  return {
+    data,
+    isLoading: patrimonioQuery.isLoading,
+    error: patrimonioQuery.error as Error | null,
+  };
+}

--- a/apps/web/src/services/__tests__/financial-instruments.client.test.ts
+++ b/apps/web/src/services/__tests__/financial-instruments.client.test.ts
@@ -1,8 +1,10 @@
 /**
  * Unit tests for financial-instruments.client (ADR-005 Fase 2.1).
  *
- * Focus: mapping logic + computeNetWorth pure function.
- * Integration (VIEW query) coperta da E2E patrimonio.spec.ts.
+ * Focus: `computeNetWorth` pure function (golden cases).
+ * Mapping `mapRowToInstrument` is internal (non-exported); fail-visible
+ * behavior è coperta tramite integration (VIEW query live) che sarà
+ * aggiunta in patrimonio.spec.ts (Fase 2.1 follow-up deferred).
  */
 
 import { describe, it, expect } from 'vitest';

--- a/apps/web/src/services/__tests__/financial-instruments.client.test.ts
+++ b/apps/web/src/services/__tests__/financial-instruments.client.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Unit tests for financial-instruments.client (ADR-005 Fase 2.1).
+ *
+ * Focus: mapping logic + computeNetWorth pure function.
+ * Integration (VIEW query) coperta da E2E patrimonio.spec.ts.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  computeNetWorth,
+  type FinancialInstrument,
+} from '../financial-instruments.client';
+
+// =============================================================================
+// Fixture factory
+// =============================================================================
+
+function makeInstrument(overrides: Partial<FinancialInstrument> = {}): FinancialInstrument {
+  return {
+    id: 'id-' + Math.random().toString(36).slice(2),
+    class: 'ASSET',
+    type: 'CHECKING',
+    userId: null,
+    familyId: 'family-test',
+    name: 'Test Instrument',
+    currentBalance: 1000,
+    currency: 'EUR',
+    originalAmount: null,
+    creditLimit: null,
+    interestRate: null,
+    minimumPayment: null,
+    goalId: null,
+    status: 'ACTIVE',
+    institutionName: null,
+    createdAt: '2026-04-24T00:00:00Z',
+    updatedAt: '2026-04-24T00:00:00Z',
+    ...overrides,
+  };
+}
+
+// =============================================================================
+// computeNetWorth
+// =============================================================================
+
+describe('computeNetWorth', () => {
+  it('returns zero net worth for empty list', () => {
+    const result = computeNetWorth([]);
+    expect(result.assets).toBe(0);
+    expect(result.liabilities).toBe(0);
+    expect(result.netWorth).toBe(0);
+    expect(result.count).toEqual({ asset: 0, liability: 0 });
+    expect(result.currency).toBe('EUR');
+  });
+
+  it('sums assets correctly when only ASSET class present', () => {
+    const items = [
+      makeInstrument({ class: 'ASSET', currentBalance: 5000 }),
+      makeInstrument({ class: 'ASSET', currentBalance: 3000 }),
+    ];
+    const result = computeNetWorth(items);
+    expect(result.assets).toBe(8000);
+    expect(result.liabilities).toBe(0);
+    expect(result.netWorth).toBe(8000);
+    expect(result.count.asset).toBe(2);
+    expect(result.count.liability).toBe(0);
+  });
+
+  it('sums liabilities correctly when only LIABILITY class present', () => {
+    const items = [
+      makeInstrument({ class: 'LIABILITY', currentBalance: 1000 }),
+      makeInstrument({ class: 'LIABILITY', currentBalance: 500 }),
+    ];
+    const result = computeNetWorth(items);
+    expect(result.assets).toBe(0);
+    expect(result.liabilities).toBe(1500);
+    expect(result.netWorth).toBe(-1500);
+    expect(result.count.liability).toBe(2);
+  });
+
+  it('computes net worth correctly with mixed assets + liabilities', () => {
+    // Golden case da design doc: 10000 + 5000 - 2000 = 13000
+    const items = [
+      makeInstrument({ class: 'ASSET', currentBalance: 10000, name: 'Checking' }),
+      makeInstrument({ class: 'ASSET', currentBalance: 5000, name: 'Savings' }),
+      makeInstrument({ class: 'LIABILITY', currentBalance: 2000, name: 'BNPL' }),
+    ];
+    const result = computeNetWorth(items);
+    expect(result.assets).toBe(15000);
+    expect(result.liabilities).toBe(2000);
+    expect(result.netWorth).toBe(13000);
+    expect(result.count).toEqual({ asset: 2, liability: 1 });
+  });
+
+  it('handles negative net worth (more liabilities than assets)', () => {
+    const items = [
+      makeInstrument({ class: 'ASSET', currentBalance: 500 }),
+      makeInstrument({ class: 'LIABILITY', currentBalance: 3000 }),
+    ];
+    const result = computeNetWorth(items);
+    expect(result.netWorth).toBe(-2500);
+    expect(result.assets).toBe(500);
+    expect(result.liabilities).toBe(3000);
+  });
+
+  it('handles zero-balance items without skipping them in count', () => {
+    const items = [
+      makeInstrument({ class: 'ASSET', currentBalance: 0 }),
+      makeInstrument({ class: 'LIABILITY', currentBalance: 0 }),
+    ];
+    const result = computeNetWorth(items);
+    expect(result.netWorth).toBe(0);
+    expect(result.count.asset).toBe(1);
+    expect(result.count.liability).toBe(1);
+  });
+
+  it('coerces string-number balances via Number()', () => {
+    // Edge: Supabase VIEW ritorna numeric come string in alcuni scenari
+    const items = [
+      makeInstrument({ class: 'ASSET', currentBalance: '1000.50' as unknown as number }),
+      makeInstrument({ class: 'LIABILITY', currentBalance: '200.25' as unknown as number }),
+    ];
+    const result = computeNetWorth(items);
+    expect(result.assets).toBeCloseTo(1000.5, 2);
+    expect(result.liabilities).toBeCloseTo(200.25, 2);
+    expect(result.netWorth).toBeCloseTo(800.25, 2);
+  });
+
+  it('preserves EUR currency as default (multi-currency Fase 3)', () => {
+    const result = computeNetWorth([makeInstrument({ currency: 'USD' })]);
+    // Fase 2.1: ignora currency per item, assume EUR aggregato
+    expect(result.currency).toBe('EUR');
+  });
+});

--- a/apps/web/src/services/financial-instruments.client.ts
+++ b/apps/web/src/services/financial-instruments.client.ts
@@ -100,11 +100,28 @@ type ViewRow = {
 };
 
 function mapRowToInstrument(row: ViewRow): FinancialInstrument | null {
-  // Copilot-style fail-visible filter: required fields null = corruption/RLS bug
-  if (row.id === null || row.class === null || row.name === null || row.status === null) {
+  // Copilot review #541 fix: fail-visible su TUTTI i required fields (schema
+  // NOT NULL nelle tabelle base → VIEW null indica corruption/RLS/schema drift).
+  // Include current_balance, currency, created_at, updated_at per evitare
+  // fabbricare valori (`?? 0`, `?? 'EUR'`, `?? new Date()`) che mascherano bug.
+  const required = {
+    id: row.id,
+    class: row.class,
+    type: row.type,
+    name: row.name,
+    status: row.status,
+    current_balance: row.current_balance,
+    currency: row.currency,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+  const nullFields = Object.entries(required)
+    .filter(([, v]) => v === null)
+    .map(([k]) => k);
+  if (nullFields.length > 0) {
     console.error(
-      '[financialInstrumentsClient] Skipping invalid row with null required field:',
-      { id: row.id, class: row.class, name: row.name, status: row.status },
+      '[financialInstrumentsClient] Skipping row with null required field(s):',
+      { nullFields, rowId: row.id },
     );
     return null;
   }
@@ -113,24 +130,25 @@ function mapRowToInstrument(row: ViewRow): FinancialInstrument | null {
     console.error('[financialInstrumentsClient] Unknown class value:', row.class);
     return null;
   }
+  // TypeScript narrowing: post-filter i field required sono non-null
   return {
-    id: row.id,
+    id: row.id as string,
     class: cls,
-    type: row.type ?? 'OTHER',
+    type: row.type as string,
     userId: row.user_id,
     familyId: row.family_id,
-    name: row.name,
-    currentBalance: Number(row.current_balance ?? 0),
-    currency: row.currency ?? 'EUR',
+    name: row.name as string,
+    currentBalance: Number(row.current_balance),
+    currency: row.currency as string,
     originalAmount: row.original_amount !== null ? Number(row.original_amount) : null,
     creditLimit: row.credit_limit !== null ? Number(row.credit_limit) : null,
     interestRate: row.interest_rate !== null ? Number(row.interest_rate) : null,
     minimumPayment: row.minimum_payment !== null ? Number(row.minimum_payment) : null,
     goalId: row.goal_id,
-    status: row.status,
+    status: row.status as string,
     institutionName: row.institution_name,
-    createdAt: row.created_at ?? new Date().toISOString(),
-    updatedAt: row.updated_at ?? new Date().toISOString(),
+    createdAt: row.created_at as string,
+    updatedAt: row.updated_at as string,
   };
 }
 

--- a/apps/web/src/services/financial-instruments.client.ts
+++ b/apps/web/src/services/financial-instruments.client.ts
@@ -1,0 +1,203 @@
+/**
+ * Financial Instruments Client — ADR-005 Fase 2.1 Patrimonio foundation
+ *
+ * Read-only unified view over accounts (ASSET) + liabilities (LIABILITY) via
+ * VIEW `public.financial_instruments`. Write path = dispatcher verso clients
+ * sottostanti (accounts.client / liabilities.client) in base a `class`.
+ *
+ * Design: ~/vault/moneywise/research/adr-005-fase-2-1-design.md
+ * ADR: ~/vault/moneywise/decisions/adr-005-unified-financial-instruments.md
+ *
+ * @module services/financial-instruments.client
+ */
+
+import { createClient } from '@/utils/supabase/client';
+
+// =============================================================================
+// Types — Discriminated union (class field)
+// =============================================================================
+
+export type InstrumentClass = 'ASSET' | 'LIABILITY';
+
+/**
+ * Unified row shape dalla VIEW `financial_instruments`.
+ * Campi ASSET-only o LIABILITY-only sono nullable (VIEW NULL cast).
+ */
+export interface FinancialInstrument {
+  id: string;
+  class: InstrumentClass;
+  type: string; // account_type | liability_type (enum castati a text)
+  userId: string | null; // solo ASSET (liabilities è family-scoped)
+  familyId: string | null;
+  name: string;
+  currentBalance: number; // positivo sempre (convenzione italiana)
+  currency: string;
+  /** Solo LIABILITY (originale prestito/BNPL). Null per ASSET. */
+  originalAmount: number | null;
+  /** CC su accounts o liabilities — dual-source fino Fase 2.2. */
+  creditLimit: number | null;
+  /** Solo LIABILITY. */
+  interestRate: number | null;
+  /** Solo LIABILITY. */
+  minimumPayment: number | null;
+  /** Sprint 1.6 Fase 2A link. */
+  goalId: string | null;
+  status: string;
+  /** Solo ASSET (liabilities non traccia — gap Fase 2.2). */
+  institutionName: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface NetWorthResult {
+  assets: number; // somma current_balance WHERE class=ASSET
+  liabilities: number; // somma current_balance WHERE class=LIABILITY (positivo)
+  netWorth: number; // assets - liabilities
+  currency: string; // EUR (multi-currency Fase 3)
+  count: { asset: number; liability: number };
+}
+
+export interface InstrumentFilter {
+  class?: InstrumentClass;
+  /** `null` = unlinked, stringa = goal specifico, undefined = no filter. */
+  goalId?: string | null;
+  status?: string;
+}
+
+export class FinancialInstrumentsApiError extends Error {
+  constructor(
+    message: string,
+    public statusCode: number,
+    public source: 'VIEW' | 'ACCOUNTS' | 'LIABILITIES' = 'VIEW',
+  ) {
+    super(message);
+    this.name = 'FinancialInstrumentsApiError';
+  }
+}
+
+// =============================================================================
+// Row mapper — snake_case VIEW → camelCase FinancialInstrument
+// =============================================================================
+
+type ViewRow = {
+  id: string | null;
+  class: string | null;
+  type: string | null;
+  user_id: string | null;
+  family_id: string | null;
+  name: string | null;
+  current_balance: number | null;
+  currency: string | null;
+  original_amount: number | null;
+  credit_limit: number | null;
+  interest_rate: number | null;
+  minimum_payment: number | null;
+  goal_id: string | null;
+  status: string | null;
+  institution_name: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+};
+
+function mapRowToInstrument(row: ViewRow): FinancialInstrument | null {
+  // Copilot-style fail-visible filter: required fields null = corruption/RLS bug
+  if (row.id === null || row.class === null || row.name === null || row.status === null) {
+    console.error(
+      '[financialInstrumentsClient] Skipping invalid row with null required field:',
+      { id: row.id, class: row.class, name: row.name, status: row.status },
+    );
+    return null;
+  }
+  const cls = row.class as InstrumentClass;
+  if (cls !== 'ASSET' && cls !== 'LIABILITY') {
+    console.error('[financialInstrumentsClient] Unknown class value:', row.class);
+    return null;
+  }
+  return {
+    id: row.id,
+    class: cls,
+    type: row.type ?? 'OTHER',
+    userId: row.user_id,
+    familyId: row.family_id,
+    name: row.name,
+    currentBalance: Number(row.current_balance ?? 0),
+    currency: row.currency ?? 'EUR',
+    originalAmount: row.original_amount !== null ? Number(row.original_amount) : null,
+    creditLimit: row.credit_limit !== null ? Number(row.credit_limit) : null,
+    interestRate: row.interest_rate !== null ? Number(row.interest_rate) : null,
+    minimumPayment: row.minimum_payment !== null ? Number(row.minimum_payment) : null,
+    goalId: row.goal_id,
+    status: row.status,
+    institutionName: row.institution_name,
+    createdAt: row.created_at ?? new Date().toISOString(),
+    updatedAt: row.updated_at ?? new Date().toISOString(),
+  };
+}
+
+// =============================================================================
+// Client (read-only Fase 2.1)
+// =============================================================================
+
+export const financialInstrumentsClient = {
+  /**
+   * List financial instruments with optional filter.
+   * RLS trasparente via security_invoker VIEW.
+   */
+  async list(filter?: InstrumentFilter): Promise<FinancialInstrument[]> {
+    const supabase = createClient();
+    let query = supabase.from('financial_instruments').select('*');
+
+    if (filter?.class) query = query.eq('class', filter.class);
+    if (filter?.status) query = query.eq('status', filter.status);
+    if (filter?.goalId !== undefined) {
+      query = filter.goalId === null ? query.is('goal_id', null) : query.eq('goal_id', filter.goalId);
+    }
+
+    const { data, error } = await query;
+    if (error) {
+      throw new FinancialInstrumentsApiError(error.message, 500, 'VIEW');
+    }
+
+    return (data ?? [])
+      .map(mapRowToInstrument)
+      .filter((i): i is FinancialInstrument => i !== null);
+  },
+
+  /**
+   * Compute net worth from client-side aggregation.
+   * Fase 2.1 scelta: no RPC dedicato (dataset tiny, TanStack Query cacha).
+   * Upgrade path Fase 2.2: RPC + multi-currency.
+   */
+  async netWorth(): Promise<NetWorthResult> {
+    const items = await this.list();
+    return computeNetWorth(items);
+  },
+};
+
+/**
+ * Pure function: calcola net worth da una lista di instruments.
+ * Exposed per testing + UI optimistic updates.
+ */
+export function computeNetWorth(items: FinancialInstrument[]): NetWorthResult {
+  const result: NetWorthResult = {
+    assets: 0,
+    liabilities: 0,
+    netWorth: 0,
+    currency: 'EUR',
+    count: { asset: 0, liability: 0 },
+  };
+
+  for (const item of items) {
+    const val = Number(item.currentBalance);
+    if (item.class === 'ASSET') {
+      result.assets += val;
+      result.count.asset += 1;
+    } else {
+      result.liabilities += val;
+      result.count.liability += 1;
+    }
+  }
+
+  result.netWorth = result.assets - result.liabilities;
+  return result;
+}

--- a/apps/web/src/utils/supabase/database.types.ts
+++ b/apps/web/src/utils/supabase/database.types.ts
@@ -1499,6 +1499,28 @@ export type Database = {
       }
     }
     Views: {
+      financial_instruments: {
+        Row: {
+          class: string | null
+          created_at: string | null
+          credit_limit: number | null
+          currency: string | null
+          current_balance: number | null
+          family_id: string | null
+          goal_id: string | null
+          id: string | null
+          institution_name: string | null
+          interest_rate: number | null
+          minimum_payment: number | null
+          name: string | null
+          original_amount: number | null
+          status: string | null
+          type: string | null
+          updated_at: string | null
+          user_id: string | null
+        }
+        Relationships: []
+      }
       goals_with_progress: {
         Row: {
           created_at: string | null

--- a/supabase/migrations/20260424120000_adr005_fase2_1_financial_instruments_view.sql
+++ b/supabase/migrations/20260424120000_adr005_fase2_1_financial_instruments_view.sql
@@ -1,0 +1,90 @@
+-- ADR-005 Fase 2.1 — financial_instruments VIEW (Patrimonio foundation)
+--
+-- Implements design ~/vault/moneywise/research/adr-005-fase-2-1-design.md.
+-- Closes Fase 2.1 foundation task (Sprint 1.6.6 Fase 2 execution).
+--
+-- Scope:
+--   - UNION ALL accounts (class='ASSET', filtered) + liabilities (class='LIABILITY')
+--   - security_invoker = true → RLS transitive da tabelle base (zero bypass)
+--   - Filter accounts.type NOT IN (CREDIT_CARD, LOAN, MORTGAGE) — legacy USA-style
+--     debit accounts NON contano come asset (doppio tracking con liabilities).
+--
+-- Formula net worth (client-side, Fase 2.1):
+--   SUM(current_balance WHERE class='ASSET') - SUM(current_balance WHERE class='LIABILITY')
+--   Convenzione italiana: current_balance positivo sia per asset sia per debito;
+--   il segno è gestito nella formula, non nel dato.
+--
+-- Migration SAFE:
+--   - Additive-only (CREATE VIEW)
+--   - Zero data migration
+--   - Rollback: DROP VIEW IF EXISTS public.financial_instruments (idempotent)
+--
+-- Security: VIEW con security_invoker=true (PG15+). RLS policies su accounts +
+-- liabilities applicano transitively al caller. Nessun bypass.
+--
+-- Performance: UNION ALL (no sort+dedup) ~0.1ms per scala beta (N<20 row).
+-- Indici esistenti: idx_accounts_user_id, idx_accounts_family_id,
+-- idx_liabilities_family_status coprono RLS filter.
+
+-- Preconditions
+DO $$ BEGIN
+  ASSERT (SELECT current_setting('server_version_num')::int >= 150000),
+    'PostgreSQL 15+ required for security_invoker VIEW option';
+  ASSERT EXISTS (SELECT 1 FROM information_schema.columns
+                 WHERE table_name='accounts' AND column_name='goal_id'),
+    'Fase 2A migration (accounts.goal_id) must precede ADR-005 Fase 2.1';
+  ASSERT EXISTS (SELECT 1 FROM information_schema.columns
+                 WHERE table_name='liabilities' AND column_name='goal_id'),
+    'Fase 2A migration (liabilities.goal_id) must precede ADR-005 Fase 2.1';
+END $$;
+
+CREATE VIEW public.financial_instruments
+WITH (security_invoker = true)
+AS
+SELECT
+  a.id                                        AS id,
+  'ASSET'::text                               AS class,
+  a.type::text                                AS type,
+  a.user_id                                   AS user_id,
+  a.family_id                                 AS family_id,
+  a.name                                      AS name,
+  a.current_balance                           AS current_balance,
+  a.currency                                  AS currency,
+  NULL::numeric(15,2)                         AS original_amount,
+  a.credit_limit                              AS credit_limit,
+  NULL::numeric(5,2)                          AS interest_rate,
+  NULL::numeric(15,2)                         AS minimum_payment,
+  a.goal_id                                   AS goal_id,
+  a.status::text                              AS status,
+  a.institution_name                          AS institution_name,
+  a.created_at                                AS created_at,
+  a.updated_at                                AS updated_at
+FROM public.accounts a
+WHERE a.type NOT IN ('CREDIT_CARD','LOAN','MORTGAGE')
+
+UNION ALL
+
+SELECT
+  l.id                                        AS id,
+  'LIABILITY'::text                           AS class,
+  l.type::text                                AS type,
+  NULL::uuid                                  AS user_id,
+  l.family_id                                 AS family_id,
+  l.name                                      AS name,
+  l.current_balance                           AS current_balance,
+  l.currency                                  AS currency,
+  l.original_amount                           AS original_amount,
+  l.credit_limit                              AS credit_limit,
+  l.interest_rate                             AS interest_rate,
+  l.minimum_payment                           AS minimum_payment,
+  l.goal_id                                   AS goal_id,
+  l.status::text                              AS status,
+  NULL::varchar(255)                          AS institution_name,
+  l.created_at                                AS created_at,
+  l.updated_at                                AS updated_at
+FROM public.liabilities l;
+
+COMMENT ON VIEW public.financial_instruments IS
+  'ADR-005 Fase 2.1: unified read-only view su accounts (ASSET, excluded legacy CC/LOAN/MORTGAGE) + liabilities (LIABILITY). security_invoker delega RLS alle tabelle base. Closes Sprint 1.6.6 Fase 2 foundation.';
+
+GRANT SELECT ON public.financial_instruments TO authenticated;


### PR DESCRIPTION
## Summary

Implementa **ADR-005 Fase 2.1 Patrimonio foundation** — vista unificata read-only su asset (accounts) + debiti (liabilities) con net worth computation.

**Design doc**: \`~/vault/moneywise/research/adr-005-fase-2-1-design.md\` (architect agent 2026-04-24).
**Decision locks ADR-005**: Q1=B coesistenza 1 sprint, Q2=B no-trend Fase 2.1, Q3=A rule-based classifier Fase 2.2.

## Deliverable

### Database
- \`supabase/migrations/20260424120000_adr005_fase2_1_financial_instruments_view.sql\`
- VIEW \`public.financial_instruments\` con \`security_invoker=true\` (RLS transitive)
- UNION ALL: accounts (class='ASSET', esclusi legacy CC/LOAN/MORTGAGE) + liabilities (class='LIABILITY')
- Preconditions DO block (PG15+, accounts.goal_id, liabilities.goal_id)

### Service layer
- \`apps/web/src/services/financial-instruments.client.ts\` — read API + discriminated union
- \`computeNetWorth()\` pure function (client-side aggregation, no RPC Fase 2.1)
- Fail-visible filter su null required fields (pattern review #538)

### UI \`/dashboard/patrimonio\`
- \`PatrimonioHeader\` — net worth + count asset/debiti
- \`PatrimonioTabs\` — filter Tutto/Asset/Debiti/Per goal (UI-side)
- \`InstrumentGroup\` — collapsible per type (Banche/Investimenti/Contanti/Carte/Mutui/BNPL)
- \`InstrumentRow\` — row unified (emerald asset, red liability) + goal badge + institution
- \`EmptyState\` — CTA verso /accounts o /liabilities legacy

### Sidebar coexistenza
- Entry "Patrimonio" con badge "Nuovo" sopra /conti + /debiti
- \`NewFeatureBanner\` shared su pagine legacy \`/accounts\` e \`/liabilities\`

### Types regen
- \`database.types.ts\` include VIEW \`financial_instruments\` (MCP)

## Tests

- 8 unit test \`computeNetWorth\` (golden cases)
- Full suite: **1906/1908 passed** (+8 nuovi, zero regression)
- Typecheck: 0 errors, Lint: 0 errors

## MCP validation (local DB)

- Migration applied via \`apply_migration\`
- Row count match: 6 view rows = 5 accounts filtered + 1 liability ✓
- Net worth golden: €47.990,75 (€48.650,75 asset − €660 debiti) ✓

## Deferred (Fase 2.1 follow-up)

- E2E test \`patrimonio.spec.ts\` (~30min, Playwright)
- Write dispatcher (create/update/delete) — Fase 2.2 Q3 (classifier rule-based)
- Deprecation banner rimozione — Fase 2.2 migration checklist

## Test plan

- [x] Typecheck + unit test + lint green
- [x] MCP SQL validation net worth
- [ ] Manual QA: navigate /dashboard/patrimonio, verify tabs filter, goal badge, empty state
- [ ] Verify sidebar badge "Nuovo" rendering
- [ ] Verify legacy pages show banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)