### PR TITLE
feat(finance): #045 amortization helpers (formula francese)

### DIFF
--- a/apps/web/__tests__/lib/finance/amortization.test.ts
+++ b/apps/web/__tests__/lib/finance/amortization.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Unit tests for amortization helpers (#045).
+ *
+ * Golden values verificati vs calcolatrici banca italiana (Agos/Findomestic):
+ * - 4000€ TAEG 10% 36 rate → ~€129.07/mese (user QA scenario 2B-3 input 110.88 → scarto ~14%)
+ * - 10000€ TAEG 5% 60 rate → ~€188.71/mese
+ * - 200000€ TAEG 3% 240 rate (mutuo) → ~€1,109.20/mese
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  calculateMonthlyPayment,
+  amortize,
+  paymentScartoRatio,
+} from '@/lib/finance/amortization';
+
+describe('calculateMonthlyPayment', () => {
+  // === Golden values vs banche italiane ===
+
+  it('Agos-typical: 4000€ TAEG 10% 36 rate → ~€129.07', () => {
+    const rata = calculateMonthlyPayment({
+      principal: 4000,
+      annualRate: 10,
+      numPayments: 36,
+    });
+    expect(rata).toBeCloseTo(129.07, 1);
+  });
+
+  it('Prestito medio: 10000€ TAEG 5% 60 rate → ~€188.71', () => {
+    const rata = calculateMonthlyPayment({
+      principal: 10000,
+      annualRate: 5,
+      numPayments: 60,
+    });
+    expect(rata).toBeCloseTo(188.71, 1);
+  });
+
+  it('Mutuo: 200000€ TAEG 3% 240 rate (20 anni) → ~€1109.20', () => {
+    const rata = calculateMonthlyPayment({
+      principal: 200000,
+      annualRate: 3,
+      numPayments: 240,
+    });
+    expect(rata).toBeCloseTo(1109.2, 1);
+  });
+
+  // === Edge cases ===
+
+  it('Zero-interest: principal / n', () => {
+    const rata = calculateMonthlyPayment({
+      principal: 3000,
+      annualRate: 0,
+      numPayments: 12,
+    });
+    expect(rata).toBe(250);
+  });
+
+  it('Zero-interest BNPL 4 rate: 400 / 4 = 100', () => {
+    const rata = calculateMonthlyPayment({
+      principal: 400,
+      annualRate: 0,
+      numPayments: 4,
+    });
+    expect(rata).toBe(100);
+  });
+
+  it('Returns 0 when principal is zero', () => {
+    expect(calculateMonthlyPayment({ principal: 0, annualRate: 5, numPayments: 12 })).toBe(0);
+  });
+
+  it('Returns 0 when principal is negative', () => {
+    expect(calculateMonthlyPayment({ principal: -1000, annualRate: 5, numPayments: 12 })).toBe(0);
+  });
+
+  it('Returns 0 when numPayments is zero', () => {
+    expect(calculateMonthlyPayment({ principal: 1000, annualRate: 5, numPayments: 0 })).toBe(0);
+  });
+
+  it('Returns 0 when numPayments is negative', () => {
+    expect(calculateMonthlyPayment({ principal: 1000, annualRate: 5, numPayments: -1 })).toBe(0);
+  });
+
+  it('Returns 0 when annualRate is negative', () => {
+    expect(calculateMonthlyPayment({ principal: 1000, annualRate: -1, numPayments: 12 })).toBe(0);
+  });
+
+  it('Handles high TAEG (credit card) 25% 12 rate 1000€', () => {
+    const rata = calculateMonthlyPayment({
+      principal: 1000,
+      annualRate: 25,
+      numPayments: 12,
+    });
+    // ~€94.56 — alto tasso revolving CC
+    expect(rata).toBeGreaterThan(93);
+    expect(rata).toBeLessThan(96);
+  });
+
+  it('Rounds to 2 decimals (euro cent)', () => {
+    const rata = calculateMonthlyPayment({
+      principal: 4000,
+      annualRate: 10,
+      numPayments: 36,
+    });
+    // Deve essere multiplo di 0.01
+    expect(Math.abs(rata * 100 - Math.round(rata * 100))).toBeLessThan(0.01);
+  });
+});
+
+describe('amortize', () => {
+  it('returns total paid + total interest for Agos scenario', () => {
+    const result = amortize({ principal: 4000, annualRate: 10, numPayments: 36 });
+    expect(result.monthlyPayment).toBeCloseTo(129.07, 1);
+    // Total paid = 36 × 129.07 ≈ 4646.50
+    expect(result.totalPaid).toBeCloseTo(4646.5, 0);
+    // Interest = total − principal ≈ 646
+    expect(result.totalInterest).toBeCloseTo(646.5, 0);
+  });
+
+  it('zero-interest has totalInterest = 0', () => {
+    const result = amortize({ principal: 1200, annualRate: 0, numPayments: 12 });
+    expect(result.monthlyPayment).toBe(100);
+    expect(result.totalPaid).toBe(1200);
+    expect(result.totalInterest).toBe(0);
+  });
+
+  it('returns zero-shape for invalid input', () => {
+    const result = amortize({ principal: 0, annualRate: 5, numPayments: 12 });
+    expect(result.monthlyPayment).toBe(0);
+    expect(result.totalPaid).toBe(0);
+    expect(result.totalInterest).toBe(0);
+  });
+});
+
+describe('paymentScartoRatio', () => {
+  it('returns 0 when userPayment matches calculated', () => {
+    expect(paymentScartoRatio(129.07, 129.07)).toBe(0);
+  });
+
+  it('returns negative ratio when user underpays (Agos scenario 110.88 vs 129.07)', () => {
+    const ratio = paymentScartoRatio(110.88, 129.07);
+    expect(ratio).toBeCloseTo(-0.141, 2); // ~14% underpay
+  });
+
+  it('returns positive ratio when user overpays', () => {
+    const ratio = paymentScartoRatio(150, 129.07);
+    expect(ratio).toBeGreaterThan(0.16);
+  });
+
+  it('returns NaN when calculated is zero (non-comparable)', () => {
+    expect(paymentScartoRatio(100, 0)).toBeNaN();
+  });
+
+  it('returns NaN when calculated is negative (edge invalid)', () => {
+    expect(paymentScartoRatio(100, -10)).toBeNaN();
+  });
+});

--- a/apps/web/src/lib/finance/amortization.ts
+++ b/apps/web/src/lib/finance/amortization.ts
@@ -1,0 +1,79 @@
+/**
+ * Amortization helpers — ADR/atomic #045 Fase 3 UX polish.
+ *
+ * Formula francese per rata costante:
+ *   rata = capitale × [i × (1 + i)^n] / [(1 + i)^n − 1]
+ * dove:
+ *   - capitale = importo finanziato (principal)
+ *   - i = tasso periodico (TAEG annuo / 12 per rate mensili)
+ *   - n = numero totale rate
+ *
+ * Use cases:
+ *   - Suggest rata in LiabilityForm (hint "Rata calcolata: €X")
+ *   - Warning scarto >10% vs `minimumPayment` inserito dall'utente
+ *   - Coerenza cross-field: originalAmount + TAEG + installmentsCount → rata attesa
+ *
+ * Edge cases gestiti:
+ *   - principal ≤ 0 → 0
+ *   - numPayments ≤ 0 → 0
+ *   - annualRate = 0 (prestito zero-interesse) → rata = principal / n
+ *   - annualRate negativo → 0 (input invalido)
+ */
+
+export interface AmortizationInput {
+  principal: number; // capitale iniziale, es. 4000
+  annualRate: number; // TAEG annuo percentuale, es. 10 per 10%. 0 per zero-interest.
+  numPayments: number; // numero totale rate mensili, es. 36
+}
+
+export interface AmortizationResult {
+  monthlyPayment: number; // rata mensile costante (formula francese)
+  totalPaid: number; // monthlyPayment × numPayments
+  totalInterest: number; // totalPaid − principal (may be 0 per zero-rate)
+}
+
+/**
+ * Calcola rata mensile (formula francese).
+ * Returns 0 per input invalidi (no-throw).
+ */
+export function calculateMonthlyPayment(input: AmortizationInput): number {
+  const { principal, annualRate, numPayments } = input;
+
+  if (principal <= 0 || numPayments <= 0 || annualRate < 0) return 0;
+
+  // Zero-interest: rata = capitale / n
+  if (annualRate === 0) {
+    return roundEuro(principal / numPayments);
+  }
+
+  const monthlyRate = annualRate / 100 / 12;
+  const compound = Math.pow(1 + monthlyRate, numPayments);
+  const rata = (principal * monthlyRate * compound) / (compound - 1);
+  return roundEuro(rata);
+}
+
+/**
+ * Full amortization breakdown (rata + totale pagato + interessi totali).
+ */
+export function amortize(input: AmortizationInput): AmortizationResult {
+  const monthlyPayment = calculateMonthlyPayment(input);
+  const totalPaid = roundEuro(monthlyPayment * input.numPayments);
+  const totalInterest = roundEuro(totalPaid - input.principal);
+  return { monthlyPayment, totalPaid, totalInterest };
+}
+
+/**
+ * Compara rata user-inserita vs rata calcolata → ratio scarto.
+ * Returns NaN se calculated = 0 (non confrontabile).
+ */
+export function paymentScartoRatio(
+  userPayment: number,
+  calculatedPayment: number,
+): number {
+  if (calculatedPayment <= 0) return NaN;
+  return (userPayment - calculatedPayment) / calculatedPayment;
+}
+
+function roundEuro(n: number): number {
+  return Math.round(n * 100) / 100;
+}


### PR DESCRIPTION
## Summary

Closes atomic note \`planning/issues/045-*.md\` (vault-based MVP) — Fase 3 UX polish P1.

User feedback manual QA 2026-04-22 scenario 2B-3: form Finanziamento non segnalava scarto tra rata user-inserita (110.88) e rata francese calcolata (~€129.07) → 14% sottovalutata.

## Changes

- **Nuovo** \`lib/finance/amortization.ts\`:
  - \`calculateMonthlyPayment\` (formula francese)
  - \`amortize\` (breakdown totale + interessi)
  - \`paymentScartoRatio\` (delta % user vs calculated, per warning consumer)

- Edge cases completi: invalid input → 0, zero-interest BNPL → principal/n, euro cent rounding.

## Tests

- **20 unit test** golden vs banche italiane (Agos €129.07, Mutuo €1109.20)
- Full suite: **1937/1939 passed** (+20), zero regression
- Typecheck: 0 errors

## Scope

**In scope MVP**: helper puri + test golden (~1h).

**Out of scope** (Fase 2.2 o post-beta):
- UI integration LiabilityForm (hint "Rata calcolata", warning scarto >10%)
- Migration DB colonne start_date/end_date/installments_count/frequency
- Zod cross-field refine (currentBalance ≤ originalAmount, TAEG range, ecc)

Helper reusable pronto per consumer successivo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)