### PR TITLE
feat(onboarding): #051 wizard Step 2 large 2-col no-scroll

### DIFF
--- a/apps/web/src/components/onboarding/WizardPianoGenerato.tsx
+++ b/apps/web/src/components/onboarding/WizardPianoGenerato.tsx
@@ -171,8 +171,11 @@ export function WizardPianoGenerato({ mode = 'create', onClose }: WizardPianoGen
       {/* Sprint 1.6.4D #036: dim overlay + blur app dietro visibile (NO nero opaco) */}
       <Dialog.Overlay className="fixed inset-0 z-40 bg-black/30 backdrop-blur-md" />
 
+      {/* #051: Step 2 (Profilo) richiede layout 2-col → max-w-4xl; altri step max-w-2xl */}
       <Dialog.Content
-        className="fixed left-1/2 top-1/2 z-50 w-full max-w-2xl -translate-x-1/2 -translate-y-1/2 rounded-xl bg-card shadow-2xl p-6 outline-none max-h-[90vh] overflow-y-auto"
+        className={`fixed left-1/2 top-1/2 z-50 w-full ${
+          currentStep === 2 ? 'max-w-4xl' : 'max-w-2xl'
+        } -translate-x-1/2 -translate-y-1/2 rounded-xl bg-card shadow-2xl p-6 outline-none max-h-[90vh] overflow-y-auto`}
         aria-describedby="wizard-step-description"
         // Sprint 1.6.4D #036: prevent close on outside click (user deve chiudere
         // esplicitamente via X button o Esc → rispetta user intent, evita close

--- a/apps/web/src/components/onboarding/steps/StepProfile.tsx
+++ b/apps/web/src/components/onboarding/steps/StepProfile.tsx
@@ -297,6 +297,8 @@ export function StepProfile() {
         </p>
       </div>
 
+      {/* #051: grid 2-col per Reddito + Essentials (mobile fallback single-col) */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
       {/* ── Reddito mensile ── */}
       <div>
         <label
@@ -384,7 +386,10 @@ export function StepProfile() {
           </button>
         </div>
       </div>
+      </div>
 
+      {/* #051: grid 2-col per Lifestyle + Savings */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
       {/* ── Lifestyle buffer ── */}
       <div>
         <label htmlFor={lifestyleId} className="text-sm font-medium text-foreground block mb-1">
@@ -456,6 +461,7 @@ export function StepProfile() {
             Minimo €{SAVINGS_MIN}/mese. Regola 50/30/20: ~20% del reddito.
           </p>
         )}
+      </div>
       </div>
 
       {/* ── Investimenti target (optional) ── */}


### PR DESCRIPTION
## Summary

Closes atomic note \`planning/issues/051-*.md\` (vault-based) — non correlato a GitHub issue #51.

User feedback manual QA Sprint 4C: Step 2 "Profilo" modale stretta ~500px, scroll verticale obbligato.

## Changes

- **WizardPianoGenerato**: \`Dialog.Content\` width conditional:
  \`currentStep===2\` → \`max-w-4xl\` (~896px), altrimenti \`max-w-2xl\` (~672px)

- **StepProfile**: grid 2-col su coppie logiche
  - [Reddito + Essentials%] grid 1 (md:grid-cols-2)
  - [Lifestyle + Savings] grid 2 (md:grid-cols-2)
  - Investimenti (opzionale) full-width
  - Distribution bar + banner full-width

## Rationale

Approccio chirurgico: zero riordinamento field, wrap coppie in grid, mobile fallback automatic single-col. Funzionalità Wave 4C (reactive savings, nudge, overflow) preservate 100%.

## Tests

- Full suite: **1917/1919 passed**, zero regression
- Typecheck: 0 errors

## Scope

In scope: Modal width + grid 2-col su Step 2.

Out of scope: Refactor globale wizard width altri step, custom slider tick marks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)